### PR TITLE
docs: replace xmlrunner references with pytest-centric wording

### DIFF
--- a/scanner/tests/test_audit_points_scan_pure.py
+++ b/scanner/tests/test_audit_points_scan_pure.py
@@ -2,9 +2,10 @@
 Unit tests for pure helpers in scanner/lib/audit-points-scan.py.
 
 Each test exercises exactly one behaviour. No network, no subprocess.
-tempfile.TemporaryDirectory is used for filesystem fixtures (stdlib only,
-so the file runs under both `python3 -m unittest xmlrunner discover` and
-pytest).
+tempfile.TemporaryDirectory is used for filesystem fixtures (stdlib only).
+Tests are stdlib-only and pass under both pytest (the CI runner) and plain
+`python3 -m unittest` discovery. No third-party test deps beyond what the
+test exercises.
 
 Import strategy: audit-points-scan.py has hyphens in the filename, so it
 cannot be imported via `import audit-points-scan`.  We load it once via

--- a/scanner/tests/test_dashboard_data_loader_pure.py
+++ b/scanner/tests/test_dashboard_data_loader_pure.py
@@ -5,7 +5,9 @@ Focuses on pure helpers (OCSF parsing, provider normalisation, severity
 classification, provider filters, env status) plus tmp-path coverage of
 the JSON loaders and caching branches.  Each test exercises one behaviour
 and is independent of any other test (no shared mutable state, no network).
-Written so both unittest (`xmlrunner discover`) and pytest can execute it.
+Tests are stdlib-only and pass under both pytest (the CI runner) and
+plain `python3 -m unittest` discovery. No third-party test deps beyond
+what the test exercises.
 """
 
 import json

--- a/scanner/tests/test_dashboard_html_builders_pure.py
+++ b/scanner/tests/test_dashboard_html_builders_pure.py
@@ -12,10 +12,11 @@ Each test exercises a single behaviour of the private HTML-builder helpers:
   * _build_datadog_cases_section
 
 Tests are authored as both bare `def test_*()` functions (for pytest) AND
-as a `unittest.TestCase` wrapper (for `python3 -m xmlrunner discover` in CI,
-which loads unittest.TestLoader and therefore only picks up TestCase
-subclasses).  Uses stdlib + unittest.mock only — no `import pytest`, so CI
-(which does not install pytest) will still import the module successfully.
+as a `unittest.TestCase` wrapper (for `python3 -m unittest discover`, which
+loads unittest.TestLoader and therefore only picks up TestCase subclasses).
+Uses stdlib + unittest.mock only — no third-party test deps beyond what
+the test exercises. Passes under both pytest (the CI runner) and plain
+`python3 -m unittest` discovery.
 """
 
 import os
@@ -748,8 +749,8 @@ def test_datadog_cases_html_escapes_title():
 
 # ---------------------------------------------------------------------------
 # unittest.TestCase wrapper so the same assertions run under `python -m
-# unittest discover` / `xmlrunner discover` (CI), which only picks up
-# TestCase subclasses — not bare `def test_*` functions.
+# unittest discover` (which only picks up TestCase subclasses — not bare
+# `def test_*` functions) as well as under pytest.
 # ---------------------------------------------------------------------------
 
 

--- a/scanner/tests/test_dashboard_html_helpers_pure.py
+++ b/scanner/tests/test_dashboard_html_helpers_pure.py
@@ -7,8 +7,9 @@ _cmd_pill, _compute_severity_counts, _compute_severity_bars,
 _build_replacements.
 
 Each test exercises one behaviour and is independent of any other
-test (no shared mutable state, no network).  Written so both
-unittest (`xmlrunner discover`) and pytest can execute it.
+test (no shared mutable state, no network).  Tests are stdlib-only and
+pass under both pytest (the CI runner) and plain `python3 -m unittest`
+discovery. No third-party test deps beyond what the test exercises.
 """
 
 import hashlib

--- a/scanner/tests/test_dashboard_mapping_pure.py
+++ b/scanner/tests/test_dashboard_mapping_pure.py
@@ -6,8 +6,9 @@ COMPLIANCE_FRAMEWORKS, OWASP_TO_ARCH) and pure mapping functions
 (get_check_en, map_findings_to_owasp, map_architecture,
 _match_prowler_compliance, map_compliance).
 
-Tests are stdlib-only and work under both unittest (xmlrunner discover) and
-pytest. No pytest import, no internal IPs, no network, no shared state.
+Tests are stdlib-only and pass under both pytest (the CI runner) and plain
+`python3 -m unittest` discovery. No third-party test deps beyond what the
+test exercises. No internal IPs, no network, no shared state.
 """
 
 import importlib

--- a/scanner/tests/test_dashboard_template_pure.py
+++ b/scanner/tests/test_dashboard_template_pure.py
@@ -3,8 +3,9 @@ Unit tests for scanner/lib/dashboard_template.py.
 
 Targets previously-uncovered branches (sys.path insertion, scan_dir and
 repo_root exception handlers, open() exception in the SVG read loop, and
-the inline-SVG fallback).  Stdlib + unittest.mock only so CI's
-`python3 -m xmlrunner discover` can run the suite unchanged.
+the inline-SVG fallback).  Tests are stdlib-only and pass under both
+pytest (the CI runner) and plain `python3 -m unittest` discovery.
+No third-party test deps beyond what the test exercises.
 """
 
 import base64

--- a/scanner/tests/test_zscaler_api_gaps.py
+++ b/scanner/tests/test_zscaler_api_gaps.py
@@ -6,9 +6,11 @@ Targets the lines not reached by test_zscaler_api_smoke.py:
   - main() body         (lines 176-199)
 
 CI-compat notes:
-  - No `import pytest` (CI uses `python3 -m xmlrunner discover`).
-  - Plain `unittest.TestCase` subclass + `def test_*()` functions.
-  - Stdlib + unittest.mock only.
+  - No `import pytest`; plain `unittest.TestCase` subclass + `def test_*()`
+    functions so the file is discoverable by both pytest (the CI runner) and
+    plain `python3 -m unittest` discovery.
+  - Stdlib + unittest.mock only — no third-party test deps beyond what the
+    test exercises.
   - No internal / RFC1918 addresses — RFC 5737 example domains only.
   - zscaler-api.py has a hyphen in its filename, so we load it via
     importlib.util.spec_from_file_location (see test_diagram_gen_pure_helpers.py).
@@ -338,8 +340,8 @@ def test_main_collect_posture_exception_still_attempts_logout():
 
 
 # ---------------------------------------------------------------------------
-# unittest.TestCase wrapper so `python3 -m unittest` discovers these as tests
-# when the xmlrunner path is used in CI.
+# unittest.TestCase wrapper so `python3 -m unittest discover` picks up these
+# tests alongside pytest (the CI runner).
 # ---------------------------------------------------------------------------
 
 class ZscalerApiGapsTestCase(unittest.TestCase):


### PR DESCRIPTION
## Summary
After #110 dropped \`unittest-xml-reporting\` from CI deps, seven test files still referenced "xmlrunner discover" in their docstrings/comments. Pure docstring-only cleanup.

- \`test_audit_points_scan_pure.py\`, \`test_dashboard_data_loader_pure.py\`, \`test_dashboard_html_builders_pure.py\`, \`test_dashboard_html_helpers_pure.py\`, \`test_dashboard_mapping_pure.py\`, \`test_dashboard_template_pure.py\`, \`test_zscaler_api_gaps.py\`
- 30 insertions / 21 deletions, no code/behavior change.

## Test plan
- [x] \`python3 -m pytest scanner/tests/ -q\` — 1017 passed, 205 subtests
- [x] No CI workflow changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)