### PR TITLE
chore(ci): migrate setup-node from node20 to node22

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
       - name: npm audit
         run: npm audit --audit-level=high

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Check version


### PR DESCRIPTION
## Summary
- Updates `node-version: '20'` → `'22'` in `lint.yml` and `npm-publish.yml`
- The 3 upstream actions (gitleaks, shellcheck, dependency-review) still have no node22 releases — tracked via deprecation comments in the workflow

## Upstream Status (as of 2026-04-11)
| Action | Latest | Node22? |
|---|---|---|
| `actions/dependency-review-action` | v4.9.0 | No |
| `gitleaks/gitleaks-action` | v2.3.9 | No |
| `ludeeus/action-shellcheck` | 2.0.0 | No |

GitHub forced migration: **2026-06-02** (node24 default), **2026-09-16** (node20 removed)

## Test plan
- [ ] CI passes with node22 (Lint + Security Scan Gate)
- [ ] npm-audit still works under node22
- [ ] npm publish works under node22

🤖 Generated with [Claude Code](https://claude.com/claude-code)