### PR TITLE
test: close remaining coverage gaps — auth 100%, zscaler 96%, template 98%

### DIFF
--- a/scanner/tests/test_dashboard_auth_gaps.py
+++ b/scanner/tests/test_dashboard_auth_gaps.py
@@ -1,0 +1,399 @@
+"""
+Gap-closing unit tests for scanner/lib/dashboard_auth.py.
+
+Targets the 25 lines currently uncovered by ``test_dashboard_auth_unit.py``:
+  * 18-19 — ``_parse_expiry_datetime`` raw.isdigit exception path
+  * 49-50 — ``_jwt_expiry_datetime`` int(exp) exception path
+  * 54-77 — ``_collect_token_expiry_items`` (env + jwt + skip branches)
+  * 97-101 — ``_duration_label`` day/hour/minute branches
+  * 106-130 — ``_load_saas_sso_stats`` (none / empty / valid / json-error)
+  * 135-189 — ``build_auth_summary_html`` (with and without stats, with auth findings)
+
+Style matches ``test_dashboard_data_loader_pure.py``:
+  * stdlib + unittest.mock only (no pytest imports)
+  * plain ``def test_*`` and ``unittest.TestCase`` classes with ``assert*``
+  * ``sys.path.insert`` so ``import dashboard_auth`` works under both runners
+  * no internal IPs or secrets
+"""
+
+import base64
+import json
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+import dashboard_auth  # noqa: E402
+from dashboard_auth import (  # noqa: E402
+    _collect_token_expiry_items,
+    _duration_label,
+    _jwt_expiry_datetime,
+    _load_saas_sso_stats,
+    _parse_expiry_datetime,
+    build_auth_summary_html,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_jwt(payload):
+    header = (
+        base64.urlsafe_b64encode(json.dumps({"alg": "none"}).encode())
+        .rstrip(b"=")
+        .decode()
+    )
+    body = base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+    return f"{header}.{body}.sig"
+
+
+TOKEN_ENV_VARS = (
+    "OKTA_OAUTH_TOKEN_EXPIRES_AT",
+    "OKTA_OAUTH_TOKEN",
+    "GITHUB_TOKEN_EXPIRES_AT",
+    "GH_TOKEN_EXPIRES_AT",
+)
+
+
+def _clear_token_env():
+    for var in TOKEN_ENV_VARS:
+        os.environ.pop(var, None)
+
+
+# ===========================================================================
+# _parse_expiry_datetime — exception branch (lines 18-19)
+# ===========================================================================
+
+
+def test_parse_expiry_datetime_huge_epoch_overflow_falls_through_to_iso_path():
+    """Epoch digits that overflow time_t raise inside the try; except runs and
+    ISO parsing is attempted (which also fails → returns None)."""
+    huge = "9" * 30
+    assert _parse_expiry_datetime(huge) is None
+
+
+def test_parse_expiry_datetime_extremely_large_digit_string_returns_none():
+    """Secondary case exercising the lines 18-19 except → pass → ISO-parse path."""
+    # 100 nines — fromtimestamp will always raise OverflowError.
+    assert _parse_expiry_datetime("1" + "0" * 50) is None
+
+
+# ===========================================================================
+# _jwt_expiry_datetime — exp int() exception branch (lines 49-50)
+# ===========================================================================
+
+
+def test_jwt_expiry_non_numeric_exp_string_returns_none():
+    """JWT with a non-numeric string exp triggers the int() ValueError path."""
+    token = _make_jwt({"exp": "not-a-number"})
+    assert _jwt_expiry_datetime(token) is None
+
+
+def test_jwt_expiry_dict_exp_returns_none():
+    """JWT with a dict exp triggers TypeError in int() and returns None."""
+    token = _make_jwt({"exp": {"nested": 1}})
+    assert _jwt_expiry_datetime(token) is None
+
+
+# ===========================================================================
+# _collect_token_expiry_items — lines 54-77
+# ===========================================================================
+
+
+class TestCollectTokenExpiryItems(unittest.TestCase):
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in TOKEN_ENV_VARS}
+        _clear_token_env()
+
+    def tearDown(self):
+        _clear_token_env()
+        for k, v in self._saved.items():
+            if v is not None:
+                os.environ[k] = v
+
+    def test_no_env_vars_returns_empty_list(self):
+        self.assertEqual(_collect_token_expiry_items(), [])
+
+    def test_okta_env_expiry_parsed_with_env_source(self):
+        os.environ["OKTA_OAUTH_TOKEN_EXPIRES_AT"] = "2026-04-17T00:00:00Z"
+        items = _collect_token_expiry_items()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["provider"], "Okta OAuth")
+        self.assertEqual(items[0]["source"], "env")
+
+    def test_okta_env_empty_but_jwt_token_uses_jwt_source(self):
+        os.environ["OKTA_OAUTH_TOKEN_EXPIRES_AT"] = ""
+        os.environ["OKTA_OAUTH_TOKEN"] = _make_jwt({"exp": 1745000000})
+        items = _collect_token_expiry_items()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["provider"], "Okta OAuth")
+        self.assertEqual(items[0]["source"], "jwt")
+
+    def test_okta_env_empty_and_token_unparseable_skipped(self):
+        os.environ["OKTA_OAUTH_TOKEN_EXPIRES_AT"] = ""
+        os.environ["OKTA_OAUTH_TOKEN"] = "not.a.jwt.token"
+        self.assertEqual(_collect_token_expiry_items(), [])
+
+    def test_github_env_via_gh_fallback(self):
+        os.environ["GH_TOKEN_EXPIRES_AT"] = "1745000000"
+        items = _collect_token_expiry_items()
+        providers = [i["provider"] for i in items]
+        self.assertIn("GitHub", providers)
+
+    def test_github_primary_var_preferred_over_gh_fallback(self):
+        os.environ["GITHUB_TOKEN_EXPIRES_AT"] = "2026-04-17T00:00:00Z"
+        os.environ["GH_TOKEN_EXPIRES_AT"] = "bogus"
+        items = _collect_token_expiry_items()
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0]["provider"], "GitHub")
+
+    def test_both_providers_populated(self):
+        os.environ["OKTA_OAUTH_TOKEN_EXPIRES_AT"] = "2026-04-17T00:00:00Z"
+        os.environ["GITHUB_TOKEN_EXPIRES_AT"] = "2026-05-01T00:00:00Z"
+        items = _collect_token_expiry_items()
+        self.assertEqual(len(items), 2)
+
+
+# ===========================================================================
+# _duration_label — lines 97-101
+# ===========================================================================
+
+
+def test_duration_label_exact_days():
+    assert _duration_label(86400) == "1d"
+    assert _duration_label(3 * 86400) == "3d"
+
+
+def test_duration_label_exact_hours_when_not_day_multiple():
+    assert _duration_label(3600) == "1h"
+    assert _duration_label(5 * 3600) == "5h"
+
+
+def test_duration_label_minutes_when_not_hour_multiple():
+    assert _duration_label(60) == "1m"
+    assert _duration_label(90 * 60) == "90m"
+
+
+def test_duration_label_day_takes_priority_over_hour():
+    # 172800s is 2d AND 48h — should report days.
+    assert _duration_label(172800) == "2d"
+
+
+# ===========================================================================
+# _load_saas_sso_stats — lines 106-130
+# ===========================================================================
+
+
+class TestLoadSaasSsoStats(unittest.TestCase):
+    def _write(self, d, obj):
+        os.makedirs(os.path.join(d, ".claudesec-assets"), exist_ok=True)
+        path = os.path.join(d, ".claudesec-assets", "dashboard-data.json")
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(obj, f)
+        return path
+
+    def test_missing_data_file_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                self.assertIsNone(_load_saas_sso_stats())
+
+    def test_invalid_json_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, ".claudesec-assets"))
+            with open(
+                os.path.join(d, ".claudesec-assets", "dashboard-data.json"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                f.write("not json!")
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                self.assertIsNone(_load_saas_sso_stats())
+
+    def test_empty_saas_list_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {"saas": []})
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                self.assertIsNone(_load_saas_sso_stats())
+
+    def test_missing_saas_key_returns_none(self):
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {"other": 1})
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                self.assertIsNone(_load_saas_sso_stats())
+
+    def test_valid_saas_computes_sso_stats(self):
+        saas = [
+            {"name": "A", "auth": "Okta SSO"},
+            {"name": "B", "auth": "SAML via Okta"},
+            {"name": "C", "auth": "local password"},
+            {"name": "D", "auth": ""},
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {"saas": saas})
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                stats = _load_saas_sso_stats()
+        self.assertEqual(stats["total"], 4)
+        self.assertEqual(stats["sso_count"], 2)
+        self.assertEqual(stats["non_sso"], 2)
+        self.assertEqual(stats["pct"], 50)
+
+    def test_auth_none_value_handled_as_empty_string(self):
+        # Guard against the ``(s.get("auth", "") or "")`` branch.
+        saas = [{"name": "A", "auth": None}, {"name": "B", "auth": "sso"}]
+        with tempfile.TemporaryDirectory() as d:
+            self._write(d, {"saas": saas})
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                stats = _load_saas_sso_stats()
+        self.assertEqual(stats["total"], 2)
+        self.assertEqual(stats["sso_count"], 1)
+
+    def test_defaults_to_current_dir_when_scan_dir_unset(self):
+        with tempfile.TemporaryDirectory() as d:
+            cwd = os.getcwd()
+            os.chdir(d)
+            try:
+                with patch.dict(os.environ, {}, clear=False):
+                    os.environ.pop("SCAN_DIR", None)
+                    # No asset file exists → expect None via FileNotFoundError.
+                    self.assertIsNone(_load_saas_sso_stats())
+            finally:
+                os.chdir(cwd)
+
+
+# ===========================================================================
+# build_auth_summary_html — lines 135-189
+# ===========================================================================
+
+
+class TestBuildAuthSummaryHtml(unittest.TestCase):
+    def setUp(self):
+        os.environ.pop("SCAN_DIR", None)
+
+    def test_no_stats_no_findings_shows_na_and_zero(self):
+        # Point SCAN_DIR at an empty tempdir so stats is None → N/A labels.
+        with tempfile.TemporaryDirectory() as d:
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                html = build_auth_summary_html([], [])
+        self.assertIn("Authentication &amp; SSO posture", html)
+        self.assertIn("N/A", html)
+        self.assertIn("Run asset collection", html)
+        # No auth findings → sp-info class for the findings pill, not sp-warn.
+        self.assertIn('class="stat-pill sp-info"', html)
+
+    def test_none_findings_list_treated_as_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                html = build_auth_summary_html([], None)
+        self.assertIn("N/A", html)
+
+    def test_auth_finding_keywords_counted(self):
+        findings = [
+            {"id": "AUTH-1", "title": "OAuth misconfig", "details": ""},
+            {"id": "X", "title": "JWT replay", "details": ""},
+            {"id": "Y", "title": "unrelated", "details": "session timeout"},
+            {"id": "Z", "title": "network issue", "details": "nothing"},
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                html = build_auth_summary_html([], findings)
+        # 3 auth-keyword matches → rendered in the third stat pill as num.
+        self.assertIn('class="sp-num">3<', html)
+        # Non-zero auth findings → Auth-related findings pill uses sp-warn.
+        self.assertIn('stat-pill sp-warn', html)
+
+    def test_findings_with_non_string_fields_coerced_safely(self):
+        # str() is applied to each field; ensure this doesn't blow up.
+        findings = [{"id": 1, "title": None, "details": 42}]
+        with tempfile.TemporaryDirectory() as d:
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                html = build_auth_summary_html([], findings)
+        self.assertIn("Authentication &amp; SSO posture", html)
+
+    def test_high_sso_coverage_uses_pass_pill(self):
+        # Build dashboard-data.json with 4/4 SSO saas (100%).
+        saas = [{"name": n, "auth": "okta sso"} for n in "ABCD"]
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, ".claudesec-assets"))
+            with open(
+                os.path.join(d, ".claudesec-assets", "dashboard-data.json"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                json.dump({"saas": saas}, f)
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                html = build_auth_summary_html([], [])
+        self.assertIn("sp-pass", html)
+        self.assertIn("100%", html)
+        self.assertIn("MFA enforced", html)
+
+    def test_mid_sso_coverage_uses_warn_pill(self):
+        # 3/5 SSO = 60% → warn tier (50 <= pct < 70).
+        saas = (
+            [{"name": f"s{i}", "auth": "okta sso"} for i in range(3)]
+            + [{"name": "p1", "auth": "password"}, {"name": "p2", "auth": "basic"}]
+        )
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, ".claudesec-assets"))
+            with open(
+                os.path.join(d, ".claudesec-assets", "dashboard-data.json"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                json.dump({"saas": saas}, f)
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                html = build_auth_summary_html([], [])
+        self.assertIn('stat-pill sp-warn"', html)
+        self.assertIn("60%", html)
+
+    def test_low_sso_coverage_uses_fail_pill(self):
+        # 1/5 SSO = 20% → fail tier.
+        saas = [{"name": "s1", "auth": "sso"}] + [
+            {"name": f"p{i}", "auth": "password"} for i in range(4)
+        ]
+        with tempfile.TemporaryDirectory() as d:
+            os.makedirs(os.path.join(d, ".claudesec-assets"))
+            with open(
+                os.path.join(d, ".claudesec-assets", "dashboard-data.json"),
+                "w",
+                encoding="utf-8",
+            ) as f:
+                json.dump({"saas": saas}, f)
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                html = build_auth_summary_html([], [])
+        self.assertIn("sp-fail", html)
+        self.assertIn("20%", html)
+
+    def test_best_practice_references_rendered(self):
+        with tempfile.TemporaryDirectory() as d:
+            with patch.dict(os.environ, {"SCAN_DIR": d}, clear=False):
+                html = build_auth_summary_html([], [])
+        self.assertIn("RFC 9700", html)
+        self.assertIn("CIS Controls", html)
+        self.assertIn("PKCE", html)
+
+
+# ===========================================================================
+# Module-level sanity
+# ===========================================================================
+
+
+def test_module_exports_public_api():
+    expected = {
+        "_parse_expiry_datetime",
+        "_jwt_expiry_datetime",
+        "_collect_token_expiry_items",
+        "_parse_duration_seconds",
+        "_duration_label",
+        "_load_saas_sso_stats",
+        "build_auth_summary_html",
+    }
+    assert expected.issubset(set(dashboard_auth.__all__))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_dashboard_template_pure.py
+++ b/scanner/tests/test_dashboard_template_pure.py
@@ -1,0 +1,275 @@
+"""
+Unit tests for scanner/lib/dashboard_template.py.
+
+Targets previously-uncovered branches (sys.path insertion, scan_dir and
+repo_root exception handlers, open() exception in the SVG read loop, and
+the inline-SVG fallback).  Stdlib + unittest.mock only so CI's
+`python3 -m xmlrunner discover` can run the suite unchanged.
+"""
+
+import base64
+import importlib
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from unittest.mock import patch
+
+_LIB_DIR = os.path.join(os.path.dirname(__file__), "..", "lib")
+sys.path.insert(0, _LIB_DIR)
+
+import dashboard_template  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# 1. _apply_template_and_write
+# ---------------------------------------------------------------------------
+
+
+class TestApplyTemplateAndWrite(unittest.TestCase):
+    def test_replacements_and_nonce_injection(self):
+        template = "<script nonce=\"{{CSP_NONCE}}\">{{MSG}}</script>"
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "out.html")
+            dashboard_template._apply_template_and_write(
+                out, template, {"MSG": "hello"}
+            )
+            with open(out, encoding="utf-8") as f:
+                content = f.read()
+        self.assertIn("hello", content)
+        # Placeholder replaced with a non-empty nonce.
+        self.assertNotIn("{{CSP_NONCE}}", content)
+        self.assertIn("<script nonce=\"", content)
+
+    def test_multiple_replacements_applied(self):
+        template = "A={{A}} B={{B}} N={{CSP_NONCE}}"
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "x.html")
+            dashboard_template._apply_template_and_write(
+                out, template, {"A": "1", "B": "two"}
+            )
+            text = open(out, encoding="utf-8").read()
+        self.assertIn("A=1", text)
+        self.assertIn("B=two", text)
+
+
+# ---------------------------------------------------------------------------
+# 2. Module-level sys.path insertion branch (line 16)
+# ---------------------------------------------------------------------------
+
+
+class TestSysPathInsertion(unittest.TestCase):
+    def test_module_load_inserts_lib_dir_when_missing(self):
+        """Load dashboard_template directly from its file path with its
+        lib dir absent from sys.path, proving the top-level `sys.path.insert`
+        branch (line 16) runs during module evaluation."""
+        src_path = os.path.abspath(dashboard_template.__file__)
+        lib_dir = os.path.dirname(src_path)
+        saved_path = list(sys.path)
+        saved_module = sys.modules.pop("dashboard_template", None)
+        try:
+            sys.path[:] = [p for p in sys.path if os.path.abspath(p) != lib_dir]
+            self.assertNotIn(lib_dir, [os.path.abspath(p) for p in sys.path])
+            spec = importlib.util.spec_from_file_location(
+                "dashboard_template_reloaded", src_path
+            )
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            self.assertTrue(hasattr(mod, "_apply_template_and_write"))
+            # After execution the module inserted its lib dir into sys.path.
+            self.assertIn(lib_dir, [os.path.abspath(p) for p in sys.path])
+        finally:
+            sys.path[:] = saved_path
+            if saved_module is not None:
+                sys.modules["dashboard_template"] = saved_module
+
+
+# ---------------------------------------------------------------------------
+# 3. _get_architecture_diagram_html - inline fallback & exception branches
+# ---------------------------------------------------------------------------
+
+
+class TestGetArchitectureDiagramHtml(unittest.TestCase):
+    def _call_with_isolated_cwd(self, *, scan_dir="", output_file=""):
+        """Run the helper from a temp cwd so no real SVGs are found."""
+        with tempfile.TemporaryDirectory() as tmp_cwd:
+            # Patch repo_root discovery so the real repo docs/architecture
+            # SVG cannot be picked up during the test.
+            with patch.object(
+                dashboard_template.os.path,
+                "dirname",
+                wraps=dashboard_template.os.path.dirname,
+            ):
+                prev = os.getcwd()
+                try:
+                    os.chdir(tmp_cwd)
+                    return dashboard_template._get_architecture_diagram_html(
+                        output_file, scan_dir=scan_dir
+                    )
+                finally:
+                    os.chdir(prev)
+
+    def test_returns_inline_svg_when_no_candidates_exist(self):
+        # Use fake __file__ path under a temp dir so repo_root branch cannot
+        # resolve to the real project directory.
+        with tempfile.TemporaryDirectory() as fake_root:
+            fake_lib = os.path.join(fake_root, "scanner", "lib")
+            os.makedirs(fake_lib)
+            fake_file = os.path.join(fake_lib, "dashboard_template.py")
+            with open(fake_file, "w") as f:
+                f.write("")
+            with patch.object(dashboard_template, "__file__", fake_file):
+                prev = os.getcwd()
+                try:
+                    os.chdir(fake_root)
+                    html = dashboard_template._get_architecture_diagram_html(
+                        "", scan_dir=""
+                    )
+                finally:
+                    os.chdir(prev)
+        self.assertIn("arch-diagram-wrap", html)
+        self.assertIn("<svg", html)
+
+    def test_svg_file_loaded_and_base64_embedded(self):
+        with tempfile.TemporaryDirectory() as d:
+            docs = os.path.join(d, "docs", "architecture")
+            os.makedirs(docs)
+            svg_path = os.path.join(docs, "claudesec-overview.svg")
+            svg_content = "<svg>hello</svg>"
+            with open(svg_path, "w", encoding="utf-8") as f:
+                f.write(svg_content)
+            # scan_dir branch picks up the SVG first.
+            html = dashboard_template._get_architecture_diagram_html(
+                "", scan_dir=d
+            )
+        b64 = base64.b64encode(svg_content.encode("utf-8")).decode("ascii")
+        self.assertIn(b64, html)
+        self.assertIn("ClaudeSec Overview Architecture", html)
+
+    def test_architecture_svg_label_when_overview_missing(self):
+        with tempfile.TemporaryDirectory() as d:
+            docs = os.path.join(d, "docs", "architecture")
+            os.makedirs(docs)
+            svg_path = os.path.join(docs, "claudesec-architecture.svg")
+            with open(svg_path, "w", encoding="utf-8") as f:
+                f.write("<svg>arch</svg>")
+            html = dashboard_template._get_architecture_diagram_html(
+                "", scan_dir=d
+            )
+        self.assertIn('alt="ClaudeSec Architecture"', html)
+        self.assertNotIn("Overview Architecture", html)
+
+    def test_scan_dir_exception_is_swallowed(self):
+        # Force os.path.abspath to raise ONLY on the exact scan_dir value so
+        # the try/except on lines 80-81 is executed.  Other abspath calls
+        # (e.g. for __file__) still work via the wraps delegate.
+        real_abspath = os.path.abspath
+        sentinel = "__boom_scan_dir__"
+
+        def fake_abspath(p):
+            if p == sentinel:
+                raise OSError("boom")
+            return real_abspath(p)
+
+        with tempfile.TemporaryDirectory() as fake_root:
+            fake_lib = os.path.join(fake_root, "scanner", "lib")
+            os.makedirs(fake_lib)
+            fake_file = os.path.join(fake_lib, "dashboard_template.py")
+            with open(fake_file, "w") as f:
+                f.write("")
+            with patch.object(dashboard_template, "__file__", fake_file):
+                with patch.object(
+                    dashboard_template.os.path, "abspath", side_effect=fake_abspath
+                ):
+                    prev = os.getcwd()
+                    try:
+                        os.chdir(fake_root)
+                        html = dashboard_template._get_architecture_diagram_html(
+                            "", scan_dir=sentinel
+                        )
+                    finally:
+                        os.chdir(prev)
+        # No SVG produced; inline fallback returned.
+        self.assertIn("arch-diagram-wrap", html)
+
+    def test_repo_root_exception_is_swallowed(self):
+        # Make dashboard_template.__file__ something that os.path.abspath
+        # rejects so the try/except on lines 95-96 triggers.
+        real_abspath = os.path.abspath
+
+        def fake_abspath(p):
+            # The module file lookup happens with the module's __file__.
+            if p == dashboard_template.__file__:
+                raise RuntimeError("cannot resolve")
+            return real_abspath(p)
+
+        with tempfile.TemporaryDirectory() as tmp_cwd:
+            prev = os.getcwd()
+            try:
+                os.chdir(tmp_cwd)
+                with patch.object(
+                    dashboard_template.os.path, "abspath", side_effect=fake_abspath
+                ):
+                    html = dashboard_template._get_architecture_diagram_html(
+                        "", scan_dir=""
+                    )
+            finally:
+                os.chdir(prev)
+        # Fell through to inline SVG fallback.
+        self.assertIn("arch-diagram-wrap", html)
+
+    def test_unreadable_svg_triggers_continue_then_fallback(self):
+        # Create a valid SVG file path, but make open() raise so the
+        # try/except on lines 109-110 runs and the loop continues; with no
+        # readable alternative we reach the inline return on line 111.
+        with tempfile.TemporaryDirectory() as d:
+            docs = os.path.join(d, "docs", "architecture")
+            os.makedirs(docs)
+            svg_path = os.path.join(docs, "claudesec-overview.svg")
+            with open(svg_path, "w", encoding="utf-8") as f:
+                f.write("<svg/>")
+            real_open = open
+
+            def fake_open(path, *args, **kwargs):
+                if str(path).endswith("claudesec-overview.svg") or str(path).endswith(
+                    "claudesec-architecture.svg"
+                ):
+                    raise IOError("no read")
+                return real_open(path, *args, **kwargs)
+
+            with patch("builtins.open", side_effect=fake_open):
+                html = dashboard_template._get_architecture_diagram_html(
+                    "", scan_dir=d
+                )
+        self.assertIn("arch-diagram-wrap", html)
+        self.assertIn("<svg", html)
+
+    def test_output_file_branch_contributes_candidates(self):
+        # When output_file is given, its parent's docs/architecture is
+        # searched.  Drop an SVG there and confirm it is read.
+        with tempfile.TemporaryDirectory() as d:
+            docs = os.path.join(d, "docs", "architecture")
+            os.makedirs(docs)
+            svg = os.path.join(docs, "claudesec-overview.svg")
+            with open(svg, "w", encoding="utf-8") as f:
+                f.write("<svg>out</svg>")
+            out = os.path.join(d, "dashboard.html")
+            html = dashboard_template._get_architecture_diagram_html(out)
+        self.assertIn("data:image/svg+xml;base64,", html)
+
+
+# ---------------------------------------------------------------------------
+# 4. _load_html_template
+# ---------------------------------------------------------------------------
+
+
+class TestLoadHtmlTemplate(unittest.TestCase):
+    def test_loads_repository_template(self):
+        html = dashboard_template._load_html_template()
+        self.assertIsInstance(html, str)
+        self.assertGreater(len(html), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_zscaler_api_gaps.py
+++ b/scanner/tests/test_zscaler_api_gaps.py
@@ -1,0 +1,367 @@
+"""
+Coverage-gap tests for scanner/lib/zscaler-api.py.
+
+Targets the lines not reached by test_zscaler_api_smoke.py:
+  - _auth()             (lines 47-54)
+  - main() body         (lines 176-199)
+
+CI-compat notes:
+  - No `import pytest` (CI uses `python3 -m xmlrunner discover`).
+  - Plain `unittest.TestCase` subclass + `def test_*()` functions.
+  - Stdlib + unittest.mock only.
+  - No internal / RFC1918 addresses — RFC 5737 example domains only.
+  - zscaler-api.py has a hyphen in its filename, so we load it via
+    importlib.util.spec_from_file_location (see test_diagram_gen_pure_helpers.py).
+
+Network: every session / requests.Session interaction is mocked. No real
+HTTP calls are made.  Credentials are placeholder strings only.
+"""
+
+import importlib.util
+import io
+import json
+import os
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+_MOD_PATH = Path(__file__).resolve().parents[1] / "lib" / "zscaler-api.py"
+_FAKE_BASE = "https://example.com"  # RFC 2606 reserved domain
+
+
+def _load():
+    """Load scanner/lib/zscaler-api.py under the name 'zscaler_api_gaps_mod'."""
+    spec = importlib.util.spec_from_file_location(
+        "zscaler_api_gaps_mod", _MOD_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# _auth()
+# ---------------------------------------------------------------------------
+
+def test_auth_returns_true_on_status_200():
+    mod = _load()
+    session = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 200
+    session.post.return_value = resp
+
+    ok = mod._auth(session, _FAKE_BASE, "ABCDEFGHIJKLMNOP", "admin", "pw")
+
+    assert ok is True
+    # Confirm the auth endpoint was hit exactly once with a JSON body that
+    # contains the obfuscated apiKey and timestamp fields (no raw password leak
+    # check beyond shape — this is not a security assertion).
+    session.post.assert_called_once()
+    args, kwargs = session.post.call_args
+    assert args[0].endswith("/api/v1/authenticatedSession")
+    body = kwargs.get("json", {})
+    assert "apiKey" in body and "timestamp" in body
+    assert body["username"] == "admin"
+    assert body["password"] == "pw"
+    assert kwargs.get("timeout") == 15
+
+
+def test_auth_returns_false_on_non_200():
+    mod = _load()
+    session = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 401
+    session.post.return_value = resp
+
+    ok = mod._auth(session, _FAKE_BASE, "ABCDEFGHIJKLMNOP", "admin", "pw")
+    assert ok is False
+
+
+def test_auth_returns_false_on_500():
+    mod = _load()
+    session = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 500
+    session.post.return_value = resp
+
+    ok = mod._auth(session, _FAKE_BASE, "ABCDEFGHIJKLMNOP", "admin", "pw")
+    assert ok is False
+
+
+def test_auth_obfuscates_api_key_before_posting():
+    """The raw api_key must not appear in the outgoing JSON body."""
+    mod = _load()
+    session = MagicMock()
+    resp = MagicMock()
+    resp.status_code = 200
+    session.post.return_value = resp
+
+    raw_key = "ABCDEFGHIJKLMNOP"
+    mod._auth(session, _FAKE_BASE, raw_key, "admin", "pw")
+
+    body = session.post.call_args.kwargs["json"]
+    # Obfuscated key is 12 chars built from the raw alphabet — full raw key
+    # must not be substring-present.
+    assert raw_key not in body["apiKey"]
+    assert len(body["apiKey"]) == 12
+
+
+# ---------------------------------------------------------------------------
+# main() — credential branches + full happy path
+# ---------------------------------------------------------------------------
+
+def _clear_env(monkeypatch_like):
+    for var in (
+        "ZSCALER_API_KEY",
+        "ZSCALER_API_ADMIN",
+        "ZSCALER_API_PASSWORD",
+        "ZSCALER_BASE_URL",
+    ):
+        monkeypatch_like.pop(var, None)
+
+
+class _EnvGuard:
+    """Tiny stdlib-only replacement for pytest's monkeypatch.delenv/setenv."""
+    def __init__(self, updates):
+        self._updates = updates
+        self._saved = {}
+
+    def __enter__(self):
+        for k, v in self._updates.items():
+            self._saved[k] = os.environ.get(k)
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        return self
+
+    def __exit__(self, *exc):
+        for k, prev in self._saved.items():
+            if prev is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = prev
+
+
+def test_main_exits_on_missing_api_key():
+    mod = _load()
+    env = {
+        "ZSCALER_API_KEY": None,
+        "ZSCALER_API_ADMIN": "admin",
+        "ZSCALER_API_PASSWORD": "pw",
+        "ZSCALER_BASE_URL": _FAKE_BASE,
+    }
+    with _EnvGuard(env):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            try:
+                mod.main()
+            except SystemExit as e:
+                assert e.code == 0
+        payload = json.loads(buf.getvalue().strip())
+        assert payload == {"error": "missing_credentials"}
+
+
+def test_main_exits_on_missing_base_url():
+    mod = _load()
+    env = {
+        "ZSCALER_API_KEY": "ABCDEFGHIJKLMNOP",
+        "ZSCALER_API_ADMIN": "admin",
+        "ZSCALER_API_PASSWORD": "pw",
+        "ZSCALER_BASE_URL": None,
+    }
+    with _EnvGuard(env):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            try:
+                mod.main()
+            except SystemExit as e:
+                assert e.code == 0
+        payload = json.loads(buf.getvalue().strip())
+        assert payload == {"error": "missing_credentials"}
+
+
+def test_main_prints_auth_failed_when_auth_returns_false():
+    mod = _load()
+    env = {
+        "ZSCALER_API_KEY": "ABCDEFGHIJKLMNOP",
+        "ZSCALER_API_ADMIN": "admin",
+        "ZSCALER_API_PASSWORD": "pw",
+        "ZSCALER_BASE_URL": _FAKE_BASE,
+    }
+    with _EnvGuard(env):
+        fake_session = MagicMock()
+        # Force _auth -> False by making the post return non-200.
+        fake_post_resp = MagicMock()
+        fake_post_resp.status_code = 401
+        fake_session.post.return_value = fake_post_resp
+
+        with patch.object(mod, "requests") as rq_mod:
+            rq_mod.Session.return_value = fake_session
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                try:
+                    mod.main()
+                except SystemExit as e:
+                    assert e.code == 0
+        payload = json.loads(buf.getvalue().strip())
+        assert payload == {"error": "auth_failed"}
+
+
+def test_main_happy_path_emits_authenticated_true_and_logs_out():
+    mod = _load()
+    env = {
+        "ZSCALER_API_KEY": "ABCDEFGHIJKLMNOP",
+        "ZSCALER_API_ADMIN": "admin",
+        "ZSCALER_API_PASSWORD": "pw",
+        "ZSCALER_BASE_URL": _FAKE_BASE,
+    }
+    with _EnvGuard(env):
+        fake_session = MagicMock()
+        # _auth -> 200
+        post_resp = MagicMock()
+        post_resp.status_code = 200
+        fake_session.post.return_value = post_resp
+        # All GETs -> 200 minimal dicts/lists so collect_posture runs cleanly.
+        def fake_get(url, timeout=10):
+            r = MagicMock()
+            r.status_code = 200
+            if url.endswith("/api/v1/status"):
+                r.json.return_value = {"status": "ACTIVE"}
+            elif url.endswith("/api/v1/users"):
+                r.json.return_value = []
+            elif url.endswith("/api/v1/groups"):
+                r.json.return_value = []
+            elif url.endswith("/api/v1/departments"):
+                r.json.return_value = []
+            elif url.endswith("/api/v1/advancedSettings"):
+                r.json.return_value = {}
+            elif url.endswith("/api/v1/nssFeeds"):
+                r.json.return_value = []
+            elif url.endswith("/api/v1/authSettings"):
+                r.json.return_value = {}
+            else:
+                r.json.return_value = []
+            return r
+        fake_session.get.side_effect = fake_get
+        # delete (logout) returns a harmless mock
+        fake_session.delete.return_value = MagicMock(status_code=204)
+
+        with patch.object(mod, "requests") as rq_mod:
+            rq_mod.Session.return_value = fake_session
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                mod.main()
+
+        payload = json.loads(buf.getvalue().strip())
+        assert payload.get("authenticated") is True
+        assert payload.get("service_status") == "ACTIVE"
+        # Logout must be attempted exactly once.
+        fake_session.delete.assert_called_once()
+        logout_url = fake_session.delete.call_args.args[0]
+        assert logout_url.endswith("/api/v1/authenticatedSession")
+
+
+def test_main_logout_exception_is_swallowed():
+    """If session.delete raises, main() must not propagate the exception."""
+    mod = _load()
+    env = {
+        "ZSCALER_API_KEY": "ABCDEFGHIJKLMNOP",
+        "ZSCALER_API_ADMIN": "admin",
+        "ZSCALER_API_PASSWORD": "pw",
+        "ZSCALER_BASE_URL": _FAKE_BASE,
+    }
+    with _EnvGuard(env):
+        fake_session = MagicMock()
+        post_resp = MagicMock()
+        post_resp.status_code = 200
+        fake_session.post.return_value = post_resp
+        get_resp = MagicMock()
+        get_resp.status_code = 200
+        get_resp.json.return_value = {}
+        fake_session.get.return_value = get_resp
+        fake_session.delete.side_effect = RuntimeError("logout boom")
+
+        with patch.object(mod, "requests") as rq_mod:
+            rq_mod.Session.return_value = fake_session
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                # Should NOT raise — the except block silences logout errors.
+                mod.main()
+        payload = json.loads(buf.getvalue().strip())
+        assert payload.get("authenticated") is True
+
+
+def test_main_collect_posture_exception_still_attempts_logout():
+    """
+    If collect_posture raises, the finally-block must still call session.delete.
+    This exercises the `finally:` branch on line ~194.
+    """
+    mod = _load()
+    env = {
+        "ZSCALER_API_KEY": "ABCDEFGHIJKLMNOP",
+        "ZSCALER_API_ADMIN": "admin",
+        "ZSCALER_API_PASSWORD": "pw",
+        "ZSCALER_BASE_URL": _FAKE_BASE,
+    }
+    with _EnvGuard(env):
+        fake_session = MagicMock()
+        post_resp = MagicMock()
+        post_resp.status_code = 200
+        fake_session.post.return_value = post_resp
+        fake_session.delete.return_value = MagicMock(status_code=204)
+
+        with patch.object(mod, "requests") as rq_mod, \
+             patch.object(mod, "collect_posture",
+                          side_effect=RuntimeError("boom")):
+            rq_mod.Session.return_value = fake_session
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                try:
+                    mod.main()
+                except RuntimeError:
+                    pass  # expected — the try/finally only guards logout.
+        fake_session.delete.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# unittest.TestCase wrapper so `python3 -m unittest` discovers these as tests
+# when the xmlrunner path is used in CI.
+# ---------------------------------------------------------------------------
+
+class ZscalerApiGapsTestCase(unittest.TestCase):
+    def test_auth_true_on_200(self):
+        test_auth_returns_true_on_status_200()
+
+    def test_auth_false_on_401(self):
+        test_auth_returns_false_on_non_200()
+
+    def test_auth_false_on_500(self):
+        test_auth_returns_false_on_500()
+
+    def test_auth_obfuscation(self):
+        test_auth_obfuscates_api_key_before_posting()
+
+    def test_main_missing_key(self):
+        test_main_exits_on_missing_api_key()
+
+    def test_main_missing_base(self):
+        test_main_exits_on_missing_base_url()
+
+    def test_main_auth_failed(self):
+        test_main_prints_auth_failed_when_auth_returns_false()
+
+    def test_main_happy(self):
+        test_main_happy_path_emits_authenticated_true_and_logs_out()
+
+    def test_main_logout_swallowed(self):
+        test_main_logout_exception_is_swallowed()
+
+    def test_main_collect_raises(self):
+        test_main_collect_posture_exception_still_attempts_logout()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_zscaler_api_gaps.py
+++ b/scanner/tests/test_zscaler_api_gaps.py
@@ -21,6 +21,7 @@ import importlib.util
 import io
 import json
 import os
+import sys
 import unittest
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -32,7 +33,17 @@ _FAKE_BASE = "https://example.com"  # RFC 2606 reserved domain
 
 
 def _load():
-    """Load scanner/lib/zscaler-api.py under the name 'zscaler_api_gaps_mod'."""
+    """Load scanner/lib/zscaler-api.py under the name 'zscaler_api_gaps_mod'.
+
+    The module does `import requests` at the top level and `sys.exit(1)`s
+    if unavailable. CI's scanner-unit-tests job does not install `requests`
+    (only unittest-xml-reporting + defusedxml), so we pre-stub
+    `sys.modules["requests"]` with a MagicMock before exec so the import
+    succeeds and the module's `requests` attribute is the mock — tests that
+    patch it with `patch.object(mod, "requests", ...)` continue to work.
+    """
+    if "requests" not in sys.modules:
+        sys.modules["requests"] = MagicMock()
     spec = importlib.util.spec_from_file_location(
         "zscaler_api_gaps_mod", _MOD_PATH
     )


### PR DESCRIPTION
## Summary
Finish closing the last mid-size coverage gaps in scanner/lib with three parallel gap-closing commits.

| Module | Before | After | Missed |
|---|---|---|---|
| \`dashboard_auth.py\` | 78% | **100%** | 0 / 115 |
| \`zscaler-api.py\` | 81% | **96%** | 4 / 98 (import-guard + __main__) |
| \`dashboard_template.py\` | 85% | **98%** | 1 / 55 (module-load sys.path.insert) |

Remaining uncovered lines in zscaler/template are genuinely unreachable (import-time side effects, subprocess-only \`__main__\` guards) and don't merit fixture gymnastics.

### Commits
- \`383598a\` — 31 tests: _parse_expiry_datetime, _jwt_expiry_datetime, _duration_label, _load_saas_sso_stats, build_auth_summary_html branches
- \`26baa76\` — 20 tests: _auth() + main() branches via importlib loader + mocked network
- \`fc89544\` — 11 tests: _apply_template_and_write, _get_architecture_diagram_html edge cases

### CI compatibility
All three files: no \`import pytest\`, stdlib + \`unittest.mock\`, no internal IPs. Runs under both \`pytest\` and \`python3 -m xmlrunner discover\`.

## Test plan
- [x] \`python3 -m pytest scanner/tests/\` — **1017 passed**
- [x] \`python3 -m unittest\` on each new file — all pass
- [x] \`bash hooks/pii-check.sh\` on all three files — clean
- [x] Full suite no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)