### PR TITLE
test: cover new dashboard_html_audit_sources path in SaaS empty-fallback patch

### DIFF
--- a/scanner/tests/test_dashboard_builders_unit.py
+++ b/scanner/tests/test_dashboard_builders_unit.py
@@ -238,20 +238,26 @@ def test_audit_points_saas_sources_empty_shows_no_sources_configured():
     ms_data = {"sources": [], "fetched_at": ""}
     # saas_bp_data.sources is explicitly [] — the function uses this value directly
     # and only falls back to SAAS_BEST_PRACTICES_SOURCES when .get("sources") is falsy.
-    # To force the empty branch we need to patch the fallback constant in the sections module.
+    # To force the empty branch we need to patch the fallback constant in every
+    # module that has imported it by name.
     import dashboard_html_sections as _sections_mod
+    import dashboard_html_audit_sources as _audit_sources_mod
     import dashboard_api_client as _dac
     original_const = _dac.SAAS_BEST_PRACTICES_SOURCES
     _dac.SAAS_BEST_PRACTICES_SOURCES = []
-    # The function reads the name via `from dashboard_api_client import ...` at module load,
-    # so we also patch it in the sections module's own namespace.
+    # The MS/SaaS source builders moved into dashboard_html_audit_sources, which
+    # rebinds SAAS_BEST_PRACTICES_SOURCES at import; sections still kept it for
+    # backwards compat. Patch both module-level names.
     original_sections = getattr(_sections_mod, "SAAS_BEST_PRACTICES_SOURCES", original_const)
+    original_audit_sources = getattr(_audit_sources_mod, "SAAS_BEST_PRACTICES_SOURCES", original_const)
     _sections_mod.SAAS_BEST_PRACTICES_SOURCES = []
+    _audit_sources_mod.SAAS_BEST_PRACTICES_SOURCES = []
     try:
         html = _build_audit_points_html(ap_data, ap_detected, ms_data, {"sources": []})
     finally:
         _dac.SAAS_BEST_PRACTICES_SOURCES = original_const
         _sections_mod.SAAS_BEST_PRACTICES_SOURCES = original_sections
+        _audit_sources_mod.SAAS_BEST_PRACTICES_SOURCES = original_audit_sources
 
     assert "No SaaS/DevOps best-practice sources configured" in html
 


### PR DESCRIPTION
## Summary

Follow-up to #92 (called out in #92's PR body).

After #92 moved the MS/SaaS source builders into the new `dashboard_html_audit_sources` module, the empty-SaaS-fallback test in #91 still only patched the old import sites (`dashboard_api_client` + `dashboard_html_sections`). The live read path is now `dashboard_html_audit_sources.SAAS_BEST_PRACTICES_SOURCES`, which the test missed — leaving room for the test to silently pass through the populated default rather than the intended empty branch.

This PR adds the third patch target with proper save/restore in the existing `try`/`finally` so all import sites are forced to `[]` for the duration of the assertion.

## Test plan

- [x] `python3 -m pytest scanner/tests/test_dashboard_builders_unit.py -v` — 31 passed
- [x] `python3 -m pytest scanner/tests/ -q` — 205 passed, 205 subtests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)