### PR TITLE
ci: fix kcov include-pattern to match actually-sourced bash files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -172,10 +172,15 @@ jobs:
       - name: Run scanner shell tests under kcov
         run: |
           mkdir -p kcov-out
+          # The bash unit tests source `$LIB_DIR/checks.sh` and
+          # `$LIB_DIR/output.sh` from scanner/lib (not scanner/checks/**/*.sh
+          # directly), so kcov's --include-pattern must match the *source*
+          # files that actually get executed. Patterns are substring-matched
+          # against the absolute file path.
           for sh in scanner/tests/test_*.sh; do
             name=$(basename "$sh" .sh)
             kcov --bash-method=DEBUG \
-              --include-pattern=scanner/checks/,scanner/lib/output.sh \
+              --include-pattern=scanner/lib/checks.sh,scanner/lib/output.sh \
               "kcov-out/$name" bash "$sh" \
               || echo "WARN: $sh exited non-zero under kcov"
           done


### PR DESCRIPTION
## Summary
Follow-up to #113 / #115. The \`scanner-shell-coverage\` job landed working (ubuntu-22.04 kcov install), but the merged report showed **\`percent_covered: 0.00\` / \`total_lines: 0\`** because the \`--include-pattern\` didn't match any file the tests actually execute.

Grep of \`scanner/tests/test_*.sh\` shows every bash test sources \`\$LIB_DIR/checks.sh\` and/or \`\$LIB_DIR/output.sh\` from **scanner/lib** — never \`scanner/checks/**/*.sh\` directly.

### Fix
\`\`\`diff
-  --include-pattern=scanner/checks/,scanner/lib/output.sh
+  --include-pattern=scanner/lib/checks.sh,scanner/lib/output.sh
\`\`\`

After merge, the next \`main\` build should produce a non-zero \`percent_covered\` in \`scanner-shell-kcov-<runid>\` artifact.

## Test plan
- [x] Confirmed via grep: all 7 \`scanner/tests/test_*.sh\` scripts source only \`\$LIB_DIR/checks.sh\` and/or \`\$LIB_DIR/output.sh\`
- [ ] scanner-shell-coverage CI job reports non-zero coverage
- [ ] Downloaded kcov artifact on next main push shows real line counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)