### PR TITLE
refactor: split OWASP/arch/compliance builders into dedicated modules (Option B)

### DIFF
--- a/scanner/lib/dashboard_html_arch.py
+++ b/scanner/lib/dashboard_html_arch.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+ClaudeSec Dashboard — Architecture HTML builder.
+
+Extracted from dashboard_html_sections.py via the Option B split documented in
+.omc/plans/dashboard-standards-split.md.  Owns rendering of the architecture
+domain cards with OWASP/compliance/scanner cross-links.
+"""
+
+import os
+import sys
+
+# Ensure sibling modules are importable when loaded via importlib
+_LIB_DIR = os.path.dirname(os.path.abspath(__file__))
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from dashboard_utils import h, sev_badge, comp_slug
+from dashboard_mapping import OWASP_2025, get_check_en
+
+
+def _build_arch_html(arch_domains) -> str:
+    """Build the Architecture tab HTML with OWASP/Compliance/Scanner cross-links."""
+    arch_html = ""
+    owasp_names = {o["id"]: o["name"] for o in OWASP_2025}
+    scanner_labels = {
+        "access-control": "Access control",
+        "infra": "Infrastructure",
+        "network": "Network",
+        "cicd": "CI/CD",
+        "code": "Code",
+        "ai": "AI",
+        "cloud": "Cloud",
+        "macos": "macOS",
+        "saas": "SaaS",
+        "windows": "Windows",
+        "prowler": "Prowler",
+        "other": "Other",
+    }
+    for idx, dom in enumerate(arch_domains):
+        status_cls = "fail" if dom["fail_count"] > 0 else "pass"
+        links = dom.get("links", {})
+        arch_html += f'<div class="arch-domain {status_cls}" id="arch-dom-{idx}" data-arch-idx="{idx}">'
+        scanner_cats = links.get("scanner", [])
+        coverage_dots = ""
+        if scanner_cats:
+            coverage_dots = '<span class="arch-coverage">'
+            for scat in scanner_cats:
+                slab = scanner_labels.get(scat, scat)
+                has_data = dom["fail_count"] > 0
+                dot_cls = "cov-on" if has_data else "cov-off"
+                coverage_dots += f'<span class="cov-dot {dot_cls}" title="{h(slab)}">{h(slab[:3])}</span>'
+            coverage_dots += '</span>'
+        arch_html += f'<div class="arch-header" onclick="toggleArch(this)"><span class="arch-icon">{dom["icon"]}</span><span class="arch-name">{h(dom["name"])}</span>{coverage_dots}<span class="arch-stat"><span class="arch-fail">{dom["fail_count"]} failed</span></span><span class="arch-arrow">▸</span></div>'
+        arch_html += '<div class="arch-body">'
+        summary = dom.get("summary", "")
+        action = dom.get("action", "")
+        summary = (dom.get("summary") or dom.get("name") or "").strip()
+        action = (
+            dom.get("action")
+            or "Apply security best practices for this domain; see related OWASP and compliance controls."
+        ).strip()
+        arch_html += '<div class="arch-summary-block">'
+        arch_html += f'<p class="arch-summary-ko"><strong>Summary</strong> {h(summary or "See related findings and controls below.")}</p>'
+        arch_html += (
+            f'<p class="arch-action-ko"><strong>Remediation</strong> {h(action)}</p>'
+        )
+        arch_html += "</div>"
+        if links.get("owasp") or links.get("compliance") or links.get("scanner"):
+            arch_html += '<div class="arch-links"><span class="arch-links-label">Related items</span>'
+            for oid in links.get("owasp", []):
+                oname = owasp_names.get(oid, oid)
+                arch_html += f'<button class="arch-link-chip arch-owasp" onclick="switchTab(\'bestpractices\',\'owasp-{oid}\')" title="OWASP {oid}">{oid}</button>'
+            for fw, ctrl in links.get("compliance", []):
+                cid = comp_slug(fw)
+                arch_html += f'<button class="arch-link-chip arch-comp" onclick="switchTab(\'bestpractices\',\'{cid}\')" title="{h(fw)} {h(ctrl)}">{ctrl}</button>'
+            for scat in links.get("scanner", []):
+                slab = scanner_labels.get(scat, scat)
+                arch_html += f'<button class="arch-link-chip arch-scanner" onclick="switchTab(\'overview\',\'scanner-cat-{scat}\')" title="Scanner {slab}">{slab}</button>'
+            arch_html += "</div>"
+        if dom["findings"]:
+            for ff in dom["findings"][:8]:
+                res = (ff.get("resource") or "").strip()
+                prov = (ff.get("provider") or "").strip()
+                res_html = f' <span class="of-resource" title="Resource: {h(res)}">📍 <code>{h(res[:40])}</code></span>' if res else ""
+                prov_html = f' <span class="of-prov">{h(prov.upper())}</span>' if prov else ""
+                en = get_check_en(ff.get("check", ""))
+                arch_html += f'<div class="af-row">{sev_badge(ff["severity"])} <code>{h(ff["check"])}</code>{prov_html} {h(ff["message"][:100])}{res_html}</div>'
+                arch_html += f'<div class="af-detail"><span class="af-action">Action: {h(en["action"][:120])}</span></div>'
+            if dom["fail_count"] > 8:
+                arch_html += (
+                    f'<div class="of-more">... and {dom["fail_count"] - 8} more</div>'
+                )
+        else:
+            arch_html += '<div class="arch-pass">✓ No findings in this domain.</div>'
+        arch_html += "</div></div>"
+    return arch_html

--- a/scanner/lib/dashboard_html_compliance.py
+++ b/scanner/lib/dashboard_html_compliance.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""
+ClaudeSec Dashboard — Compliance HTML builder.
+
+Extracted from dashboard_html_sections.py via the Option B split documented in
+.omc/plans/dashboard-standards-split.md.  Owns rendering of the ISO/ISMS-P/
+PCI-DSS framework tables with cross-links to the architecture domains.
+"""
+
+import os
+import sys
+
+# Ensure sibling modules are importable when loaded via importlib
+_LIB_DIR = os.path.dirname(os.path.abspath(__file__))
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from dashboard_utils import h, sev_badge, comp_slug
+from dashboard_mapping import COMPLIANCE_FRAMEWORKS, ARCH_DOMAINS
+
+
+def _build_compliance_html(compliance_map) -> str:
+    """Build the Compliance tab HTML from the compliance_map."""
+    comp_html = '<div class="comp-frameworks">'
+    for fw in COMPLIANCE_FRAMEWORKS:
+        comp_html += f'<a href="{fw["url"]}" target="_blank" class="comp-fw-chip" rel="noopener"><strong>{h(fw["name"])}</strong><span>{h(fw["desc"])}</span></a>'
+    comp_html += "</div>"
+
+    COMP_FW_TO_ARCH = {
+        "ISO 27001:2022": [0, 1, 2, 3, 4, 5],
+        "KISA ISMS-P": [1, 2, 3, 4],
+        "PCI-DSS v4.0.1": [0, 1, 2, 3, 4, 5],
+    }
+    for framework, controls in compliance_map.items():
+        total_c = len(controls)
+        pass_c = sum(1 for c in controls if c["status"] == "PASS")
+        fail_c = total_c - pass_c
+        comp_id = comp_slug(framework)
+        comp_arch_html = ""
+        for aidx in COMP_FW_TO_ARCH.get(framework, []):
+            if aidx < len(ARCH_DOMAINS):
+                d = ARCH_DOMAINS[aidx]
+                comp_arch_html += f'<button class="arch-link-chip arch-sm" onclick="switchTab(\'arch\',\'arch-dom-{aidx}\')" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
+        comp_arch_row = (
+            f'<div class="comp-arch-links"><span class="arch-links-label">Related architecture</span>{comp_arch_html}</div>'
+            if comp_arch_html
+            else ""
+        )
+        comp_html += f'<div class="comp-section" id="{comp_id}"><div class="comp-title" onclick="toggleComp(this)">{h(framework)} <span class="comp-stat"><span class="cs-pass">{pass_c} pass</span> / <span class="cs-fail">{fail_c} fail</span></span><span class="comp-arrow">▸</span></div>'
+        if comp_arch_row:
+            comp_html += comp_arch_row
+        comp_html += '<div class="comp-body"><table><thead><tr><th>Control</th><th>Name</th><th>Status</th><th>Related</th><th>Summary · Remediation</th></tr></thead><tbody>'
+        for ctrl in controls:
+            st_cls = "pass" if ctrl["status"] == "PASS" else "fail"
+            st_icon = "✓" if ctrl["status"] == "PASS" else "✗"
+            st_text = "Pass" if ctrl["status"] == "PASS" else "Fail"
+            desc = (ctrl.get("desc") or ctrl.get("name") or "").strip()
+            action = (
+                ctrl.get("action")
+                or "Apply security best practices for this control; refer to the framework documentation."
+            ).strip()
+            findings_detail = ""
+            if ctrl.get("findings"):
+                findings_detail = '<div class="comp-findings">'
+                for cf in ctrl["findings"][:5]:
+                    cf_res = (cf.get("resource") or "").strip()
+                    cf_prov = (cf.get("provider") or "").strip()
+                    cf_res_html = f' <span class="of-resource">📍 <code>{h(cf_res[:40])}</code></span>' if cf_res else ""
+                    cf_prov_html = f' <span class="of-prov">{h(cf_prov.upper())}</span>' if cf_prov else ""
+                    findings_detail += f'<div class="of-row" style="font-size:.78rem">{sev_badge(cf.get("severity","Medium"))} <code>{h(cf.get("check",""))}</code>{cf_prov_html} {h((cf.get("message") or cf.get("title") or "")[:100])}{cf_res_html}</div>'
+                if ctrl["count"] > 5:
+                    findings_detail += f'<div class="of-more">... +{ctrl["count"] - 5} more</div>'
+                findings_detail += "</div>"
+            summary_cell = f'<div class="comp-summary-cell"><span class="comp-desc-ko">{h(desc or "—")}</span><br><span class="comp-action-ko"><strong>Remediation</strong> {h(action)}</span>{findings_detail}</div>'
+            comp_html += f'<tr class="comp-{st_cls}"><td class="mono">{h(ctrl["control"])}</td><td>{h(ctrl["name"])}</td><td class="comp-st-{st_cls}">{st_icon} {st_text}</td><td>{ctrl["count"]}</td><td class="comp-summary-td">{summary_cell}</td></tr>'
+        comp_html += "</tbody></table></div></div>"
+    return comp_html

--- a/scanner/lib/dashboard_html_owasp.py
+++ b/scanner/lib/dashboard_html_owasp.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""
+ClaudeSec Dashboard — OWASP HTML builder.
+
+Extracted from dashboard_html_sections.py via the Option B split documented in
+.omc/plans/dashboard-standards-split.md.  Owns rendering of the OWASP Top
+10:2025 (web) and OWASP Top 10 for LLM Applications 2025 sections together
+with cross-links to the architecture domains.
+"""
+
+import os
+import sys
+
+# Ensure sibling modules are importable when loaded via importlib
+_LIB_DIR = os.path.dirname(os.path.abspath(__file__))
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from dashboard_utils import h, sev_badge
+from dashboard_mapping import (
+    OWASP_2025, OWASP_LLM_2025, OWASP_TO_ARCH, ARCH_DOMAINS,
+    get_check_en,
+)
+
+
+def _build_owasp_html(owasp_map):
+    out = '<h2 style="font-size:.95rem;margin-bottom:.75rem;display:flex;align-items:center;gap:.5rem"><span style="color:var(--accent)">🛡</span> OWASP Top 10:2025 — Web application security</h2>'
+    for ow in OWASP_2025:
+        oid = ow["id"]
+        findings = owasp_map.get(oid, [])
+        count = len(findings)
+        status_cls = "pass" if count == 0 else "fail"
+        out += f'<div class="owasp-item {status_cls}" id="owasp-{oid}">'
+        out += f'<div class="owasp-header" onclick="toggleOwasp(this)"><span class="owasp-id">{oid}</span><span class="owasp-name">{h(ow["name"])}</span><span class="owasp-count">{count}</span><span class="owasp-arrow">▸</span></div>'
+        arch_idx_list = OWASP_TO_ARCH.get(
+            oid, OWASP_TO_ARCH.get(oid.split(":")[0] if ":" in oid else oid, [])
+        )
+        summary = (ow.get("summary") or ow.get("desc") or "").strip()
+        action = (
+            ow.get("action")
+            or "Review the OWASP documentation and apply recommended controls."
+        ).strip()
+        out += f'<div class="owasp-body"><p class="owasp-desc">{h(ow["desc"])}</p>'
+        out += f'<p class="owasp-summary"><strong>Summary</strong> {h(summary or "See description above.")}</p>'
+        out += f'<p class="owasp-action"><strong>Remediation</strong> {h(action)}</p>'
+        out += f'<a href="{ow["url"]}" target="_blank" class="ref-link">📖 OWASP documentation</a>'
+        if arch_idx_list:
+            out += f'<div class="owasp-arch-links"><span class="arch-links-label">Related architecture</span>'
+            for i in arch_idx_list:
+                d = ARCH_DOMAINS[i] if i < len(ARCH_DOMAINS) else None
+                if d:
+                    out += f'<button class="arch-link-chip" onclick="switchTab(\'arch\',\'arch-dom-{i}\')" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
+            out += "</div>"
+        if findings:
+            out += '<div class="owasp-findings">'
+            for ff in findings[:10]:
+                res = (ff.get("resource") or "").strip()
+                prov = (ff.get("provider") or "").strip()
+                res_html = f' <span class="of-resource" title="Resource: {h(res)}">📍 <code>{h(res[:50])}</code></span>' if res else ""
+                prov_html = f' <span class="of-prov">{h(prov.upper())}</span>' if prov else ""
+                en = get_check_en(ff.get("check", ""))
+                out += f'<div class="of-row">{sev_badge(ff["severity"])} <code>{h(ff["check"])}</code>{prov_html} {h(ff["message"][:120])}{res_html}</div>'
+                out += f'<div class="of-detail"><span class="of-action">Action: {h(en["action"][:150])}</span></div>'
+            if count > 10:
+                out += f'<div class="of-more">... and {count - 10} more</div>'
+            out += "</div>"
+        out += "</div></div>"
+    out += '<div style="margin-top:2rem;padding-top:1.5rem;border-top:1px solid var(--border)">'
+    out += '<h2 style="font-size:.95rem;margin-bottom:.75rem;display:flex;align-items:center;gap:.5rem"><span style="color:var(--accent)">🤖</span> OWASP Top 10 for LLM Applications 2025</h2>'
+    out += '<p style="font-size:.82rem;color:var(--muted);margin-bottom:1rem">AI/LLM application security risks — <a href="https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/" target="_blank" style="color:var(--accent)">Official docs</a></p>'
+    for llm in OWASP_LLM_2025:
+        out += f'<div class="owasp-item" style="border-left:3px solid var(--accent)">'
+        out += f'<div class="owasp-header" onclick="toggleOwasp(this)"><span class="owasp-id" style="color:#f59e0b">{llm["id"]}</span><span class="owasp-name">{h(llm["name"])}</span><span class="owasp-arrow">▸</span></div>'
+        summary = (llm.get("summary") or llm.get("desc") or "").strip()
+        action = (
+            llm.get("action")
+            or "Review the OWASP GenAI documentation and apply recommended controls."
+        ).strip()
+        out += f'<div class="owasp-body"><p class="owasp-desc">{h(llm["desc"])}</p>'
+        out += f'<p class="owasp-summary"><strong>Summary</strong> {h(summary or "See description above.")}</p>'
+        out += f'<p class="owasp-action"><strong>Remediation</strong> {h(action)}</p>'
+        out += f'<a href="{llm["url"]}" target="_blank" class="ref-link">📖 OWASP GenAI documentation</a></div></div>'
+    out += "</div>"
+    return out

--- a/scanner/lib/dashboard_html_sections.py
+++ b/scanner/lib/dashboard_html_sections.py
@@ -13,14 +13,15 @@ _LIB_DIR = os.path.dirname(os.path.abspath(__file__))
 if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
-from dashboard_utils import (
-    h, sev_badge, comp_slug,
-)
-from dashboard_mapping import (
-    CATEGORY_META, OWASP_2025, OWASP_LLM_2025, OWASP_TO_ARCH, ARCH_DOMAINS,
-    COMPLIANCE_FRAMEWORKS,
-    get_check_en,
-)
+from dashboard_utils import h, sev_badge
+from dashboard_mapping import CATEGORY_META, get_check_en
+
+# Re-export builders extracted into dedicated modules in the Option B split
+# (see .omc/plans/dashboard-standards-split.md). Keeping the names here means
+# `from dashboard_html_sections import _build_owasp_html` etc. continues to work.
+from dashboard_html_owasp import _build_owasp_html  # noqa: F401
+from dashboard_html_arch import _build_arch_html  # noqa: F401
+from dashboard_html_compliance import _build_compliance_html  # noqa: F401
 from dashboard_html_helpers import (
     _infer_category, _has_cmd, _cmd_pill,
     _compute_severity_counts, _compute_severity_bars,
@@ -673,67 +674,6 @@ def _build_overview_blocks(
     }
 
 
-def _build_owasp_html(owasp_map):
-    out = '<h2 style="font-size:.95rem;margin-bottom:.75rem;display:flex;align-items:center;gap:.5rem"><span style="color:var(--accent)">🛡</span> OWASP Top 10:2025 — Web application security</h2>'
-    for ow in OWASP_2025:
-        oid = ow["id"]
-        findings = owasp_map.get(oid, [])
-        count = len(findings)
-        status_cls = "pass" if count == 0 else "fail"
-        out += f'<div class="owasp-item {status_cls}" id="owasp-{oid}">'
-        out += f'<div class="owasp-header" onclick="toggleOwasp(this)"><span class="owasp-id">{oid}</span><span class="owasp-name">{h(ow["name"])}</span><span class="owasp-count">{count}</span><span class="owasp-arrow">▸</span></div>'
-        arch_idx_list = OWASP_TO_ARCH.get(
-            oid, OWASP_TO_ARCH.get(oid.split(":")[0] if ":" in oid else oid, [])
-        )
-        summary = (ow.get("summary") or ow.get("desc") or "").strip()
-        action = (
-            ow.get("action")
-            or "Review the OWASP documentation and apply recommended controls."
-        ).strip()
-        out += f'<div class="owasp-body"><p class="owasp-desc">{h(ow["desc"])}</p>'
-        out += f'<p class="owasp-summary"><strong>Summary</strong> {h(summary or "See description above.")}</p>'
-        out += f'<p class="owasp-action"><strong>Remediation</strong> {h(action)}</p>'
-        out += f'<a href="{ow["url"]}" target="_blank" class="ref-link">📖 OWASP documentation</a>'
-        if arch_idx_list:
-            out += f'<div class="owasp-arch-links"><span class="arch-links-label">Related architecture</span>'
-            for i in arch_idx_list:
-                d = ARCH_DOMAINS[i] if i < len(ARCH_DOMAINS) else None
-                if d:
-                    out += f'<button class="arch-link-chip" onclick="switchTab(\'arch\',\'arch-dom-{i}\')" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
-            out += "</div>"
-        if findings:
-            out += '<div class="owasp-findings">'
-            for ff in findings[:10]:
-                res = (ff.get("resource") or "").strip()
-                prov = (ff.get("provider") or "").strip()
-                res_html = f' <span class="of-resource" title="Resource: {h(res)}">📍 <code>{h(res[:50])}</code></span>' if res else ""
-                prov_html = f' <span class="of-prov">{h(prov.upper())}</span>' if prov else ""
-                en = get_check_en(ff.get("check", ""))
-                out += f'<div class="of-row">{sev_badge(ff["severity"])} <code>{h(ff["check"])}</code>{prov_html} {h(ff["message"][:120])}{res_html}</div>'
-                out += f'<div class="of-detail"><span class="of-action">Action: {h(en["action"][:150])}</span></div>'
-            if count > 10:
-                out += f'<div class="of-more">... and {count - 10} more</div>'
-            out += "</div>"
-        out += "</div></div>"
-    out += '<div style="margin-top:2rem;padding-top:1.5rem;border-top:1px solid var(--border)">'
-    out += '<h2 style="font-size:.95rem;margin-bottom:.75rem;display:flex;align-items:center;gap:.5rem"><span style="color:var(--accent)">🤖</span> OWASP Top 10 for LLM Applications 2025</h2>'
-    out += '<p style="font-size:.82rem;color:var(--muted);margin-bottom:1rem">AI/LLM application security risks — <a href="https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/" target="_blank" style="color:var(--accent)">Official docs</a></p>'
-    for llm in OWASP_LLM_2025:
-        out += f'<div class="owasp-item" style="border-left:3px solid var(--accent)">'
-        out += f'<div class="owasp-header" onclick="toggleOwasp(this)"><span class="owasp-id" style="color:#f59e0b">{llm["id"]}</span><span class="owasp-name">{h(llm["name"])}</span><span class="owasp-arrow">▸</span></div>'
-        summary = (llm.get("summary") or llm.get("desc") or "").strip()
-        action = (
-            llm.get("action")
-            or "Review the OWASP GenAI documentation and apply recommended controls."
-        ).strip()
-        out += f'<div class="owasp-body"><p class="owasp-desc">{h(llm["desc"])}</p>'
-        out += f'<p class="owasp-summary"><strong>Summary</strong> {h(summary or "See description above.")}</p>'
-        out += f'<p class="owasp-action"><strong>Remediation</strong> {h(action)}</p>'
-        out += f'<a href="{llm["url"]}" target="_blank" class="ref-link">📖 OWASP GenAI documentation</a></div></div>'
-    out += "</div>"
-    return out
-
-
 def _build_prov_table(prov_summary) -> str:
     """Build the Prowler provider summary table rows (fixed display order + extras)."""
     _prov_labels = {
@@ -812,142 +752,6 @@ def _build_prov_table(prov_summary) -> str:
         )
         prov_table += f'<tr{onclick}><td>{label}</td><td class="r">{pdata["total_fail"] + pdata["total_pass"]}</td><td class="r" style="color:#f87171">{pdata["critical"]}</td><td class="r" style="color:#fca5a5">{pdata["high"]}</td><td class="r" style="color:#fde68a">{pdata["medium"]}</td><td class="r">{pdata["low"]}</td><td class="r" style="color:#22c55e">{pdata["total_pass"]}</td></tr>'
     return prov_table
-
-
-def _build_arch_html(arch_domains) -> str:
-    """Build the Architecture tab HTML with OWASP/Compliance/Scanner cross-links."""
-    arch_html = ""
-    owasp_names = {o["id"]: o["name"] for o in OWASP_2025}
-    scanner_labels = {
-        "access-control": "Access control",
-        "infra": "Infrastructure",
-        "network": "Network",
-        "cicd": "CI/CD",
-        "code": "Code",
-        "ai": "AI",
-        "cloud": "Cloud",
-        "macos": "macOS",
-        "saas": "SaaS",
-        "windows": "Windows",
-        "prowler": "Prowler",
-        "other": "Other",
-    }
-    for idx, dom in enumerate(arch_domains):
-        status_cls = "fail" if dom["fail_count"] > 0 else "pass"
-        links = dom.get("links", {})
-        arch_html += f'<div class="arch-domain {status_cls}" id="arch-dom-{idx}" data-arch-idx="{idx}">'
-        scanner_cats = links.get("scanner", [])
-        coverage_dots = ""
-        if scanner_cats:
-            coverage_dots = '<span class="arch-coverage">'
-            for scat in scanner_cats:
-                slab = scanner_labels.get(scat, scat)
-                has_data = dom["fail_count"] > 0
-                dot_cls = "cov-on" if has_data else "cov-off"
-                coverage_dots += f'<span class="cov-dot {dot_cls}" title="{h(slab)}">{h(slab[:3])}</span>'
-            coverage_dots += '</span>'
-        arch_html += f'<div class="arch-header" onclick="toggleArch(this)"><span class="arch-icon">{dom["icon"]}</span><span class="arch-name">{h(dom["name"])}</span>{coverage_dots}<span class="arch-stat"><span class="arch-fail">{dom["fail_count"]} failed</span></span><span class="arch-arrow">▸</span></div>'
-        arch_html += '<div class="arch-body">'
-        summary = dom.get("summary", "")
-        action = dom.get("action", "")
-        summary = (dom.get("summary") or dom.get("name") or "").strip()
-        action = (
-            dom.get("action")
-            or "Apply security best practices for this domain; see related OWASP and compliance controls."
-        ).strip()
-        arch_html += '<div class="arch-summary-block">'
-        arch_html += f'<p class="arch-summary-ko"><strong>Summary</strong> {h(summary or "See related findings and controls below.")}</p>'
-        arch_html += (
-            f'<p class="arch-action-ko"><strong>Remediation</strong> {h(action)}</p>'
-        )
-        arch_html += "</div>"
-        if links.get("owasp") or links.get("compliance") or links.get("scanner"):
-            arch_html += '<div class="arch-links"><span class="arch-links-label">Related items</span>'
-            for oid in links.get("owasp", []):
-                oname = owasp_names.get(oid, oid)
-                arch_html += f'<button class="arch-link-chip arch-owasp" onclick="switchTab(\'bestpractices\',\'owasp-{oid}\')" title="OWASP {oid}">{oid}</button>'
-            for fw, ctrl in links.get("compliance", []):
-                cid = comp_slug(fw)
-                arch_html += f'<button class="arch-link-chip arch-comp" onclick="switchTab(\'bestpractices\',\'{cid}\')" title="{h(fw)} {h(ctrl)}">{ctrl}</button>'
-            for scat in links.get("scanner", []):
-                slab = scanner_labels.get(scat, scat)
-                arch_html += f'<button class="arch-link-chip arch-scanner" onclick="switchTab(\'overview\',\'scanner-cat-{scat}\')" title="Scanner {slab}">{slab}</button>'
-            arch_html += "</div>"
-        if dom["findings"]:
-            for ff in dom["findings"][:8]:
-                res = (ff.get("resource") or "").strip()
-                prov = (ff.get("provider") or "").strip()
-                res_html = f' <span class="of-resource" title="Resource: {h(res)}">📍 <code>{h(res[:40])}</code></span>' if res else ""
-                prov_html = f' <span class="of-prov">{h(prov.upper())}</span>' if prov else ""
-                en = get_check_en(ff.get("check", ""))
-                arch_html += f'<div class="af-row">{sev_badge(ff["severity"])} <code>{h(ff["check"])}</code>{prov_html} {h(ff["message"][:100])}{res_html}</div>'
-                arch_html += f'<div class="af-detail"><span class="af-action">Action: {h(en["action"][:120])}</span></div>'
-            if dom["fail_count"] > 8:
-                arch_html += (
-                    f'<div class="of-more">... and {dom["fail_count"] - 8} more</div>'
-                )
-        else:
-            arch_html += '<div class="arch-pass">✓ No findings in this domain.</div>'
-        arch_html += "</div></div>"
-    return arch_html
-
-
-def _build_compliance_html(compliance_map) -> str:
-    """Build the Compliance tab HTML from the compliance_map."""
-    comp_html = '<div class="comp-frameworks">'
-    for fw in COMPLIANCE_FRAMEWORKS:
-        comp_html += f'<a href="{fw["url"]}" target="_blank" class="comp-fw-chip" rel="noopener"><strong>{h(fw["name"])}</strong><span>{h(fw["desc"])}</span></a>'
-    comp_html += "</div>"
-
-    COMP_FW_TO_ARCH = {
-        "ISO 27001:2022": [0, 1, 2, 3, 4, 5],
-        "KISA ISMS-P": [1, 2, 3, 4],
-        "PCI-DSS v4.0.1": [0, 1, 2, 3, 4, 5],
-    }
-    for framework, controls in compliance_map.items():
-        total_c = len(controls)
-        pass_c = sum(1 for c in controls if c["status"] == "PASS")
-        fail_c = total_c - pass_c
-        comp_id = comp_slug(framework)
-        comp_arch_html = ""
-        for aidx in COMP_FW_TO_ARCH.get(framework, []):
-            if aidx < len(ARCH_DOMAINS):
-                d = ARCH_DOMAINS[aidx]
-                comp_arch_html += f'<button class="arch-link-chip arch-sm" onclick="switchTab(\'arch\',\'arch-dom-{aidx}\')" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
-        comp_arch_row = (
-            f'<div class="comp-arch-links"><span class="arch-links-label">Related architecture</span>{comp_arch_html}</div>'
-            if comp_arch_html
-            else ""
-        )
-        comp_html += f'<div class="comp-section" id="{comp_id}"><div class="comp-title" onclick="toggleComp(this)">{h(framework)} <span class="comp-stat"><span class="cs-pass">{pass_c} pass</span> / <span class="cs-fail">{fail_c} fail</span></span><span class="comp-arrow">▸</span></div>'
-        if comp_arch_row:
-            comp_html += comp_arch_row
-        comp_html += '<div class="comp-body"><table><thead><tr><th>Control</th><th>Name</th><th>Status</th><th>Related</th><th>Summary · Remediation</th></tr></thead><tbody>'
-        for ctrl in controls:
-            st_cls = "pass" if ctrl["status"] == "PASS" else "fail"
-            st_icon = "✓" if ctrl["status"] == "PASS" else "✗"
-            st_text = "Pass" if ctrl["status"] == "PASS" else "Fail"
-            desc = (ctrl.get("desc") or ctrl.get("name") or "").strip()
-            action = (
-                ctrl.get("action")
-                or "Apply security best practices for this control; refer to the framework documentation."
-            ).strip()
-            findings_detail = ""
-            if ctrl.get("findings"):
-                findings_detail = '<div class="comp-findings">'
-                for cf in ctrl["findings"][:5]:
-                    cf_res = (cf.get("resource") or "").strip()
-                    cf_prov = (cf.get("provider") or "").strip()
-                    cf_res_html = f' <span class="of-resource">📍 <code>{h(cf_res[:40])}</code></span>' if cf_res else ""
-                    cf_prov_html = f' <span class="of-prov">{h(cf_prov.upper())}</span>' if cf_prov else ""
-                    findings_detail += f'<div class="of-row" style="font-size:.78rem">{sev_badge(cf.get("severity","Medium"))} <code>{h(cf.get("check",""))}</code>{cf_prov_html} {h((cf.get("message") or cf.get("title") or "")[:100])}{cf_res_html}</div>'
-                if ctrl["count"] > 5:
-                    findings_detail += f'<div class="of-more">... +{ctrl["count"] - 5} more</div>'
-                findings_detail += "</div>"
-            summary_cell = f'<div class="comp-summary-cell"><span class="comp-desc-ko">{h(desc or "—")}</span><br><span class="comp-action-ko"><strong>Remediation</strong> {h(action)}</span>{findings_detail}</div>'
-            comp_html += f'<tr class="comp-{st_cls}"><td class="mono">{h(ctrl["control"])}</td><td>{h(ctrl["name"])}</td><td class="comp-st-{st_cls}">{st_icon} {st_text}</td><td>{ctrl["count"]}</td><td class="comp-summary-td">{summary_cell}</td></tr>'
-        comp_html += "</tbody></table></div></div>"
-    return comp_html
 
 
 def _build_audit_points_html(

--- a/scanner/tests/test_dashboard_html_modules.py
+++ b/scanner/tests/test_dashboard_html_modules.py
@@ -18,6 +18,9 @@ import dashboard_html_helpers
 import dashboard_html_builders
 import dashboard_html_sections
 import dashboard_template
+import dashboard_html_owasp
+import dashboard_html_arch
+import dashboard_html_compliance
 
 
 class TestImportsAllFourModules(unittest.TestCase):
@@ -27,6 +30,9 @@ class TestImportsAllFourModules(unittest.TestCase):
             dashboard_html_builders,
             dashboard_html_sections,
             dashboard_template,
+            dashboard_html_owasp,
+            dashboard_html_arch,
+            dashboard_html_compliance,
         ):
             self.assertIsInstance(mod, types.ModuleType)
 


### PR DESCRIPTION
## Summary

Implements **Option B** from [`.omc/plans/dashboard-standards-split.md`](../tree/main/.omc/plans/dashboard-standards-split.md): split `_build_owasp_html`, `_build_arch_html`, `_build_compliance_html` out of `dashboard_html_sections.py` into three dedicated modules. Re-export shims kept in `dashboard_html_sections.py` so existing call sites and tests don't change.

## New modules

| File | Lines | Builder |
|---|--:|---|
| `scanner/lib/dashboard_html_owasp.py` | 84 | `_build_owasp_html(owasp_map)` |
| `scanner/lib/dashboard_html_arch.py` | 97 | `_build_arch_html(arch_domains)` |
| `scanner/lib/dashboard_html_compliance.py` | 77 | `_build_compliance_html(compliance_map)` |

## sections.py change

| | Before | After | Delta |
|---|--:|--:|--:|
| `dashboard_html_sections.py` | 965 | 769 | **−196** |

Imports dropped: `OWASP_2025`, `OWASP_LLM_2025`, `OWASP_TO_ARCH`, `ARCH_DOMAINS`, `COMPLIANCE_FRAMEWORKS`, `comp_slug`. Re-export shims added so `from dashboard_html_sections import _build_owasp_html` still works (used by `dashboard-gen.py` and `test_dashboard_builders_unit.py`).

## Verification

- [x] `python3 -m py_compile` on all 4 affected files — clean
- [x] `python3 -m pytest scanner/tests/ -q` — **232 passed, 205 subtests passed**
- [x] Dashboard HTML byte-identical: 225080 bytes both before and after
- [x] `diff` shows only 8 lines (4 hunks — CSP nonce + timestamps; no structural change)
- [x] `test_dashboard_html_modules.py` extended to smoke-import the three new modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)