### PR TITLE
ci: add Codecov upload + kcov shell-coverage (informational)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -139,6 +139,16 @@ jobs:
           path: test-reports/*.xml
           retention-days: 14
           if-no-files-found: ignore
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        continue-on-error: true
+        with:
+          files: test-reports/coverage.xml
+          flags: scanner-lib
+          fail_ci_if_error: false
+          verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Fail workflow on scanner unittest / coverage failure
         if: always() && steps.scanner_tests.outputs.test_exit_code != '0'
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -155,6 +155,45 @@ jobs:
           echo "scanner-unit-tests failed (or coverage below 90%) with exit code ${{ steps.scanner_tests.outputs.test_exit_code }}"
           exit 1
 
+  scanner-shell-coverage:
+    runs-on: ubuntu-latest
+    needs: scanner-unit-tests
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Install kcov
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y kcov
+      - name: Run scanner shell tests under kcov
+        run: |
+          mkdir -p kcov-out
+          for sh in scanner/tests/test_*.sh; do
+            name=$(basename "$sh" .sh)
+            kcov --bash-method=DEBUG \
+              --include-pattern=scanner/checks/,scanner/lib/output.sh \
+              "kcov-out/$name" bash "$sh" \
+              || echo "WARN: $sh exited non-zero under kcov"
+          done
+          kcov --merge kcov-out/merged kcov-out/*/
+      - name: Print bash coverage summary
+        run: |
+          if [ -f kcov-out/merged/coverage.json ]; then
+            pct=$(python3 -c "import json; d=json.load(open('kcov-out/merged/coverage.json')); print(d.get('percent_covered','?'))")
+            echo "Bash coverage (merged): ${pct}%"
+          else
+            echo "WARN: kcov merged coverage.json not found"
+            ls -la kcov-out/merged/ || true
+          fi
+      - name: Upload kcov merged report
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
+        with:
+          name: scanner-shell-kcov-${{ github.run_id }}
+          path: kcov-out/merged/
+          retention-days: 14
+          if-no-files-found: ignore
+
   dashboard-regression-check:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -156,7 +156,11 @@ jobs:
           exit 1
 
   scanner-shell-coverage:
-    runs-on: ubuntu-latest
+    # ubuntu-22.04: kcov still ships in jammy's default apt repos. On
+    # ubuntu-24.04 (noble, the current `ubuntu-latest`) kcov was dropped,
+    # so apt-get install fails. Pin to 22.04 for this informational job
+    # instead of building kcov from source.
+    runs-on: ubuntu-22.04
     needs: scanner-unit-tests
     continue-on-error: true
     steps:


### PR DESCRIPTION
## Summary
Two separate CI enhancements on top of #109/#110's pytest+coverage migration:

1. **Codecov upload**: after the existing pytest coverage step, upload \`test-reports/coverage.xml\` via \`codecov/codecov-action@v6\` (pinned SHA). Public repo, tokenless upload. Guarded with \`continue-on-error: true\` and \`fail_ci_if_error: false\` so Codecov outages never block CI. Flag: \`scanner-lib\`.

2. **kcov shell coverage (informational)**: new \`scanner-shell-coverage\` job that \`apt-get install kcov\`, runs each \`scanner/tests/test_*.sh\` under \`kcov --bash-method=DEBUG --include-pattern=scanner/checks/,scanner/lib/output.sh\`, merges reports, prints summary, uploads merged directory as artifact. Purely informational this round — no gate, \`continue-on-error: true\` at job level, \`needs: scanner-unit-tests\` so kcov only runs when Python tests pass.

Not added to the \`Lint\` aggregator's \`needs:\` list yet (per the "less risky" posture) — kcov stays opt-in until it stabilizes.

## Caveats
- Codecov action: v6.0.0 (released 2026-03-26). Inputs used are v5-compatible.
- kcov summary parsing assumes \`coverage.json\` has \`percent_covered\`; degrades to WARN if the apt version formats it differently.

## Test plan
- [ ] Codecov step succeeds on this PR (or fails soft without blocking)
- [ ] kcov job completes (informational; fail-soft if kcov apt build is missing)
- [ ] YAML parses: \`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"\` → OK (verified locally)
- [ ] scanner-unit-tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)