### PR TITLE
ci: switch kcov to --include-path + default bash-method

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -173,14 +173,18 @@ jobs:
         run: |
           mkdir -p kcov-out
           # The bash unit tests source `$LIB_DIR/checks.sh` and
-          # `$LIB_DIR/output.sh` from scanner/lib (not scanner/checks/**/*.sh
-          # directly), so kcov's --include-pattern must match the *source*
-          # files that actually get executed. Patterns are substring-matched
-          # against the absolute file path.
+          # `$LIB_DIR/output.sh` from scanner/lib, so we need kcov to
+          # instrument that directory. Previous attempts with
+          # --include-pattern matched zero files (0% coverage reported);
+          # --include-path with the absolute repo path is more reliable
+          # because kcov records sourced files as absolute paths.
+          # Also drop --bash-method=DEBUG so kcov picks the default tracer
+          # that handles `source` correctly in recent jammy kcov builds.
+          LIB_ABS="$(pwd)/scanner/lib"
+          echo "kcov include-path: $LIB_ABS"
           for sh in scanner/tests/test_*.sh; do
             name=$(basename "$sh" .sh)
-            kcov --bash-method=DEBUG \
-              --include-pattern=scanner/lib/checks.sh,scanner/lib/output.sh \
+            kcov --include-path="$LIB_ABS" \
               "kcov-out/$name" bash "$sh" \
               || echo "WARN: $sh exited non-zero under kcov"
           done


### PR DESCRIPTION
## Summary
Follow-up fix for the kcov instrumentation — #116's include-pattern rewrite still produced \`0.00%\` coverage. Replace with \`--include-path\` (absolute dir) and drop the \`--bash-method=DEBUG\` flag so kcov uses its default tracer, which handles sourced files correctly in jammy's apt build.

Before: \`--include-pattern=scanner/lib/checks.sh,scanner/lib/output.sh --bash-method=DEBUG\`
After: \`--include-path="$(pwd)/scanner/lib"\` (default bash-method)

Adds a debug log line \`kcov include-path: /home/runner/work/...\` to the CI output so any future regression is trivially diagnosable.

## Test plan
- [ ] scanner-shell-coverage job on this PR produces non-zero \`percent_covered\` in the \`kcov-merged/coverage.json\` artifact.
- [ ] Informational only — no gate impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)