### PR TITLE
test: coverage campaign — mapping 100%, helpers 98%, audit-points-scan 91% (total 92%)

### DIFF
--- a/scanner/tests/test_audit_points_scan_pure.py
+++ b/scanner/tests/test_audit_points_scan_pure.py
@@ -1,0 +1,480 @@
+"""
+Unit tests for pure helpers in scanner/lib/audit-points-scan.py.
+
+Each test exercises exactly one behaviour. No network, no subprocess.
+tempfile.TemporaryDirectory is used for filesystem fixtures (stdlib only,
+so the file runs under both `python3 -m unittest xmlrunner discover` and
+pytest).
+
+Import strategy: audit-points-scan.py has hyphens in the filename, so it
+cannot be imported via `import audit-points-scan`.  We load it once via
+importlib.util.spec_from_file_location, following the pattern already
+established in test_diagram_gen_pure_helpers.py.
+"""
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_module():
+    path = Path(__file__).resolve().parents[1] / "lib" / "audit-points-scan.py"
+    spec = importlib.util.spec_from_file_location("audit_points_scan_pure", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+MOD = _load_module()
+
+
+# ===========================================================================
+# 1. Module-level constants
+# ===========================================================================
+
+
+class TestModuleConstants(unittest.TestCase):
+    def test_cache_dir_name_is_hidden(self):
+        self.assertTrue(MOD.CACHE_DIR_NAME.startswith("."))
+
+    def test_cache_dir_name_value(self):
+        self.assertEqual(MOD.CACHE_DIR_NAME, ".claudesec-audit-points")
+
+    def test_cache_file_is_json(self):
+        self.assertTrue(MOD.CACHE_FILE.endswith(".json"))
+
+    def test_detected_file_is_json(self):
+        self.assertTrue(MOD.DETECTED_FILE.endswith(".json"))
+
+    def test_product_detectors_is_non_empty_list(self):
+        self.assertIsInstance(MOD.PRODUCT_DETECTORS, list)
+        self.assertGreater(len(MOD.PRODUCT_DETECTORS), 0)
+
+    def test_product_detectors_have_name_and_indicators(self):
+        for row in MOD.PRODUCT_DETECTORS:
+            self.assertGreaterEqual(len(row), 2)
+            self.assertIsInstance(row[0], str)
+            self.assertIsInstance(row[1], list)
+
+    def test_product_detectors_covers_jenkins(self):
+        names = [r[0] for r in MOD.PRODUCT_DETECTORS]
+        self.assertIn("Jenkins", names)
+
+    def test_product_detectors_covers_querypie(self):
+        names = [r[0] for r in MOD.PRODUCT_DETECTORS]
+        self.assertIn("QueryPie", names)
+
+
+# ===========================================================================
+# 2. _has_nexus_indicator
+# ===========================================================================
+
+
+class TestHasNexusIndicator(unittest.TestCase):
+    def test_empty_dir_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertFalse(MOD._has_nexus_indicator(d))
+
+    def test_pom_without_nexus_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "pom.xml"), "w", encoding="utf-8") as f:
+                f.write("<project><modelVersion>4.0.0</modelVersion></project>")
+            self.assertFalse(MOD._has_nexus_indicator(d))
+
+    def test_pom_with_nexus_returns_true(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "pom.xml"), "w", encoding="utf-8") as f:
+                f.write("<project><repositories><url>https://nexus.example/repo</url></repositories></project>")
+            self.assertTrue(MOD._has_nexus_indicator(d))
+
+    def test_gradle_kts_with_nexus_returns_true(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "build.gradle.kts"), "w", encoding="utf-8") as f:
+                f.write('maven { url = uri("https://Nexus.example/repository/") }')
+            self.assertTrue(MOD._has_nexus_indicator(d))
+
+    def test_gradle_groovy_with_nexus_returns_true(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "build.gradle"), "w", encoding="utf-8") as f:
+                f.write("maven { url 'https://nexus.example/repo' }")
+            self.assertTrue(MOD._has_nexus_indicator(d))
+
+    def test_case_insensitive_nexus_match(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "pom.xml"), "w", encoding="utf-8") as f:
+                f.write("NEXUS server")
+            self.assertTrue(MOD._has_nexus_indicator(d))
+
+
+# ===========================================================================
+# 3. _file_contains_any
+# ===========================================================================
+
+
+class TestFileContainsAny(unittest.TestCase):
+    def test_empty_dir_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertFalse(MOD._file_contains_any(d, ["okta"], [".env"]))
+
+    def test_file_without_keyword_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, ".env"), "w", encoding="utf-8") as f:
+                f.write("DATABASE_URL=postgres://host/db")
+            self.assertFalse(MOD._file_contains_any(d, ["okta"], [".env"]))
+
+    def test_file_with_keyword_returns_true(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, ".env"), "w", encoding="utf-8") as f:
+                f.write("OKTA_DOMAIN=example.com")
+            self.assertTrue(MOD._file_contains_any(d, ["okta"], [".env"]))
+
+    def test_wrong_suffix_ignored(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "notes.txt"), "w", encoding="utf-8") as f:
+                f.write("okta references here")
+            self.assertFalse(MOD._file_contains_any(d, ["okta"], [".env", ".yml"]))
+
+    def test_nested_file_matched(self):
+        with tempfile.TemporaryDirectory() as d:
+            sub = os.path.join(d, "sub")
+            os.makedirs(sub)
+            with open(os.path.join(sub, "config.yml"), "w", encoding="utf-8") as f:
+                f.write("querypie: enabled")
+            self.assertTrue(MOD._file_contains_any(d, ["querypie"], [".yml"]))
+
+    def test_skips_ignored_directories(self):
+        with tempfile.TemporaryDirectory() as d:
+            ignored = os.path.join(d, "node_modules")
+            os.makedirs(ignored)
+            with open(os.path.join(ignored, "config.yml"), "w", encoding="utf-8") as f:
+                f.write("okta should be ignored here")
+            self.assertFalse(MOD._file_contains_any(d, ["okta"], [".yml"]))
+
+    def test_multiple_keywords_any_matches(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, ".env"), "w", encoding="utf-8") as f:
+                f.write("HARBOR_URL=example")
+            self.assertTrue(MOD._file_contains_any(d, ["okta", "harbor"], [".env"]))
+
+    def test_multiple_suffixes_any_matches(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "config.yaml"), "w", encoding="utf-8") as f:
+                f.write("okta here")
+            self.assertTrue(MOD._file_contains_any(d, ["okta"], [".yml", ".yaml"]))
+
+
+# ===========================================================================
+# 4. _has_scalr_in_terraform
+# ===========================================================================
+
+
+class TestHasScalrInTerraform(unittest.TestCase):
+    def test_empty_dir_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertFalse(MOD._has_scalr_in_terraform(d))
+
+    def test_tf_without_scalr_returns_false(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "main.tf"), "w", encoding="utf-8") as f:
+                f.write('resource "aws_s3_bucket" "b" {}')
+            # glob.glob with "**/*.tf" (non-recursive by default) does not
+            # descend, so main.tf at the root is not matched either.
+            self.assertFalse(MOD._has_scalr_in_terraform(d))
+
+    def test_nested_tf_with_scalr_returns_true(self):
+        with tempfile.TemporaryDirectory() as d:
+            sub = os.path.join(d, "infra")
+            os.makedirs(sub)
+            with open(os.path.join(sub, "backend.tf"), "w", encoding="utf-8") as f:
+                f.write('backend "scalr" {}')
+            self.assertTrue(MOD._has_scalr_in_terraform(d))
+
+    def test_nested_tfvars_with_scalr_returns_true(self):
+        with tempfile.TemporaryDirectory() as d:
+            sub = os.path.join(d, "env")
+            os.makedirs(sub)
+            with open(os.path.join(sub, "prod.tfvars"), "w", encoding="utf-8") as f:
+                f.write("scalr_hostname = example")
+            self.assertTrue(MOD._has_scalr_in_terraform(d))
+
+
+# ===========================================================================
+# 5. detect_products
+# ===========================================================================
+
+
+class TestDetectProducts(unittest.TestCase):
+    def test_missing_dir_returns_empty_list(self):
+        self.assertEqual(MOD.detect_products("/no/such/dir/xyz/abc"), [])
+
+    def test_empty_dir_returns_empty_list(self):
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(MOD.detect_products(d), [])
+
+    def test_relative_path_is_normalised(self):
+        # Module calls os.path.abspath; a relative path to an existing dir works.
+        with tempfile.TemporaryDirectory() as d:
+            result = MOD.detect_products(d)
+            self.assertIsInstance(result, list)
+
+    def test_jenkinsfile_detects_jenkins(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "Jenkinsfile"), "w", encoding="utf-8") as f:
+                f.write("pipeline {}")
+            self.assertIn("Jenkins", MOD.detect_products(d))
+
+    def test_harbor_yml_detects_harbor(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "harbor.yml"), "w", encoding="utf-8") as f:
+                f.write("harbor: true")
+            self.assertIn("Harbor", MOD.detect_products(d))
+
+    def test_vscode_directory_detects_ides(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, ".vscode"))
+            self.assertIn("IDEs", MOD.detect_products(d))
+
+    def test_idea_directory_detects_ides(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, ".idea"))
+            self.assertIn("IDEs", MOD.detect_products(d))
+
+    def test_pom_with_nexus_extra_detects_nexus(self):
+        # Extra check (_has_nexus_indicator) triggers when pom.xml mentions nexus.
+        # pom.xml also happens to be a direct indicator, so Nexus is detected.
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "pom.xml"), "w", encoding="utf-8") as f:
+                f.write("<project><url>https://nexus.example</url></project>")
+            self.assertIn("Nexus", MOD.detect_products(d))
+
+    def test_extra_callable_path_when_no_direct_indicator(self):
+        # QueryPie: no direct indicator file, but .yml file contains the keyword.
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "svc.yml"), "w", encoding="utf-8") as f:
+                f.write("querypie: true")
+            self.assertIn("QueryPie", MOD.detect_products(d))
+
+    def test_multiple_products_detected_together(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "Jenkinsfile"), "w", encoding="utf-8") as f:
+                f.write("pipeline {}")
+            os.makedirs(os.path.join(d, ".vscode"))
+            with open(os.path.join(d, "harbor.yml"), "w", encoding="utf-8") as f:
+                f.write("harbor: true")
+            result = MOD.detect_products(d)
+            for expected in ("Jenkins", "Harbor", "IDEs"):
+                self.assertIn(expected, result)
+
+    def test_glob_indicator_with_star(self):
+        # Feed the detection with a glob containing '*' via a product whose
+        # PRODUCT_DETECTORS already uses a non-glob indicator.  We exercise
+        # the glob branch indirectly by monkey-patching PRODUCT_DETECTORS.
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "service.custom"), "w", encoding="utf-8") as f:
+                f.write("x")
+            fake = [("Custom", ["*.custom"])]
+            with patch.object(MOD, "PRODUCT_DETECTORS", fake):
+                self.assertEqual(MOD.detect_products(d), ["Custom"])
+
+    def test_glob_indicator_no_match_returns_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            fake = [("Custom", ["*.nope"])]
+            with patch.object(MOD, "PRODUCT_DETECTORS", fake):
+                self.assertEqual(MOD.detect_products(d), [])
+
+
+# ===========================================================================
+# 6. _fetch_and_cache
+# ===========================================================================
+
+
+class TestFetchAndCache(unittest.TestCase):
+    def test_returns_default_when_dashboard_missing(self):
+        # When dashboard-gen.py is absent or raises, the except branch returns
+        # the empty stub.  We force that path by patching __file__ to a
+        # location with no sibling dashboard-gen.py.
+        with tempfile.TemporaryDirectory() as d:
+            fake_file = os.path.join(d, "not_a_real_module.py")
+            with patch.object(MOD, "__file__", fake_file):
+                result = MOD._fetch_and_cache(d)
+        self.assertEqual(result, {"products": [], "fetched_at": ""})
+
+    def test_returns_dict_shape(self):
+        result = MOD._fetch_and_cache(tempfile.gettempdir())
+        self.assertIsInstance(result, dict)
+        self.assertIn("products", result)
+        self.assertIn("fetched_at", result)
+
+
+# ===========================================================================
+# 7. load_cache
+# ===========================================================================
+
+
+class TestLoadCache(unittest.TestCase):
+    def test_reads_existing_cache_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            cache_dir = os.path.join(d, MOD.CACHE_DIR_NAME)
+            os.makedirs(cache_dir)
+            payload = {"products": [{"name": "Jenkins", "files": []}], "fetched_at": "now"}
+            with open(os.path.join(cache_dir, MOD.CACHE_FILE), "w", encoding="utf-8") as f:
+                json.dump(payload, f)
+            result = MOD.load_cache(d)
+        self.assertEqual(result, payload)
+
+    def test_fallback_to_fetch_when_cache_missing(self):
+        with tempfile.TemporaryDirectory() as d:
+            with patch.object(MOD, "_fetch_and_cache", return_value={"products": [], "fetched_at": ""}):
+                result = MOD.load_cache(d)
+        self.assertEqual(result, {"products": [], "fetched_at": ""})
+        # No products → no cache file written.
+        with tempfile.TemporaryDirectory() as d2:
+            with patch.object(MOD, "_fetch_and_cache", return_value={"products": [], "fetched_at": ""}):
+                MOD.load_cache(d2)
+            self.assertFalse(
+                os.path.exists(os.path.join(d2, MOD.CACHE_DIR_NAME, MOD.CACHE_FILE))
+            )
+
+    def test_writes_cache_file_when_fetch_returns_products(self):
+        with tempfile.TemporaryDirectory() as d:
+            data = {"products": [{"name": "Jenkins", "files": []}], "fetched_at": "t"}
+            with patch.object(MOD, "_fetch_and_cache", return_value=data):
+                result = MOD.load_cache(d)
+            cache_path = os.path.join(d, MOD.CACHE_DIR_NAME, MOD.CACHE_FILE)
+            self.assertTrue(os.path.isfile(cache_path))
+            with open(cache_path, encoding="utf-8") as f:
+                persisted = json.load(f)
+        self.assertEqual(result, data)
+        self.assertEqual(persisted, data)
+
+    def test_malformed_cache_falls_back_to_fetch(self):
+        with tempfile.TemporaryDirectory() as d:
+            cache_dir = os.path.join(d, MOD.CACHE_DIR_NAME)
+            os.makedirs(cache_dir)
+            with open(os.path.join(cache_dir, MOD.CACHE_FILE), "w", encoding="utf-8") as f:
+                f.write("not valid json {")
+            with patch.object(MOD, "_fetch_and_cache", return_value={"products": [], "fetched_at": ""}):
+                result = MOD.load_cache(d)
+        self.assertEqual(result, {"products": [], "fetched_at": ""})
+
+
+# ===========================================================================
+# 8. run_audit_points_scan
+# ===========================================================================
+
+
+class TestRunAuditPointsScan(unittest.TestCase):
+    def test_empty_dir_returns_empty_detection_and_items(self):
+        with tempfile.TemporaryDirectory() as d:
+            with patch.object(MOD, "_fetch_and_cache", return_value={"products": [], "fetched_at": ""}):
+                detected, items = MOD.run_audit_points_scan(d)
+        self.assertEqual(detected, [])
+        self.assertEqual(items, [])
+
+    def test_detected_products_without_cache_entry_yield_no_items(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "Jenkinsfile"), "w", encoding="utf-8") as f:
+                f.write("pipeline {}")
+            with patch.object(MOD, "_fetch_and_cache", return_value={"products": [], "fetched_at": ""}):
+                detected, items = MOD.run_audit_points_scan(d)
+        self.assertIn("Jenkins", detected)
+        self.assertEqual(items, [])
+
+    def test_items_built_from_cache_files(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "Jenkinsfile"), "w", encoding="utf-8") as f:
+                f.write("pipeline {}")
+            cache_data = {
+                "products": [
+                    {
+                        "name": "Jenkins",
+                        "files": [
+                            {"name": "check-auth.md", "url": "https://example/check-auth.md"},
+                            {"name": "check-plugins.md", "raw_url": "https://example/raw/check-plugins.md"},
+                        ],
+                    },
+                    {"name": "Harbor", "files": [{"name": "harbor.md", "url": "https://example/h"}]},
+                ],
+                "fetched_at": "t",
+            }
+            with patch.object(MOD, "_fetch_and_cache", return_value=cache_data):
+                detected, items = MOD.run_audit_points_scan(d)
+        self.assertIn("Jenkins", detected)
+        self.assertNotIn("Harbor", detected)
+        names = [i["file_name"] for i in items]
+        self.assertIn("check-auth.md", names)
+        self.assertIn("check-plugins.md", names)
+        # raw_url fallback is used when url is absent.
+        check_plugins = next(i for i in items if i["file_name"] == "check-plugins.md")
+        self.assertEqual(check_plugins["url"], "https://example/raw/check-plugins.md")
+        # Every item has product label propagated.
+        for item in items:
+            self.assertEqual(item["product"], "Jenkins")
+
+    def test_writes_detected_json(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, ".vscode"))
+            with patch.object(MOD, "_fetch_and_cache", return_value={"products": [], "fetched_at": ""}):
+                MOD.run_audit_points_scan(d)
+            out_path = os.path.join(d, MOD.CACHE_DIR_NAME, MOD.DETECTED_FILE)
+            self.assertTrue(os.path.isfile(out_path))
+            with open(out_path, encoding="utf-8") as f:
+                out = json.load(f)
+        self.assertIn("IDEs", out["detected_products"])
+        self.assertEqual(out["items"], [])
+        self.assertTrue(os.path.isabs(out["scan_dir"]))
+
+    def test_items_missing_name_and_url_default_to_empty_string(self):
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "Jenkinsfile"), "w", encoding="utf-8") as f:
+                f.write("pipeline {}")
+            cache_data = {
+                "products": [{"name": "Jenkins", "files": [{}]}],
+                "fetched_at": "t",
+            }
+            with patch.object(MOD, "_fetch_and_cache", return_value=cache_data):
+                _detected, items = MOD.run_audit_points_scan(d)
+        self.assertEqual(items, [{"product": "Jenkins", "file_name": "", "url": ""}])
+
+
+# ===========================================================================
+# 9. main entrypoint
+# ===========================================================================
+
+
+class TestMain(unittest.TestCase):
+    def test_main_uses_env_scan_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                with patch.object(MOD, "_fetch_and_cache", return_value={"products": [], "fetched_at": ""}):
+                    with patch.object(MOD.sys, "argv", ["audit-points-scan"]):
+                        rc = MOD.main()
+        self.assertEqual(rc, 0)
+
+    def test_main_uses_argv_when_env_missing(self):
+        with tempfile.TemporaryDirectory() as d:
+            env = {k: v for k, v in os.environ.items() if k != "SCAN_DIR"}
+            with patch.dict(os.environ, env, clear=True):
+                with patch.object(MOD, "_fetch_and_cache", return_value={"products": [], "fetched_at": ""}):
+                    with patch.object(MOD.sys, "argv", ["audit-points-scan", d]):
+                        rc = MOD.main()
+        self.assertEqual(rc, 0)
+
+    def test_main_defaults_to_cwd(self):
+        # Neither SCAN_DIR nor argv[1]; main falls back to os.getcwd().
+        with tempfile.TemporaryDirectory() as d:
+            env = {k: v for k, v in os.environ.items() if k != "SCAN_DIR"}
+            with patch.dict(os.environ, env, clear=True):
+                with patch.object(MOD, "_fetch_and_cache", return_value={"products": [], "fetched_at": ""}):
+                    with patch.object(MOD.sys, "argv", ["audit-points-scan"]):
+                        with patch.object(MOD.os, "getcwd", return_value=d):
+                            rc = MOD.main()
+        self.assertEqual(rc, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_dashboard_html_helpers_pure.py
+++ b/scanner/tests/test_dashboard_html_helpers_pure.py
@@ -1,0 +1,369 @@
+"""
+Unit tests for scanner/lib/dashboard_html_helpers.py.
+
+Pure helpers covered: _infer_category, _scanner_default_action,
+_redact_target, _rel_link, _has_cmd (with shutil.which mocked),
+_cmd_pill, _compute_severity_counts, _compute_severity_bars,
+_build_replacements.
+
+Each test exercises one behaviour and is independent of any other
+test (no shared mutable state, no network).  Written so both
+unittest (`xmlrunner discover`) and pytest can execute it.
+"""
+
+import hashlib
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+import dashboard_html_helpers as helpers  # noqa: E402
+
+
+# ===========================================================================
+# 1. _infer_category
+# ===========================================================================
+
+
+class TestInferCategory(unittest.TestCase):
+    def test_iam_prefix_maps_to_access_control(self):
+        self.assertEqual(helpers._infer_category("IAM-001"), "access-control")
+
+    def test_lowercase_input_uppercased(self):
+        self.assertEqual(helpers._infer_category("iam-002"), "access-control")
+
+    def test_infra_prefix(self):
+        self.assertEqual(helpers._infer_category("INFRA-42"), "infra")
+
+    def test_docker_prefix_maps_to_infra(self):
+        self.assertEqual(helpers._infer_category("DOCKER-1"), "infra")
+
+    def test_net_prefix_maps_to_network(self):
+        self.assertEqual(helpers._infer_category("NET-9"), "network")
+
+    def test_tls_prefix_maps_to_network(self):
+        self.assertEqual(helpers._infer_category("TLS-1"), "network")
+
+    def test_nmap_prefix_maps_to_network(self):
+        self.assertEqual(helpers._infer_category("NMAP-3"), "network")
+
+    def test_cicd_prefix(self):
+        self.assertEqual(helpers._infer_category("CICD-1"), "cicd")
+
+    def test_code_and_sast_prefixes(self):
+        self.assertEqual(helpers._infer_category("CODE-1"), "code")
+        self.assertEqual(helpers._infer_category("SAST-2"), "code")
+
+    def test_ai_and_llm_prefixes(self):
+        self.assertEqual(helpers._infer_category("AI-1"), "ai")
+        self.assertEqual(helpers._infer_category("LLM-9"), "ai")
+
+    def test_cloud_family_prefixes(self):
+        for prefix in ("CLOUD", "AWS", "GCP", "AZURE"):
+            self.assertEqual(helpers._infer_category(f"{prefix}-1"), "cloud")
+
+    def test_mac_and_cis_prefixes_map_to_macos(self):
+        self.assertEqual(helpers._infer_category("MAC-1"), "macos")
+        self.assertEqual(helpers._infer_category("CIS-1"), "macos")
+
+    def test_saas_and_zia_prefixes(self):
+        self.assertEqual(helpers._infer_category("SAAS-API-022"), "saas")
+        self.assertEqual(helpers._infer_category("ZIA-1"), "saas")
+
+    def test_win_and_kisa_prefixes_map_to_windows(self):
+        self.assertEqual(helpers._infer_category("WIN-1"), "windows")
+        self.assertEqual(helpers._infer_category("KISA-7"), "windows")
+
+    def test_prowler_prefix(self):
+        self.assertEqual(helpers._infer_category("PROWLER-5"), "prowler")
+
+    def test_unknown_prefix_returns_other(self):
+        self.assertEqual(helpers._infer_category("FOO-1"), "other")
+
+    def test_no_dash_uses_full_id_uppercased(self):
+        # Without a dash, the full id is uppercased and looked up.
+        self.assertEqual(helpers._infer_category("iam"), "access-control")
+        self.assertEqual(helpers._infer_category("xyz"), "other")
+
+
+# ===========================================================================
+# 2. _scanner_default_action
+# ===========================================================================
+
+
+class TestScannerDefaultAction(unittest.TestCase):
+    def test_known_categories_return_specific_text(self):
+        for cat in (
+            "access-control",
+            "infra",
+            "network",
+            "cicd",
+            "code",
+            "ai",
+            "cloud",
+            "macos",
+            "saas",
+            "windows",
+            "prowler",
+            "other",
+        ):
+            msg = helpers._scanner_default_action(cat)
+            self.assertIsInstance(msg, str)
+            self.assertGreater(len(msg), 0)
+
+    def test_unknown_category_returns_generic_fallback(self):
+        msg = helpers._scanner_default_action("not-a-real-category")
+        self.assertIn("Review findings", msg)
+
+
+# ===========================================================================
+# 3. _redact_target
+# ===========================================================================
+
+
+class TestRedactTarget(unittest.TestCase):
+    def test_empty_value_returns_empty(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDESEC_DASHBOARD_SHOW_IDENTIFIERS", None)
+            self.assertEqual(helpers._redact_target(""), "")
+
+    def test_none_value_returns_empty(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDESEC_DASHBOARD_SHOW_IDENTIFIERS", None)
+            self.assertEqual(helpers._redact_target(None), "")
+
+    def test_show_env_returns_value_unchanged(self):
+        with patch.dict(
+            os.environ, {"CLAUDESEC_DASHBOARD_SHOW_IDENTIFIERS": "1"}, clear=False
+        ):
+            self.assertEqual(helpers._redact_target("example.com"), "example.com")
+
+    def test_default_hashes_value(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDESEC_DASHBOARD_SHOW_IDENTIFIERS", None)
+            result = helpers._redact_target("example.com")
+        expected_hash = hashlib.sha256(b"example.com").hexdigest()[:10]
+        self.assertEqual(result, f"target-{expected_hash}")
+
+    def test_show_env_other_value_still_redacts(self):
+        with patch.dict(
+            os.environ, {"CLAUDESEC_DASHBOARD_SHOW_IDENTIFIERS": "0"}, clear=False
+        ):
+            result = helpers._redact_target("example.com")
+        self.assertTrue(result.startswith("target-"))
+
+    def test_whitespace_only_value_returns_empty(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDESEC_DASHBOARD_SHOW_IDENTIFIERS", None)
+            # After .strip(), whitespace input becomes "", returned as-is.
+            self.assertEqual(helpers._redact_target("   "), "")
+
+
+# ===========================================================================
+# 4. _rel_link
+# ===========================================================================
+
+
+class TestRelLink(unittest.TestCase):
+    def test_path_is_stripped_of_leading_slash(self):
+        out = helpers._rel_link("/reports/x.html")
+        self.assertIn('href="reports/x.html"', out)
+        self.assertIn(">reports/x.html<", out)
+
+    def test_label_used_when_provided(self):
+        out = helpers._rel_link("/a.html", label="Report A")
+        self.assertIn(">Report A<", out)
+
+    def test_none_path_handled(self):
+        out = helpers._rel_link(None)
+        self.assertIn('href=""', out)
+
+    def test_label_is_escaped(self):
+        out = helpers._rel_link("x.html", label="<script>")
+        self.assertIn("&lt;script&gt;", out)
+        self.assertNotIn("<script>", out)
+
+
+# ===========================================================================
+# 5. _has_cmd  (shutil.which mocked)
+# ===========================================================================
+
+
+class TestHasCmd(unittest.TestCase):
+    def test_present_when_which_returns_path(self):
+        with patch("dashboard_html_helpers.shutil.which", return_value="/usr/bin/ls"):
+            self.assertTrue(helpers._has_cmd("ls"))
+
+    def test_absent_when_which_returns_none(self):
+        with patch("dashboard_html_helpers.shutil.which", return_value=None):
+            self.assertFalse(helpers._has_cmd("nope"))
+
+    def test_exception_returns_false(self):
+        with patch(
+            "dashboard_html_helpers.shutil.which", side_effect=OSError("boom")
+        ):
+            self.assertFalse(helpers._has_cmd("x"))
+
+
+# ===========================================================================
+# 6. _cmd_pill
+# ===========================================================================
+
+
+class TestCmdPill(unittest.TestCase):
+    def test_present_uses_env_on_and_filled_dot(self):
+        out = helpers._cmd_pill("trivy", True)
+        self.assertIn("env-on", out)
+        self.assertIn("ep-st on", out)
+        self.assertIn("●", out)
+
+    def test_absent_uses_env_off_and_open_dot(self):
+        out = helpers._cmd_pill("trivy", False)
+        self.assertIn("env-off", out)
+        self.assertIn("ep-st off", out)
+        self.assertIn("○", out)
+
+    def test_name_is_escaped(self):
+        out = helpers._cmd_pill("<bad>", True)
+        self.assertIn("&lt;bad&gt;", out)
+        self.assertNotIn("<bad>", out)
+
+    def test_note_rendered_when_provided(self):
+        out = helpers._cmd_pill("nmap", True, note="v7.95")
+        self.assertIn("v7.95", out)
+
+    def test_note_omitted_when_empty(self):
+        out = helpers._cmd_pill("nmap", True, note="")
+        self.assertNotIn("margin-top", out)
+
+
+# ===========================================================================
+# 7. _compute_severity_counts
+# ===========================================================================
+
+
+class TestComputeSeverityCounts(unittest.TestCase):
+    def test_sums_provider_summary_values(self):
+        prov_summary = {
+            "aws": {"critical": 1, "high": 2, "medium": 3, "low": 4, "informational": 5},
+            "gcp": {"critical": 0, "high": 1, "medium": 0, "low": 0, "informational": 2},
+        }
+        result = helpers._compute_severity_counts(prov_summary, [])
+        self.assertEqual(result["n_crit"], 1)
+        self.assertEqual(result["n_high"], 3)
+        self.assertEqual(result["n_med"], 3)
+        self.assertEqual(result["n_low"], 4)
+        self.assertEqual(result["n_info"], 7)
+        self.assertEqual(result["policy_022_top"], 0)
+
+    def test_findings_severity_merged_into_counts(self):
+        findings = [
+            {"severity": "critical", "id": "X-1"},
+            {"severity": "HIGH", "id": "X-2"},
+            {"severity": "Medium", "id": "X-3"},
+            {"severity": "low", "id": "X-4"},
+            {"severity": "informational", "id": "X-5"},
+            {"severity": "", "id": "X-6"},
+        ]
+        result = helpers._compute_severity_counts({}, findings)
+        self.assertEqual(result["n_crit"], 1)
+        # Non-lowercase severities are not counted because the code lowercases
+        # the severity first — so "HIGH" matches "high".
+        self.assertEqual(result["n_high"], 1)
+        self.assertEqual(result["n_med"], 1)
+        self.assertEqual(result["n_low"], 1)
+
+    def test_policy_022_counted_case_insensitive(self):
+        findings = [
+            {"severity": "high", "id": "saas-api-022"},
+            {"severity": "high", "id": "SAAS-API-022-X"},
+            {"severity": "high", "id": "OTHER"},
+        ]
+        result = helpers._compute_severity_counts({}, findings)
+        self.assertEqual(result["policy_022_top"], 2)
+
+    def test_missing_informational_key_defaults_to_zero(self):
+        prov_summary = {
+            "aws": {"critical": 0, "high": 0, "medium": 0, "low": 0},
+        }
+        result = helpers._compute_severity_counts(prov_summary, [])
+        self.assertEqual(result["n_info"], 0)
+
+    def test_empty_inputs_return_zero_counts(self):
+        result = helpers._compute_severity_counts({}, [])
+        self.assertEqual(result["n_crit"], 0)
+        self.assertEqual(result["n_high"], 0)
+        self.assertEqual(result["n_med"], 0)
+        self.assertEqual(result["n_low"], 0)
+        self.assertEqual(result["n_info"], 0)
+        self.assertEqual(result["policy_022_top"], 0)
+
+
+# ===========================================================================
+# 8. _compute_severity_bars
+# ===========================================================================
+
+
+class TestComputeSeverityBars(unittest.TestCase):
+    def test_all_zero_uses_one_denominator(self):
+        # max(0, 1) == 1 so every bar should be 0.0.
+        bars = helpers._compute_severity_bars(0, 0, 0, 0, 0)
+        self.assertEqual(bars["bar_crit"], 0.0)
+        self.assertEqual(bars["bar_high"], 0.0)
+        self.assertEqual(bars["bar_med"], 0.0)
+        self.assertEqual(bars["bar_warn"], 0.0)
+        self.assertEqual(bars["bar_low"], 0.0)
+
+    def test_percentages_sum_close_to_100(self):
+        bars = helpers._compute_severity_bars(1, 1, 1, 1, 1)
+        total = bars["bar_crit"] + bars["bar_high"] + bars["bar_med"] \
+            + bars["bar_warn"] + bars["bar_low"]
+        # Each bucket is 20.0 so the sum should be exactly 100.0.
+        self.assertAlmostEqual(total, 100.0, places=1)
+        self.assertEqual(bars["bar_crit"], 20.0)
+
+    def test_rounding_is_one_decimal(self):
+        # 1/3 = 33.333… → rounded to 33.3.
+        bars = helpers._compute_severity_bars(1, 1, 1, 0, 0)
+        self.assertEqual(bars["bar_crit"], 33.3)
+        self.assertEqual(bars["bar_high"], 33.3)
+        self.assertEqual(bars["bar_med"], 33.3)
+
+
+# ===========================================================================
+# 9. _build_replacements
+# ===========================================================================
+
+
+class TestBuildReplacements(unittest.TestCase):
+    def test_maps_positional_values_to_template_keys(self):
+        keys = helpers._TEMPLATE_KEYS
+        values = list(range(len(keys)))
+        result = helpers._build_replacements(*values)
+        for i, key in enumerate(keys):
+            self.assertIn(key, result)
+            self.assertEqual(result[key], str(i))
+
+    def test_stringifies_values(self):
+        # Passing mixed types — all should be converted to str.
+        result = helpers._build_replacements(1, "two", 3.5, None)
+        self.assertEqual(result["VERSION"], "1")
+        self.assertEqual(result["NOW"], "two")
+        self.assertEqual(result["DURATION"], "3.5")
+        self.assertEqual(result["PASSED"], "None")
+
+    def test_fewer_values_truncates_result(self):
+        # zip() stops at the shorter sequence, so only 2 keys populated.
+        result = helpers._build_replacements("a", "b")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result["VERSION"], "a")
+        self.assertEqual(result["NOW"], "b")
+
+    def test_no_values_returns_empty_dict(self):
+        self.assertEqual(helpers._build_replacements(), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_dashboard_mapping_pure.py
+++ b/scanner/tests/test_dashboard_mapping_pure.py
@@ -1,0 +1,609 @@
+"""
+Unit tests for scanner/lib/dashboard_mapping.py.
+
+Covers pure constants (OWASP_2025, OWASP_LLM_2025, CATEGORY_META, ARCH_DOMAINS,
+COMPLIANCE_FRAMEWORKS, OWASP_TO_ARCH) and pure mapping functions
+(get_check_en, map_findings_to_owasp, map_architecture,
+_match_prowler_compliance, map_compliance).
+
+Tests are stdlib-only and work under both unittest (xmlrunner discover) and
+pytest. No pytest import, no internal IPs, no network, no shared state.
+"""
+
+import importlib
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+import dashboard_mapping as dm  # noqa: E402
+
+
+def _reload_with_fallback():
+    """Reload dashboard_mapping with compliance-map.py import forced to fail.
+
+    Returns a freshly-loaded module object whose inline fallback definitions
+    (_match_prowler_compliance, map_compliance, COMPLIANCE_CONTROL_MAP) are
+    the ones used instead of the external compliance_map module.
+    """
+    # Force the spec_from_file_location call to raise so the except branch
+    # runs and _COMPLIANCE_IMPORTED stays False. The inline definitions at
+    # module scope then become the active ones.
+    with patch(
+        "importlib.util.spec_from_file_location",
+        side_effect=RuntimeError("forced fallback"),
+    ):
+        if "dashboard_mapping" in sys.modules:
+            del sys.modules["dashboard_mapping"]
+        fallback_mod = importlib.import_module("dashboard_mapping")
+    return fallback_mod
+
+
+# ===========================================================================
+# 1. CHECK_EN_MAP / DEFAULT_SUMMARY / DEFAULT_ACTION
+# ===========================================================================
+
+
+class TestCheckEnMapConstants(unittest.TestCase):
+    def test_default_summary_is_non_empty_string(self):
+        assert isinstance(dm.DEFAULT_SUMMARY, str)
+        assert len(dm.DEFAULT_SUMMARY) > 0
+
+    def test_default_action_is_non_empty_string(self):
+        assert isinstance(dm.DEFAULT_ACTION, str)
+        assert len(dm.DEFAULT_ACTION) > 0
+
+    def test_check_en_map_entries_have_summary_and_action(self):
+        assert isinstance(dm.CHECK_EN_MAP, dict)
+        assert len(dm.CHECK_EN_MAP) > 10
+        for key, val in dm.CHECK_EN_MAP.items():
+            assert isinstance(key, str) and key
+            assert "summary" in val and isinstance(val["summary"], str)
+            assert "action" in val and isinstance(val["action"], str)
+
+    def test_known_aws_key_present(self):
+        assert "guardduty_is_enabled" in dm.CHECK_EN_MAP
+        assert "s3_bucket_public_access" in dm.CHECK_EN_MAP
+
+
+# ===========================================================================
+# 2. get_check_en
+# ===========================================================================
+
+
+class TestGetCheckEn(unittest.TestCase):
+    def test_exact_key_match_returns_mapped_entry(self):
+        result = dm.get_check_en("guardduty_is_enabled")
+        assert "GuardDuty" in result["summary"]
+        assert "GuardDuty" in result["action"]
+
+    def test_keyword_substring_match(self):
+        # "mfa" substring appears in the key list
+        result = dm.get_check_en("some-check-with-mfa-in-it")
+        assert result["summary"] != dm.DEFAULT_SUMMARY
+
+    def test_case_insensitive_match(self):
+        result = dm.get_check_en("BRANCH_PROTECTION")
+        assert "branch protection" in result["summary"].lower()
+
+    def test_unknown_check_falls_back_to_default(self):
+        result = dm.get_check_en("completely_unrelated_xyz_123")
+        assert result["summary"] == dm.DEFAULT_SUMMARY
+        assert result["action"] == dm.DEFAULT_ACTION
+
+    def test_empty_string_returns_default(self):
+        result = dm.get_check_en("")
+        assert result["summary"] == dm.DEFAULT_SUMMARY
+        assert result["action"] == dm.DEFAULT_ACTION
+
+    def test_none_input_returns_default(self):
+        result = dm.get_check_en(None)
+        assert result["summary"] == dm.DEFAULT_SUMMARY
+        assert result["action"] == dm.DEFAULT_ACTION
+
+    def test_returned_dict_has_required_keys(self):
+        result = dm.get_check_en("encrypt")
+        assert set(result.keys()) == {"summary", "action"}
+
+
+# ===========================================================================
+# 3. OWASP_2025 constant
+# ===========================================================================
+
+
+class TestOwasp2025Constant(unittest.TestCase):
+    def test_has_ten_entries(self):
+        assert len(dm.OWASP_2025) == 10
+
+    def test_entries_have_required_keys(self):
+        for entry in dm.OWASP_2025:
+            for key in ("id", "name", "desc", "summary", "action", "url"):
+                assert key in entry, f"Missing {key}"
+
+    def test_ids_are_unique_and_ordered(self):
+        ids = [e["id"] for e in dm.OWASP_2025]
+        assert ids == sorted(ids)
+        assert len(set(ids)) == 10
+
+    def test_urls_point_to_owasp_org(self):
+        for e in dm.OWASP_2025:
+            assert e["url"].startswith("https://owasp.org/")
+
+
+# ===========================================================================
+# 4. OWASP_CHECK_MAP
+# ===========================================================================
+
+
+class TestOwaspCheckMap(unittest.TestCase):
+    def test_all_owasp_ids_have_keyword_list(self):
+        for entry in dm.OWASP_2025:
+            oid = entry["id"]
+            assert oid in dm.OWASP_CHECK_MAP
+            assert isinstance(dm.OWASP_CHECK_MAP[oid], list)
+            assert len(dm.OWASP_CHECK_MAP[oid]) > 0
+
+    def test_all_keywords_are_lowercase_strings(self):
+        for oid, kws in dm.OWASP_CHECK_MAP.items():
+            for kw in kws:
+                assert isinstance(kw, str)
+                assert kw == kw.lower()
+
+
+# ===========================================================================
+# 5. OWASP_LLM_2025 constant
+# ===========================================================================
+
+
+class TestOwaspLlm2025Constant(unittest.TestCase):
+    def test_has_ten_entries(self):
+        assert len(dm.OWASP_LLM_2025) == 10
+
+    def test_ids_use_llm_prefix(self):
+        for e in dm.OWASP_LLM_2025:
+            assert e["id"].startswith("LLM")
+
+    def test_entries_have_required_keys(self):
+        for entry in dm.OWASP_LLM_2025:
+            for key in ("id", "name", "desc", "summary", "action", "url"):
+                assert key in entry
+
+
+# ===========================================================================
+# 6. map_findings_to_owasp
+# ===========================================================================
+
+
+class TestMapFindingsToOwasp(unittest.TestCase):
+    def _f(self, check="", title="", message=""):
+        return {"check": check, "title": title, "message": message}
+
+    def test_empty_list_returns_all_categories_empty(self):
+        result = dm.map_findings_to_owasp([])
+        assert set(result.keys()) == {e["id"] for e in dm.OWASP_2025}
+        for findings in result.values():
+            assert findings == []
+
+    def test_branch_protection_maps_to_a01(self):
+        f = self._f(check="branch_protection", title="Branch", message="none")
+        result = dm.map_findings_to_owasp([f])
+        assert f in result["A01:2025"]
+
+    def test_encrypt_keyword_maps_to_a04(self):
+        f = self._f(check="tls_missing", title="encrypt traffic", message="")
+        result = dm.map_findings_to_owasp([f])
+        assert f in result["A04:2025"]
+
+    def test_each_finding_goes_into_first_matching_category_only(self):
+        # "branch_protection" matches A01 first, even though "logging"
+        # (A09) also appears elsewhere in the keyword map.
+        f = self._f(check="branch_protection logging", title="", message="")
+        result = dm.map_findings_to_owasp([f])
+        placed = sum(1 for findings in result.values() if f in findings)
+        assert placed == 1
+        assert f in result["A01:2025"]
+
+    def test_unmatched_finding_not_placed_anywhere(self):
+        f = self._f(check="no_match_here", title="z", message="z")
+        result = dm.map_findings_to_owasp([f])
+        for findings in result.values():
+            assert f not in findings
+
+    def test_case_insensitive_match(self):
+        f = self._f(check="MFA_DISABLED", title="", message="")
+        result = dm.map_findings_to_owasp([f])
+        assert f in result["A07:2025"]
+
+
+# ===========================================================================
+# 7. COMPLIANCE_FRAMEWORKS
+# ===========================================================================
+
+
+class TestComplianceFrameworks(unittest.TestCase):
+    def test_is_non_empty_list(self):
+        assert isinstance(dm.COMPLIANCE_FRAMEWORKS, list)
+        assert len(dm.COMPLIANCE_FRAMEWORKS) >= 5
+
+    def test_each_framework_has_required_keys(self):
+        for fw in dm.COMPLIANCE_FRAMEWORKS:
+            assert "name" in fw and fw["name"]
+            assert "url" in fw and fw["url"].startswith("http")
+            assert "desc" in fw and fw["desc"]
+
+    def test_includes_major_frameworks(self):
+        names = {fw["name"] for fw in dm.COMPLIANCE_FRAMEWORKS}
+        for expected in (
+            "OWASP Top 10:2025",
+            "ISO 27001:2022",
+            "PCI-DSS v4.0.1",
+            "NIST CSF 2.0",
+            "CIS Benchmarks",
+        ):
+            assert expected in names
+
+
+# ===========================================================================
+# 8. COMPLIANCE_CONTROL_MAP
+# ===========================================================================
+
+
+class TestComplianceControlMap(unittest.TestCase):
+    def test_is_dict_with_framework_keys(self):
+        assert isinstance(dm.COMPLIANCE_CONTROL_MAP, dict)
+        assert len(dm.COMPLIANCE_CONTROL_MAP) > 0
+
+    def test_every_control_has_required_shape(self):
+        for framework, controls in dm.COMPLIANCE_CONTROL_MAP.items():
+            assert isinstance(framework, str)
+            assert isinstance(controls, list)
+            for ctrl in controls:
+                for key in ("control", "name", "desc", "action", "checks"):
+                    assert key in ctrl, f"{framework}: missing {key}"
+                assert isinstance(ctrl["checks"], list)
+
+
+# ===========================================================================
+# 9. _match_prowler_compliance
+# ===========================================================================
+
+
+class TestMatchProwlerCompliance(unittest.TestCase):
+    def test_no_compliance_field_returns_false(self):
+        assert dm._match_prowler_compliance({}, "ISO 27001:2022") is False
+
+    def test_empty_compliance_returns_false(self):
+        assert (
+            dm._match_prowler_compliance({"compliance": {}}, "PCI-DSS") is False
+        )
+
+    def test_key_substring_match(self):
+        finding = {"compliance": {"ISO27001": ["A.8.2"]}}
+        assert dm._match_prowler_compliance(finding, "iso27001") is True
+
+    def test_value_list_substring_match(self):
+        finding = {"compliance": {"framework": ["PCI-DSS v4.0.1"]}}
+        assert dm._match_prowler_compliance(finding, "PCI-DSS") is True
+
+    def test_value_string_substring_match(self):
+        finding = {"compliance": {"framework": "NIST 800-53"}}
+        assert dm._match_prowler_compliance(finding, "nist") is True
+
+    def test_unrelated_compliance_returns_false(self):
+        finding = {"compliance": {"other": ["SOC2"]}}
+        assert dm._match_prowler_compliance(finding, "HIPAA") is False
+
+
+# ===========================================================================
+# 10. map_compliance
+# ===========================================================================
+
+
+class TestMapCompliance(unittest.TestCase):
+    def _f(self, check="", title="", message="", compliance=None):
+        d = {"check": check, "title": title, "message": message}
+        if compliance is not None:
+            d["compliance"] = compliance
+        return d
+
+    def test_empty_findings_every_control_passes(self):
+        result = dm.map_compliance([])
+        for framework, controls in result.items():
+            assert framework in dm.COMPLIANCE_CONTROL_MAP
+            for ctrl in controls:
+                assert ctrl["status"] == "PASS"
+                assert ctrl["count"] == 0
+                assert ctrl["findings"] == []
+
+    def test_keyword_match_triggers_fail(self):
+        f = self._f(check="mfa_missing", title="MFA", message="No MFA")
+        result = dm.map_compliance([f])
+        iso = result["ISO 27001:2022"]
+        a85 = next(c for c in iso if c["control"] == "A.8.5")
+        assert a85["status"] == "FAIL"
+        assert a85["count"] == 1
+
+    def test_findings_capped_at_five(self):
+        findings = [
+            self._f(check="encrypt", title=f"t{i}", message="m") for i in range(10)
+        ]
+        result = dm.map_compliance(findings)
+        iso = result["ISO 27001:2022"]
+        a824 = next(c for c in iso if c["control"] == "A.8.24")
+        assert a824["count"] == 10
+        assert len(a824["findings"]) == 5
+
+    def test_prowler_native_compliance_fallback(self):
+        # Finding has no matching keyword, but native compliance references ISO.
+        f = self._f(
+            check="unrelated",
+            title="unrelated",
+            message="unrelated",
+            compliance={"ISO 27001:2022": ["A.8.5"]},
+        )
+        result = dm.map_compliance([f])
+        iso_controls = result["ISO 27001:2022"]
+        # All ISO controls should pick this up via native fallback.
+        assert all(c["status"] == "FAIL" for c in iso_controls)
+
+
+# ===========================================================================
+# 11. ARCH_DOMAINS
+# ===========================================================================
+
+
+class TestArchDomains(unittest.TestCase):
+    def test_is_non_empty_list(self):
+        assert isinstance(dm.ARCH_DOMAINS, list)
+        assert len(dm.ARCH_DOMAINS) >= 6
+
+    def test_each_domain_has_required_keys(self):
+        for d in dm.ARCH_DOMAINS:
+            for key in ("name", "icon", "checks", "summary", "action"):
+                assert key in d
+            assert isinstance(d["checks"], list)
+            assert len(d["checks"]) > 0
+
+    def test_domain_names_are_unique(self):
+        names = [d["name"] for d in dm.ARCH_DOMAINS]
+        assert len(names) == len(set(names))
+
+
+# ===========================================================================
+# 12. ARCH_DOMAIN_LINKS
+# ===========================================================================
+
+
+class TestArchDomainLinks(unittest.TestCase):
+    def test_entries_have_owasp_compliance_scanner(self):
+        for link in dm.ARCH_DOMAIN_LINKS:
+            assert "owasp" in link
+            assert "compliance" in link
+            assert "scanner" in link
+            assert isinstance(link["owasp"], list)
+            assert isinstance(link["compliance"], list)
+            assert isinstance(link["scanner"], list)
+
+    def test_compliance_entries_are_framework_control_tuples(self):
+        for link in dm.ARCH_DOMAIN_LINKS:
+            for item in link["compliance"]:
+                assert isinstance(item, tuple)
+                assert len(item) == 2
+                assert isinstance(item[0], str) and isinstance(item[1], str)
+
+
+# ===========================================================================
+# 13. OWASP_TO_ARCH
+# ===========================================================================
+
+
+class TestOwaspToArch(unittest.TestCase):
+    def test_has_entries_for_all_owasp_prefixes(self):
+        # Keys use "A01", "A02", ... without the :2025 suffix.
+        for i in range(1, 11):
+            key = f"A{i:02d}"
+            assert key in dm.OWASP_TO_ARCH
+
+    def test_values_are_domain_index_lists(self):
+        max_idx = len(dm.ARCH_DOMAINS) - 1
+        for key, indices in dm.OWASP_TO_ARCH.items():
+            assert isinstance(indices, list)
+            for idx in indices:
+                assert 0 <= idx <= max_idx
+
+
+# ===========================================================================
+# 14. map_architecture
+# ===========================================================================
+
+
+class TestMapArchitecture(unittest.TestCase):
+    def _f(self, check="", title="", message=""):
+        return {"check": check, "title": title, "message": message}
+
+    def test_empty_findings_returns_domain_shape(self):
+        result = dm.map_architecture([])
+        assert len(result) == len(dm.ARCH_DOMAINS)
+        for entry in result:
+            assert entry["fail_count"] == 0
+            assert entry["findings"] == []
+            assert "links" in entry
+            assert "name" in entry and "icon" in entry
+
+    def test_mfa_finding_hits_identity_and_access(self):
+        f = self._f(check="mfa_disabled", title="", message="")
+        result = dm.map_architecture([f])
+        iam = next(d for d in result if d["name"] == "Identity & Access")
+        assert iam["fail_count"] == 1
+        assert iam["findings"] == [f]
+
+    def test_findings_capped_at_ten(self):
+        findings = [self._f(check="tls_bad", title=f"t{i}") for i in range(15)]
+        result = dm.map_architecture(findings)
+        net = next(d for d in result if d["name"] == "Network & TLS")
+        assert net["fail_count"] == 15
+        assert len(net["findings"]) == 10
+
+    def test_non_matching_finding_not_placed(self):
+        f = self._f(check="zzz_nothing", title="", message="")
+        result = dm.map_architecture([f])
+        for entry in result:
+            assert f not in entry["findings"]
+
+    def test_links_attached_per_index(self):
+        result = dm.map_architecture([])
+        for i, entry in enumerate(result):
+            if i < len(dm.ARCH_DOMAIN_LINKS):
+                assert entry["links"] == dm.ARCH_DOMAIN_LINKS[i]
+            else:
+                assert entry["links"] == {
+                    "owasp": [],
+                    "compliance": [],
+                    "scanner": [],
+                }
+
+
+# ===========================================================================
+# 15. CATEGORY_META
+# ===========================================================================
+
+
+class TestCategoryMeta(unittest.TestCase):
+    def test_is_non_empty_dict(self):
+        assert isinstance(dm.CATEGORY_META, dict)
+        assert len(dm.CATEGORY_META) > 5
+
+    def test_each_entry_has_icon_label_desc(self):
+        for key, meta in dm.CATEGORY_META.items():
+            assert isinstance(key, str) and key
+            for required in ("icon", "label", "desc"):
+                assert required in meta, f"{key}: missing {required}"
+                assert isinstance(meta[required], str)
+                assert meta[required]
+
+    def test_expected_categories_present(self):
+        for cat in (
+            "access-control",
+            "infra",
+            "network",
+            "cicd",
+            "code",
+            "cloud",
+            "other",
+        ):
+            assert cat in dm.CATEGORY_META
+
+
+# ===========================================================================
+# 16. __all__ exports
+# ===========================================================================
+
+
+class TestAllExports(unittest.TestCase):
+    def test_all_exports_resolve(self):
+        for name in dm.__all__:
+            assert hasattr(dm, name), f"Missing export: {name}"
+
+
+# ===========================================================================
+# 17. Fallback branch (inline definitions when compliance-map.py import fails)
+# ===========================================================================
+
+
+class TestFallbackBranch(unittest.TestCase):
+    """Exercise the inline fallback definitions at lines 603-605, 608, 931-976.
+
+    When compliance-map.py cannot be imported, dashboard_mapping defines
+    COMPLIANCE_CONTROL_MAP, _match_prowler_compliance, and map_compliance
+    inline. These tests reload the module with the external import forced to
+    fail so the fallback code runs.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.fb = _reload_with_fallback()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Restore the canonical module for any later tests in the same run.
+        if "dashboard_mapping" in sys.modules:
+            del sys.modules["dashboard_mapping"]
+        importlib.import_module("dashboard_mapping")
+
+    def test_fallback_compliance_control_map_populated(self):
+        assert isinstance(self.fb.COMPLIANCE_CONTROL_MAP, dict)
+        # Inline fallback covers ISO, ISMS-P, PCI-DSS, NIST, CIS.
+        for fw in (
+            "ISO 27001:2022",
+            "KISA ISMS-P",
+            "PCI-DSS v4.0.1",
+            "NIST 800-53 Rev5",
+            "CIS Benchmarks",
+        ):
+            assert fw in self.fb.COMPLIANCE_CONTROL_MAP
+
+    def test_fallback_match_prowler_compliance_key_hit(self):
+        finding = {"compliance": {"ISO 27001": ["A.8.2"]}}
+        assert self.fb._match_prowler_compliance(finding, "iso 27001") is True
+
+    def test_fallback_match_prowler_compliance_value_list_hit(self):
+        finding = {"compliance": {"framework": ["PCI-DSS v4.0.1"]}}
+        assert self.fb._match_prowler_compliance(finding, "pci-dss") is True
+
+    def test_fallback_match_prowler_compliance_value_string_hit(self):
+        finding = {"compliance": {"framework": "NIST"}}
+        assert self.fb._match_prowler_compliance(finding, "nist") is True
+
+    def test_fallback_match_prowler_compliance_empty(self):
+        assert self.fb._match_prowler_compliance({}, "ISO") is False
+        assert (
+            self.fb._match_prowler_compliance({"compliance": {}}, "ISO") is False
+        )
+
+    def test_fallback_match_prowler_compliance_miss(self):
+        finding = {"compliance": {"other": ["SOC2"]}}
+        assert self.fb._match_prowler_compliance(finding, "HIPAA") is False
+
+    def test_fallback_map_compliance_empty_all_pass(self):
+        result = self.fb.map_compliance([])
+        for controls in result.values():
+            for ctrl in controls:
+                assert ctrl["status"] == "PASS"
+                assert ctrl["count"] == 0
+                assert ctrl["findings"] == []
+
+    def test_fallback_map_compliance_keyword_fail(self):
+        f = {"check": "mfa", "title": "missing", "message": ""}
+        result = self.fb.map_compliance([f])
+        iso = result["ISO 27001:2022"]
+        a85 = next(c for c in iso if c["control"] == "A.8.5")
+        assert a85["status"] == "FAIL"
+        assert a85["count"] == 1
+
+    def test_fallback_map_compliance_findings_capped_at_five(self):
+        findings = [
+            {"check": "encrypt", "title": f"t{i}", "message": ""} for i in range(7)
+        ]
+        result = self.fb.map_compliance(findings)
+        iso = result["ISO 27001:2022"]
+        a824 = next(c for c in iso if c["control"] == "A.8.24")
+        assert a824["count"] == 7
+        assert len(a824["findings"]) == 5
+
+    def test_fallback_map_compliance_native_fallback(self):
+        f = {
+            "check": "unrelated",
+            "title": "unrelated",
+            "message": "unrelated",
+            "compliance": {"ISO 27001:2022": ["A.8.5"]},
+        }
+        result = self.fb.map_compliance([f])
+        # Native compliance reference fires on every ISO control.
+        for ctrl in result["ISO 27001:2022"]:
+            assert ctrl["status"] == "FAIL"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Three-module coverage push. Bumps scanner/lib total coverage from ~78% to **92%**, clearing the 85% target.

| Module | Before | After | Δ | Missed |
|---|---|---|---|---|
| \`dashboard_mapping.py\` | 61% | **100%** | +39 | 0 / 94 |
| \`dashboard_html_helpers.py\` | 75% | **98%** | +23 | 1 / 63 |
| \`audit-points-scan.py\` | 50% | **91%** | +41 | 11 / 129 |

### Commits
- \`50eb34d\` — 67 tests covering all mapping constants + 5 pure functions + importlib-fallback branch
- \`ed74d03\` — 49 tests for \`_infer_category\`, \`_redact_target\`, \`_rel_link\`, \`_has_cmd\` (with \`shutil.which\` mocked), \`_cmd_pill\`, severity counts/bars, \`_build_replacements\`
- \`6359ade\` — 52 tests covering product detection helpers, \`detect_products\`, \`_fetch_and_cache\`, \`load_cache\`, \`run_audit_points_scan\`, and \`main()\`

### CI compatibility
No \`import pytest\` anywhere. All three files use plain \`def test_*()\` + \`unittest.mock\` — runs under both \`pytest\` and \`python3 -m xmlrunner discover\`.

### PII clean
All three files verified against \`hooks/pii-check.sh\` locally.

## Test plan
- [x] \`python3 -m pytest scanner/tests/\` — **931 passed**
- [x] \`python3 -m unittest\` discovery on each new file — all pass
- [x] \`bash hooks/pii-check.sh\` on all three files — clean
- [x] No production code modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)