### PR TITLE
Reduce seminar deck size by pruning unreachable PPTX parts

### DIFF
--- a/docs/reports/claudesec-security-seminar-30min-template.md
+++ b/docs/reports/claudesec-security-seminar-30min-template.md
@@ -8,7 +8,7 @@ tags: [ppt, seminar, claudesec, devsecops, isms]
 
 ## 사용 자료
 
-- 템플릿: `$CLAUDESEC_PPT_TEMPLATE` 또는 `~/Downloads/버디 방향성 2026.pptx`
+- 템플릿: `$CLAUDESEC_PPT_TEMPLATE or ~/Downloads/버디 방향성 2026.pptx`
 - LinkedIn 공개 글: `https://kr.linkedin.com/posts/twodragon_devsecops-isms-%EB%B3%B4%EC%95%88-activity-7439616126894104577-6ADD`
 - LinkedIn 공개 이미지 3장
 - 로컬 문서:

--- a/scanner/tests/test_generate_security_seminar_template_ppt.py
+++ b/scanner/tests/test_generate_security_seminar_template_ppt.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+def load_module():
+    script_path = Path(__file__).resolve().parents[2] / "scripts" / "generate_security_seminar_template_ppt.py"
+    spec = importlib.util.spec_from_file_location("generate_security_seminar_template_ppt", script_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_prune_unreachable_parts_removes_unused_package_parts(tmp_path: Path) -> None:
+    module = load_module()
+
+    write_text(
+        tmp_path / "[Content_Types].xml",
+        """<?xml version="1.0" encoding="UTF-8"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/ppt/presentation.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.presentation.main+xml"/>
+  <Override PartName="/ppt/slides/slide1.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+  <Override PartName="/ppt/slides/slide2.xml" ContentType="application/vnd.openxmlformats-officedocument.presentationml.slide+xml"/>
+</Types>
+""",
+    )
+    write_text(
+        tmp_path / "_rels" / ".rels",
+        """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="ppt/presentation.xml"/>
+</Relationships>
+""",
+    )
+    write_text(tmp_path / "ppt" / "presentation.xml", "<presentation/>")
+    write_text(
+        tmp_path / "ppt" / "_rels" / "presentation.xml.rels",
+        """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slide" Target="slides/slide1.xml"/>
+</Relationships>
+""",
+    )
+    write_text(tmp_path / "ppt" / "slides" / "slide1.xml", "<slide/>")
+    write_text(
+        tmp_path / "ppt" / "slides" / "_rels" / "slide1.xml.rels",
+        """<?xml version="1.0" encoding="UTF-8"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/image1.png"/>
+</Relationships>
+""",
+    )
+    write_text(tmp_path / "ppt" / "media" / "image1.png", "keep")
+    write_text(tmp_path / "ppt" / "slides" / "slide2.xml", "<slide/>")
+    write_text(tmp_path / "ppt" / "media" / "image2.png", "drop")
+
+    module.prune_unreachable_parts(tmp_path)
+
+    assert (tmp_path / "ppt" / "presentation.xml").exists()
+    assert (tmp_path / "ppt" / "slides" / "slide1.xml").exists()
+    assert (tmp_path / "ppt" / "media" / "image1.png").exists()
+    assert not (tmp_path / "ppt" / "slides" / "slide2.xml").exists()
+    assert not (tmp_path / "ppt" / "media" / "image2.png").exists()
+
+    content_types = (tmp_path / "[Content_Types].xml").read_text(encoding="utf-8")
+    assert "/ppt/slides/slide1.xml" in content_types
+    assert "/ppt/slides/slide2.xml" not in content_types

--- a/scripts/generate_security_seminar_template_ppt.py
+++ b/scripts/generate_security_seminar_template_ppt.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import copy
 import os
+import posixpath
 import zipfile
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -35,6 +36,7 @@ NS = {
     "vt": "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes",
     "ep": "http://schemas.openxmlformats.org/officeDocument/2006/extended-properties",
 }
+REL_NS = {"pr": "http://schemas.openxmlformats.org/package/2006/relationships"}
 
 for prefix, uri in NS.items():
     ET.register_namespace(prefix if prefix not in ("ep", "vt") else prefix, uri)
@@ -326,6 +328,12 @@ def reorder_presentation(presentation_path: Path, rels_path: Path) -> None:
         rel_id = rel_by_target[slide_name]
         sld_id_lst.append(copy.deepcopy(existing[rel_id]))
     pres_tree.write(presentation_path, encoding="UTF-8", xml_declaration=True)
+    keep_rel_ids = {rel_by_target[slide_name] for slide_name in SLIDE_ORDER}
+    for rel in list(rels_root):
+        target = rel.attrib.get("Target", "")
+        if target.startswith("slides/") and rel.attrib.get("Id") not in keep_rel_ids:
+            rels_root.remove(rel)
+    rels_tree.write(rels_path, encoding="UTF-8", xml_declaration=True)
 
 
 def update_app_xml(app_path: Path) -> None:
@@ -376,6 +384,82 @@ def rezip(source_dir: Path, output_path: Path) -> None:
         for path in sorted(source_dir.rglob("*")):
             if path.is_file():
                 zf.write(path, path.relative_to(source_dir).as_posix())
+
+
+def rels_path_for(part_name: str) -> str:
+    if not part_name:
+        return "_rels/.rels"
+    parent, name = posixpath.split(part_name)
+    if parent:
+        return f"{parent}/_rels/{name}.rels"
+    return f"_rels/{name}.rels"
+
+
+def resolve_target(part_name: str, target: str) -> str | None:
+    if "://" in target or target.startswith("mailto:"):
+        return None
+    if target.startswith("/"):
+        return posixpath.normpath(target.lstrip("/"))
+    base_dir = posixpath.dirname(part_name)
+    return posixpath.normpath(posixpath.join(base_dir, target))
+
+
+def collect_reachable_parts(package_dir: Path) -> set[str]:
+    reachable = {"[Content_Types].xml"}
+    queue = [""]
+    seen = set()
+    while queue:
+        part_name = queue.pop()
+        if part_name in seen:
+            continue
+        seen.add(part_name)
+        rels_name = rels_path_for(part_name)
+        rels_path = package_dir / rels_name
+        if not rels_path.exists():
+            continue
+        reachable.add(rels_name)
+        tree = ET.parse(rels_path)
+        root = tree.getroot()
+        for rel in root.findall("pr:Relationship", REL_NS):
+            if rel.attrib.get("TargetMode") == "External":
+                continue
+            target_name = resolve_target(part_name, rel.attrib["Target"])
+            if target_name is None:
+                continue
+            target_path = package_dir / target_name
+            if not target_path.exists():
+                continue
+            reachable.add(target_name)
+            queue.append(target_name)
+    return reachable
+
+
+def prune_content_types(package_dir: Path, reachable: set[str]) -> None:
+    content_types_path = package_dir / "[Content_Types].xml"
+    tree = ET.parse(content_types_path)
+    root = tree.getroot()
+    for override in list(root.findall("{*}Override")):
+        part_name = override.attrib["PartName"].lstrip("/")
+        if part_name not in reachable:
+            root.remove(override)
+    tree.write(content_types_path, encoding="UTF-8", xml_declaration=True)
+
+
+def prune_unreachable_parts(package_dir: Path) -> None:
+    reachable = collect_reachable_parts(package_dir)
+    prune_content_types(package_dir, reachable)
+    for path in sorted(package_dir.rglob("*"), reverse=True):
+        if not path.is_file():
+            continue
+        relative = path.relative_to(package_dir).as_posix()
+        if relative not in reachable:
+            path.unlink()
+    for path in sorted(package_dir.rglob("*"), reverse=True):
+        if path.is_dir():
+            try:
+                path.rmdir()
+            except OSError:
+                pass
 
 
 def write_outline() -> None:
@@ -440,6 +524,7 @@ def main() -> None:
 
         reorder_presentation(tmpdir / "ppt" / "presentation.xml", tmpdir / "ppt" / "_rels" / "presentation.xml.rels")
         update_app_xml(tmpdir / "docProps" / "app.xml")
+        prune_unreachable_parts(tmpdir)
         rezip(tmpdir, OUTPUT)
 
     write_outline()


### PR DESCRIPTION
The seminar template generator now removes slides, media, and package
metadata that become unreachable after slide reordering. This keeps the
exported PPTX under GitHub's large-file warning threshold while locking
the pruning behavior with a focused package-level regression test.

Constraint: The generated PPTX should stay reviewable in git without introducing Git LFS as an immediate dependency
Rejected: Move the deck to Git LFS now | local git lacks LFS and script-side pruning resolves the current size risk directly
Confidence: high
Scope-risk: narrow
Reversibility: clean
Directive: If slide ordering or relationship rewriting changes, regenerate the PPTX and re-check package reachability before shipping
Tested: python3 -m pytest scanner/tests/test_generate_security_seminar_template_ppt.py -v
Tested: python3 -m py_compile scripts/generate_security_seminar_template_ppt.py
Tested: npx -y markdownlint-cli2 docs/reports/claudesec-security-seminar-30min-template.md
Tested: zip inspection confirmed slides=16 media=37 total=137 size=34922270
Not-tested: Manual open/render check in PowerPoint or Keynote after pruning
