### PR TITLE
fix: Jekyll Pages build failure from Liquid syntax conflict

### DIFF
--- a/docs/ai/code-review.md
+++ b/docs/ai/code-review.md
@@ -100,6 +100,7 @@ claude "Audit package.json for:
 
 ## Integration with CI/CD
 
+{% raw %}
 ```yaml
 # .github/workflows/security-review.yml
 name: AI Security Review
@@ -123,6 +124,7 @@ jobs:
           # Your AI review integration here
           echo "Review files: ${{ steps.changes.outputs.files }}"
 ```
+{% endraw %}
 
 ## Best Practices
 

--- a/docs/ai/code-review.md
+++ b/docs/ai/code-review.md
@@ -101,6 +101,7 @@ claude "Audit package.json for:
 ## Integration with CI/CD
 
 {% raw %}
+
 ```yaml
 # .github/workflows/security-review.yml
 name: AI Security Review
@@ -124,6 +125,7 @@ jobs:
           # Your AI review integration here
           echo "Review files: ${{ steps.changes.outputs.files }}"
 ```
+
 {% endraw %}
 
 ## Best Practices

--- a/docs/devsecops/cloud-security-posture.md
+++ b/docs/devsecops/cloud-security-posture.md
@@ -62,6 +62,7 @@ prowler github \
 ### CI/CD Integration
 
 {% raw %}
+
 ```yaml
 # .github/workflows/prowler.yml
 name: Cloud Security Scan
@@ -158,6 +159,7 @@ jobs:
             exit 1
           fi
 ```
+
 {% endraw %}
 
 ### Compliance Frameworks (41+)

--- a/docs/devsecops/cloud-security-posture.md
+++ b/docs/devsecops/cloud-security-posture.md
@@ -61,6 +61,7 @@ prowler github \
 
 ### CI/CD Integration
 
+{% raw %}
 ```yaml
 # .github/workflows/prowler.yml
 name: Cloud Security Scan
@@ -157,6 +158,7 @@ jobs:
             exit 1
           fi
 ```
+{% endraw %}
 
 ### Compliance Frameworks (41+)
 

--- a/docs/devsecops/dast-testing.md
+++ b/docs/devsecops/dast-testing.md
@@ -160,6 +160,7 @@ jobs:
 ### Full Scan — 스테이징 정기 스캔
 
 {% raw %}
+
 ```yaml
 # .github/workflows/dast-full-scan.yml
 name: DAST Full Scan (Nightly)
@@ -217,6 +218,7 @@ jobs:
               body: 'DAST Full Scan에서 Critical 취약점이 발견되었습니다. Artifacts를 확인하세요.'
             })
 ```
+
 {% endraw %}
 
 ### API Scan — REST/OpenAPI 대상

--- a/docs/devsecops/dast-testing.md
+++ b/docs/devsecops/dast-testing.md
@@ -159,6 +159,7 @@ jobs:
 
 ### Full Scan — 스테이징 정기 스캔
 
+{% raw %}
 ```yaml
 # .github/workflows/dast-full-scan.yml
 name: DAST Full Scan (Nightly)
@@ -216,6 +217,7 @@ jobs:
               body: 'DAST Full Scan에서 Critical 취약점이 발견되었습니다. Artifacts를 확인하세요.'
             })
 ```
+{% endraw %}
 
 ### API Scan — REST/OpenAPI 대상
 

--- a/docs/devsecops/kubernetes-security.md
+++ b/docs/devsecops/kubernetes-security.md
@@ -55,6 +55,7 @@ ENTRYPOINT ["node", "server.js"]
 
 ### Scan & Sign
 
+{% raw %}
 ```yaml
 # CI pipeline
 - name: Scan image
@@ -63,6 +64,7 @@ ENTRYPOINT ["node", "server.js"]
 - name: Sign image
   run: cosign sign --yes ghcr.io/myorg/myapp:${{ github.sha }}
 ```
+{% endraw %}
 
 ### Image Policy
 

--- a/docs/devsecops/kubernetes-security.md
+++ b/docs/devsecops/kubernetes-security.md
@@ -56,6 +56,7 @@ ENTRYPOINT ["node", "server.js"]
 ### Scan & Sign
 
 {% raw %}
+
 ```yaml
 # CI pipeline
 - name: Scan image
@@ -64,6 +65,7 @@ ENTRYPOINT ["node", "server.js"]
 - name: Sign image
   run: cosign sign --yes ghcr.io/myorg/myapp:${{ github.sha }}
 ```
+
 {% endraw %}
 
 ### Image Policy

--- a/docs/devsecops/owasp-top10-2025.md
+++ b/docs/devsecops/owasp-top10-2025.md
@@ -128,6 +128,7 @@ Expanded from "Vulnerable Components" to cover the **entire software supply chai
 ### Controls
 
 {% raw %}
+
 ```yaml
 # SBOM generation in CI
 - name: Generate SBOM
@@ -143,6 +144,7 @@ Expanded from "Vulnerable Components" to cover the **entire software supply chai
     fail-on-severity: moderate
     deny-licenses: GPL-3.0, AGPL-3.0
 ```
+
 {% endraw %}
 
 See [Supply Chain Security Guide](supply-chain-security.md) for full SLSA/SBOM/Sigstore coverage.

--- a/docs/devsecops/owasp-top10-2025.md
+++ b/docs/devsecops/owasp-top10-2025.md
@@ -127,6 +127,7 @@ Expanded from "Vulnerable Components" to cover the **entire software supply chai
 
 ### Controls
 
+{% raw %}
 ```yaml
 # SBOM generation in CI
 - name: Generate SBOM
@@ -142,6 +143,7 @@ Expanded from "Vulnerable Components" to cover the **entire software supply chai
     fail-on-severity: moderate
     deny-licenses: GPL-3.0, AGPL-3.0
 ```
+{% endraw %}
 
 See [Supply Chain Security Guide](supply-chain-security.md) for full SLSA/SBOM/Sigstore coverage.
 

--- a/docs/devsecops/pipeline.md
+++ b/docs/devsecops/pipeline.md
@@ -62,6 +62,7 @@ repos:
 
 ### 3. Build Stage
 
+{% raw %}
 ```yaml
 # GitHub Actions example
 - name: Build with SBOM
@@ -72,6 +73,7 @@ repos:
   uses: sigstore/cosign-installer@v3
   run: cosign sign myapp:${{ github.sha }}
 ```
+{% endraw %}
 
 ### 4. Test Stage — SAST
 

--- a/docs/devsecops/pipeline.md
+++ b/docs/devsecops/pipeline.md
@@ -63,6 +63,7 @@ repos:
 ### 3. Build Stage
 
 {% raw %}
+
 ```yaml
 # GitHub Actions example
 - name: Build with SBOM
@@ -73,6 +74,7 @@ repos:
   uses: sigstore/cosign-installer@v3
   run: cosign sign myapp:${{ github.sha }}
 ```
+
 {% endraw %}
 
 ### 4. Test Stage — SAST

--- a/docs/devsecops/supply-chain-security.md
+++ b/docs/devsecops/supply-chain-security.md
@@ -46,6 +46,7 @@ Supply chain attacks (SolarWinds, Log4Shell, xz-utils, 2025 Bybit hack) demonstr
 ### GitHub Actions SLSA Implementation
 
 {% raw %}
+
 ```yaml
 # Generate SLSA provenance for container images
 name: SLSA Build
@@ -76,6 +77,7 @@ jobs:
           image: ghcr.io/${{ github.repository }}
           digest: ${{ steps.build.outputs.digest }}
 ```
+
 {% endraw %}
 
 ---
@@ -103,6 +105,7 @@ An SBOM is a machine-readable inventory of all software components, dependencies
 ### CI Integration
 
 {% raw %}
+
 ```yaml
 # Generate SBOM + scan vulnerabilities
 - name: Generate SBOM
@@ -135,6 +138,7 @@ An SBOM is a machine-readable inventory of all software components, dependencies
       -F "project=$PROJECT_UUID" \
       -F "bom=@sbom.cdx.json"
 ```
+
 {% endraw %}
 
 ---

--- a/docs/devsecops/supply-chain-security.md
+++ b/docs/devsecops/supply-chain-security.md
@@ -45,6 +45,7 @@ Supply chain attacks (SolarWinds, Log4Shell, xz-utils, 2025 Bybit hack) demonstr
 
 ### GitHub Actions SLSA Implementation
 
+{% raw %}
 ```yaml
 # Generate SLSA provenance for container images
 name: SLSA Build
@@ -75,6 +76,7 @@ jobs:
           image: ghcr.io/${{ github.repository }}
           digest: ${{ steps.build.outputs.digest }}
 ```
+{% endraw %}
 
 ---
 
@@ -100,6 +102,7 @@ An SBOM is a machine-readable inventory of all software components, dependencies
 
 ### CI Integration
 
+{% raw %}
 ```yaml
 # Generate SBOM + scan vulnerabilities
 - name: Generate SBOM
@@ -132,6 +135,7 @@ An SBOM is a machine-readable inventory of all software components, dependencies
       -F "project=$PROJECT_UUID" \
       -F "bom=@sbom.cdx.json"
 ```
+{% endraw %}
 
 ---
 

--- a/docs/github/actions-security.md
+++ b/docs/github/actions-security.md
@@ -20,6 +20,7 @@ tags: [github-actions, ci-cd, supply-chain, security]
 
 ### 2. Script Injection
 
+{% raw %}
 ```yaml
 # BAD: Directly interpolating user input
 - run: echo "Hello ${{ github.event.issue.title }}"
@@ -29,6 +30,7 @@ tags: [github-actions, ci-cd, supply-chain, security]
     ISSUE_TITLE: ${{ github.event.issue.title }}
   run: echo "Hello $ISSUE_TITLE"
 ```
+{% endraw %}
 
 ### 3. Excessive Permissions
 
@@ -61,6 +63,7 @@ jobs:
 
 ### Secrets Management
 
+{% raw %}
 ```yaml
 # Use GitHub Environments for secret scoping
 jobs:
@@ -79,6 +82,7 @@ jobs:
           # GOOD: Verify secret exists without exposing
           if [ -z "$API_KEY" ]; then echo "API_KEY not set"; exit 1; fi
 ```
+{% endraw %}
 
 ### Third-Party Actions
 
@@ -136,6 +140,7 @@ jobs:
 
 ### Secure Docker Build & Push
 
+{% raw %}
 ```yaml
 name: Docker
 on:
@@ -165,6 +170,7 @@ jobs:
           provenance: true
           sbom: true
 ```
+{% endraw %}
 
 ## OpenSSF Best Practices
 

--- a/docs/github/actions-security.md
+++ b/docs/github/actions-security.md
@@ -21,6 +21,7 @@ tags: [github-actions, ci-cd, supply-chain, security]
 ### 2. Script Injection
 
 {% raw %}
+
 ```yaml
 # BAD: Directly interpolating user input
 - run: echo "Hello ${{ github.event.issue.title }}"
@@ -30,6 +31,7 @@ tags: [github-actions, ci-cd, supply-chain, security]
     ISSUE_TITLE: ${{ github.event.issue.title }}
   run: echo "Hello $ISSUE_TITLE"
 ```
+
 {% endraw %}
 
 ### 3. Excessive Permissions
@@ -64,6 +66,7 @@ jobs:
 ### Secrets Management
 
 {% raw %}
+
 ```yaml
 # Use GitHub Environments for secret scoping
 jobs:
@@ -82,6 +85,7 @@ jobs:
           # GOOD: Verify secret exists without exposing
           if [ -z "$API_KEY" ]; then echo "API_KEY not set"; exit 1; fi
 ```
+
 {% endraw %}
 
 ### Third-Party Actions
@@ -141,6 +145,7 @@ jobs:
 ### Secure Docker Build & Push
 
 {% raw %}
+
 ```yaml
 name: Docker
 on:
@@ -170,6 +175,7 @@ jobs:
           provenance: true
           sbom: true
 ```
+
 {% endraw %}
 
 ## OpenSSF Best Practices

--- a/docs/github/security-features.md
+++ b/docs/github/security-features.md
@@ -68,6 +68,7 @@ updates:
 
 ## 2. Code Scanning (CodeQL)
 
+{% raw %}
 ```yaml
 # .github/workflows/codeql.yml
 name: CodeQL Analysis
@@ -96,6 +97,7 @@ jobs:
       - uses: github/codeql-action/autobuild@v3
       - uses: github/codeql-action/analyze@v3
 ```
+{% endraw %}
 
 ### Custom CodeQL Queries
 

--- a/docs/github/security-features.md
+++ b/docs/github/security-features.md
@@ -69,6 +69,7 @@ updates:
 ## 2. Code Scanning (CodeQL)
 
 {% raw %}
+
 ```yaml
 # .github/workflows/codeql.yml
 name: CodeQL Analysis
@@ -97,6 +98,7 @@ jobs:
       - uses: github/codeql-action/autobuild@v3
       - uses: github/codeql-action/analyze@v3
 ```
+
 {% endraw %}
 
 ### Custom CodeQL Queries


### PR DESCRIPTION
## Summary
- GitHub Pages builds were failing because `${{ }}` GitHub Actions expressions in code blocks were interpreted as Liquid template syntax by Jekyll
- Wrapped 14 affected code blocks across 9 docs files with `{% raw %}`/`{% endraw %}` tags

## Affected files
- `docs/devsecops/pipeline.md`
- `docs/devsecops/supply-chain-security.md`
- `docs/devsecops/owasp-top10-2025.md`
- `docs/devsecops/dast-testing.md`
- `docs/devsecops/cloud-security-posture.md`
- `docs/devsecops/kubernetes-security.md`
- `docs/github/actions-security.md`
- `docs/github/security-features.md`
- `docs/ai/code-review.md`

## Test plan
- [x] 162 tests pass locally
- [x] All `${{ }}` occurrences verified inside raw blocks
- [ ] GitHub Pages build succeeds after merge