### PR TITLE
ci: switch scanner-unit-tests to pytest + add 90% coverage gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -105,15 +105,22 @@ jobs:
         run: bash scanner/tests/test_check_network_tls.sh
       - name: Run bash unit tests (cicd/pipeline checks)
         run: bash scanner/tests/test_check_cicd_pipeline.sh
-      - name: Run scanner unittest baseline (JUnit XML)
+      - name: Run scanner pytest + coverage gate (>=90%)
         id: scanner_tests
         env:
           PYTHONPATH: .
           CLAUDESEC_DASHBOARD_OFFLINE: "1"
         run: |
           python3 -m py_compile scanner/lib/dashboard-gen.py scanner/lib/compliance-map.py scanner/tests/test_dashboard_gen_smoke.py scanner/tests/test_markdown_preview.py scanner/tests/test_prowler_ocsf.py scanner/tests/test_prowler_ocsf_e2e.py scanner/tests/test_compliance_map.py
+          mkdir -p test-reports
           set +e
-          python3 -m xmlrunner discover -s scanner/tests -p "test_*.py" -o test-reports
+          python3 -m pytest scanner/tests/ \
+            --junitxml=test-reports/pytest-junit.xml \
+            --cov=scanner/lib \
+            --cov-report=term \
+            --cov-report=xml:test-reports/coverage.xml \
+            --cov-fail-under=90 \
+            -q
           test_exit_code=$?
           echo "test_exit_code=$test_exit_code" >> "$GITHUB_OUTPUT"
           exit 0
@@ -124,7 +131,7 @@ jobs:
           report_paths: 'test-reports/*.xml'
           fail_on_failure: false
           require_tests: false
-      - name: Upload scanner unittest XML artifacts
+      - name: Upload scanner unittest + coverage artifacts
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
         with:
@@ -132,10 +139,10 @@ jobs:
           path: test-reports/*.xml
           retention-days: 14
           if-no-files-found: ignore
-      - name: Fail workflow on scanner unittest failure
+      - name: Fail workflow on scanner unittest / coverage failure
         if: always() && steps.scanner_tests.outputs.test_exit_code != '0'
         run: |
-          echo "scanner-unit-tests failed with exit code ${{ steps.scanner_tests.outputs.test_exit_code }}"
+          echo "scanner-unit-tests failed (or coverage below 90%) with exit code ${{ steps.scanner_tests.outputs.test_exit_code }}"
           exit 1
 
   dashboard-regression-check:

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -3,3 +3,4 @@ defusedxml>=0.7.1
 pytest>=7.0
 pytest-cov>=4.0
 requests>=2.28
+Pillow>=10.0

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,2 +1,5 @@
 unittest-xml-reporting>=3.0
 defusedxml>=0.7.1
+pytest>=7.0
+pytest-cov>=4.0
+requests>=2.28


### PR DESCRIPTION
## Summary
Lock in the coverage gains from PRs #103–#108 with a strict CI gate, and fix a silent CI blindspot at the same time.

### Why
The existing \`scanner-unit-tests\` job used \`python3 -m xmlrunner discover\`, which only collects \`unittest.TestCase\` subclasses (~619 tests). Module-level \`def test_*()\` functions — the style used by roughly 400 of the tests added this week (e.g. \`test_diagram_gen_pure_helpers\`, \`test_dashboard_data_loader_pure\`, \`test_dashboard_gen_pure\`) — were being **silently skipped on CI**. Local pytest ran 1017; CI ran 619.

### What changed
- **\`requirements-ci.txt\`**: add \`pytest>=7.0\`, \`pytest-cov>=4.0\`, \`requests>=2.28\` (the last is needed because \`scanner/lib/zscaler-api.py\` does \`import requests\` at module load and \`sys.exit(1)\`s on ImportError).
- **\`.github/workflows/lint.yml\` \`scanner-unit-tests\` job**: replace the xmlrunner invocation with:
  \`\`\`
  python3 -m pytest scanner/tests/ \\
    --junitxml=test-reports/pytest-junit.xml \\
    --cov=scanner/lib --cov-report=term --cov-report=xml \\
    --cov-fail-under=90 -q
  \`\`\`
  JUnit XML continues to flow into the existing \`mikepenz/action-junit-report\` reporter; the \`coverage.xml\` is uploaded alongside the junit report as a CI artifact.

### Coverage status at the gate
\`\`\`
TOTAL  3419  128  96%  -- gate is 90%
\`\`\`
~6pp of headroom before the gate trips.

## Test plan
- [x] Verified locally: \`CLAUDESEC_DASHBOARD_OFFLINE=1 PYTHONPATH=. python3 -m pytest scanner/tests/ --cov=scanner/lib --cov-fail-under=90 -q\` → 1017 passed, 205 subtests passed, coverage 96.26%, gate PASSED.
- [ ] CI \`scanner-unit-tests\` job passes on this PR.

## Risks
- pytest finds real test failures that xmlrunner was hiding. Mitigated by pre-flight of the same pytest command locally with all production dependencies.
- \`requests\` added to CI means the sys.modules stub in \`test_zscaler_api_gaps.py\` becomes no-op (harmless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)