### PR TITLE
ci: raise coverage gate to 95% + remove xmlrunner from requirements

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -89,7 +89,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: requirements-ci.txt
-      - name: Install XML test reporter
+      - name: Install Python test deps
         run: python3 -m pip install --upgrade -r requirements-ci.txt
       - name: Run bash unit tests (kubeconfig discovery, OIDC detection)
         run: bash scanner/tests/test_kube_discovery.sh
@@ -105,7 +105,7 @@ jobs:
         run: bash scanner/tests/test_check_network_tls.sh
       - name: Run bash unit tests (cicd/pipeline checks)
         run: bash scanner/tests/test_check_cicd_pipeline.sh
-      - name: Run scanner pytest + coverage gate (>=90%)
+      - name: Run scanner pytest + coverage gate (>=95%)
         id: scanner_tests
         env:
           PYTHONPATH: .
@@ -119,7 +119,7 @@ jobs:
             --cov=scanner/lib \
             --cov-report=term \
             --cov-report=xml:test-reports/coverage.xml \
-            --cov-fail-under=90 \
+            --cov-fail-under=95 \
             -q
           test_exit_code=$?
           echo "test_exit_code=$test_exit_code" >> "$GITHUB_OUTPUT"

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,4 +1,3 @@
-unittest-xml-reporting>=3.0
 defusedxml>=0.7.1
 pytest>=7.0
 pytest-cov>=4.0


### PR DESCRIPTION
## Summary
Follow-up cleanup on the PR #109 pytest/coverage migration. Two small, complementary changes + one verification.

### Changes
1. **Raise coverage gate 90% → 95%.** Current total scanner/lib coverage is **96.26%** (1017 passed, 205 subtests), leaving ~1pp of headroom. A stricter gate catches regressions earlier.
2. **Remove \`unittest-xml-reporting\` from \`requirements-ci.txt\`.** After #109 switched CI to pytest, xmlrunner is never invoked. \`grep -r\` confirms zero Python imports of \`xmlrunner\` or \`unittest_xml_reporting\` — the only remaining references are stale comments in test docstrings that are still accurate (those tests pass under vanilla unittest discovery too).
3. **Rename CI step** "Install XML test reporter" → "Install Python test deps" to match what's actually installed.

### Verification of bash tests in CI (no change, just confirmed)
All 7 \`scanner/tests/*.sh\` scripts ARE invoked individually in the \`scanner-unit-tests\` job (lint.yml lines 94–107). No coverage gap for the shell-side tests.

### Local verification
\`\`\`
CLAUDESEC_DASHBOARD_OFFLINE=1 PYTHONPATH=. python3 -m pytest \\
  scanner/tests/ --cov=scanner/lib --cov-fail-under=95 -q
-> 1017 passed, coverage 96.26%, gate PASSED.
\`\`\`

## Test plan
- [x] Local pytest + 95% gate: PASSES
- [x] \`grep\` for xmlrunner imports: NONE in Python code (only stale docstring comments)
- [ ] CI \`scanner-unit-tests\` job passes with the stricter gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)