### PR TITLE
docs: add Codecov badge + codecov.yml for PR comment integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 > AI Security Best Practices toolkit for secure development with Claude Code
 
 [![npm version](https://img.shields.io/npm/v/claudesec?color=cb3837&logo=npm)](https://www.npmjs.com/package/claudesec)
+[![codecov](https://codecov.io/gh/Twodragon0/claudesec/branch/main/graph/badge.svg?flag=scanner-lib)](https://codecov.io/gh/Twodragon0/claudesec)
 [![GitHub stars](https://img.shields.io/github/stars/Twodragon0/claudesec?style=flat&color=yellow)](https://github.com/Twodragon0/claudesec/stargazers)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,31 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 95%
+        threshold: 1%
+        flags:
+          - scanner-lib
+    patch:
+      default:
+        target: 90%
+        flags:
+          - scanner-lib
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+  require_base: no
+  require_head: yes
+
+flags:
+  scanner-lib:
+    paths:
+      - scanner/lib/
+    carryforward: true
+
+ignore:
+  - "scanner/tests/"
+  - "docs/"
+  - "examples/"


### PR DESCRIPTION
## Summary
Follow-up to #113 (which uploads scanner-lib coverage.xml to Codecov). This PR wires the dashboard side:

- **README badge** between npm-version and GitHub-stars, linked to the \`scanner-lib\` flag on the \`main\` branch.
- **\`codecov.yml\`** at the repo root:
  - Project target: **95%** (matches the CI gate from #110) with 1% threshold
  - Patch target: **90%** so PRs can land slightly lower before we raise the bar
  - Comment layout: \`reach, diff, flags, files\`
  - \`scanner-lib\` flag scoped to \`scanner/lib/\` with carryforward enabled
  - \`ignore:\` scanner/tests, docs, examples

Once this PR merges and the next \`main\` build publishes coverage, the badge will render the current **96.26%** and PR comments will start appearing on subsequent PRs.

## Test plan
- [x] README renders locally (badge markup matches shields.io standard pattern)
- [x] \`codecov.yml\` is syntactically valid YAML (no parser complaints)
- [ ] After merge: first \`main\` CI run uploads to Codecov → badge populates
- [ ] Next PR sees Codecov comment with diff coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)