### PR TITLE
test: extend bash coverage (37% → ~60%+) + CI coverage journey doc

### DIFF
--- a/docs/guides/ci-coverage-journey.md
+++ b/docs/guides/ci-coverage-journey.md
@@ -1,0 +1,130 @@
+---
+title: "CI Coverage Journey (2026-04-17 → 04-20)"
+description: Retrospective of the four-day CI modernization and coverage campaign that moved ClaudeSec from 64%/xmlrunner to 96%/pytest with Codecov and kcov bash coverage.
+tags: [ci, coverage, pytest, kcov, codecov, retrospective]
+---
+
+# CI Coverage Journey (2026-04-17 → 04-20)
+
+This retrospective documents the coverage campaign that modernized ClaudeSec's CI pipeline from `xmlrunner` to `pytest` and closed a significant coverage gap using Codecov and kcov bash instrumentation.
+
+## Starting Point (2026-04-17)
+
+On April 17, the scanner Python coverage sat at approximately 64% with 309 tests passing in CI. The root cause was a silent limitation in the test framework: `python3 -m xmlrunner discover` only collected `unittest.TestCase` subclasses and skipped approximately 400 module-level `def test_*()` functions entirely—a hard limit that went unnoticed until coverage analysis revealed the gap.
+
+## Python Coverage Campaign
+
+Seven PRs modernized Python coverage in sequence:
+
+### #103 — Network builders extraction + diagram-gen
+
+- Extracted network builder utilities into a separate module
+- Increased `diagram-gen.py` coverage from 25% → 93%
+
+### #104 — dashboard_data_loader.py
+
+- Built out unit tests for data loading pipeline
+- Coverage: 57% → 94%
+
+### #105 — dashboard_html_builders.py + gitignore
+
+- Comprehensive HTML builder test suite
+- Coverage: 64% → 99%
+- Added `.gitignore` entry for Notion sync script
+
+### #106 — dashboard_mapping, html_helpers, audit-points-scan
+
+- `dashboard_mapping`: 100% coverage
+- `html_helpers`: 98% coverage
+- `audit_points_scan`: 91% coverage
+
+### #107 — dashboard-gen.py
+
+- Main dashboard generator test suite
+- Coverage: 70% → 99%
+
+### #108 — dashboard_auth.py, zscaler-api.py, dashboard_template.py
+
+- `dashboard_auth.py`: 100% coverage
+- `zscaler-api.py`: 96% coverage (used `sys.modules` stub for `requests` in tests)
+- `dashboard_template.py`: 98% coverage
+- Fixed nmap IP fixture using RFC 5737 documentation IP range
+
+## CI Pipeline Modernization
+
+### #109 — Switch to pytest
+
+`xmlrunner discover` collected only 619 tests (unittest.TestCase subclasses), while `pytest` collected 1017 + 205 subtests—a 64% increase in test discovery. This switch enabled accurate coverage measurement.
+
+Changes:
+
+- Replaced `python3 -m xmlrunner discover` with `pytest`
+- Added `pytest`, `pytest-cov`, `requests`, `Pillow` to `requirements-ci.txt`
+- Implemented 90% coverage gate in CI
+
+### #110 — Raise gate to 95%
+
+- Coverage gate raised to 95% (minimum acceptable coverage)
+- Dropped `unittest-xml-reporting` from CI dependencies
+
+### #112 — Docstring cleanup
+
+- Updated test docstrings to reflect pytest-centric conventions (removed xmlrunner-specific wording)
+
+## External Coverage Reporting & Bash Coverage
+
+### #113 — Codecov integration + kcov shell tests
+
+- Added Codecov upload step to CI
+- Introduced `kcov` job for shell script coverage (informational)
+
+### #115 — Codecov badge + codecov.yml policy
+
+- Added Codecov badge to README
+- Created `codecov.yml` with project target 95%, patch target 90%
+
+### #116, #117 — kcov coverage attempts
+
+Two attempts to fix 0% bash coverage:
+
+- Adjusted `--include-pattern` and `--include-path` flags
+- Issue: kcov v38 (Ubuntu Jammy default) has broken sourced-file instrumentation
+
+### #118 — kcov v42 from source + real fixes
+
+Built kcov v42 from source on `ubuntu-latest` and fixed two instrumentation bugs:
+
+1. **Include-pattern for sourced files**: Switched from `--include-path=scanner/lib` to `--include-pattern=checks.sh,output.sh`. Because test scripts source via `$SCRIPT_DIR/../lib/checks.sh`, canonical-path patterns fail; filename-only substring matching works.
+
+2. **Invoke kcov correctly**: Changed from `kcov OUTDIR bash script.sh` (traces the bash binary) to `kcov OUTDIR script.sh` (traces script lines directly).
+
+Result: First real bash coverage—**37.05%** (555/1498 lines).
+
+## Lessons: Closing the 95/37 Gap
+
+1. **Verify discovery**: Always confirm the CI runner actually executes the tests you wrote locally. `xmlrunner discover` silently dropped 40% of tests.
+
+2. **Trace the target**: For tools with native-code wrapping (kcov), verify whether you're instrumenting the interpreter (`bash script.sh`) or the script itself (`script.sh`).
+
+3. **Pattern matching semantics**: kcov include-pattern uses substring matching against the literal sourced path. When `source $SCRIPT_DIR/../lib/checks.sh` resolves to a dynamic path, use filename-only patterns.
+
+4. **Build from source**: Ubuntu Jammy's apt kcov (v38) is broken for sourced-file instrumentation. Build ≥v40 from source on `ubuntu-latest` CI images.
+
+## Metrics Snapshot
+
+| Metric | 2026-04-17 start | 2026-04-20 end |
+|---|---|---|
+| PRs merged | — | 15 |
+| Tests running (CI) | 619 (xmlrunner) | 1017 + 205 subtests (pytest) |
+| scanner/lib Python coverage | 64% | 96% |
+| Python CI coverage gate | none | 95% |
+| scanner/lib bash coverage | unmeasured | 37% |
+| Codecov integration | none | badge + PR comments |
+
+## References
+
+- [pytest documentation](https://docs.pytest.org)
+- [pytest-cov coverage plugin](https://pytest-cov.readthedocs.io)
+- [Codecov coverage analysis](https://about.codecov.io)
+- [kcov bash coverage instrumentation](https://github.com/SimonKagstrom/kcov)
+- [NIST SP 800-53 SA-11: Developer Testing and Evaluation](https://csrc.nist.gov/projects/cprt/catalog#/cprt/framework/version/SP_800_53_5_1_0/home?element=SA-11)

--- a/scanner/tests/test_checks_helpers.sh
+++ b/scanner/tests/test_checks_helpers.sh
@@ -209,12 +209,10 @@ region = us-east-1
 [profile sso-eng]
 sso_start_url = https://example.awsapps.com/start
 sso_region = us-east-1
-sso_account_id = 000000000001
 sso_role_name = Engineer
 
 [profile sso-prod]
 sso_session = team
-sso_account_id = 000000000002
 sso_role_name = Admin
 
 [profile keyed-only]

--- a/scanner/tests/test_checks_helpers.sh
+++ b/scanner/tests/test_checks_helpers.sh
@@ -1,0 +1,456 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC2016
+# Unit tests for scanner/lib/checks.sh helper functions.
+# Focuses on pure-shell helpers: file/dir/grep helpers, compliance map,
+# AWS/GCP/GitHub/Okta/Datadog/kubectl helpers where they can be exercised
+# without external CLIs.
+# Run: bash scanner/tests/test_checks_helpers.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    echo "    actual: $haystack"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected NOT to contain: $needle"
+    echo "    actual: $haystack"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_true() {
+  local label="$1" rc="$2"
+  if [[ "$rc" == "0" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label (rc=$rc)"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_false() {
+  local label="$1" rc="$2"
+  if [[ "$rc" != "0" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label (rc=$rc)"
+    ((TEST_FAILED++))
+  fi
+}
+
+# Color codes some helpers reference
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+
+source "$LIB_DIR/checks.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ============================================================================
+# has_command()
+# ============================================================================
+echo ""
+echo "=== has_command() ==="
+
+has_command bash; assert_true "has_command: bash present" "$?"
+has_command __definitely_not_a_cmd_xyz__; assert_false "has_command: bogus missing" "$?"
+
+# ============================================================================
+# run_with_timeout()
+# ============================================================================
+echo ""
+echo "=== run_with_timeout() ==="
+
+run_with_timeout 5 true; assert_true "run_with_timeout: true succeeds" "$?"
+run_with_timeout 5 false; assert_false "run_with_timeout: false returns nonzero" "$?"
+
+# ============================================================================
+# has_file() / has_dir() / file_contains() / files_contain() / count_files()
+# ============================================================================
+echo ""
+echo "=== has_file / has_dir / file_contains / files_contain / count_files ==="
+
+mkdir -p "$tmpdir/fs/sub"
+echo "hello world" > "$tmpdir/fs/a.txt"
+echo "secret=abc" > "$tmpdir/fs/b.env"
+echo "goodbye"    > "$tmpdir/fs/sub/c.txt"
+
+SCAN_DIR="$tmpdir/fs"
+
+has_file "a.txt"; assert_true "has_file: existing file" "$?"
+has_file "missing.txt"; assert_false "has_file: missing file" "$?"
+has_dir "sub"; assert_true "has_dir: existing dir" "$?"
+has_dir "nope"; assert_false "has_dir: missing dir" "$?"
+
+file_contains "a.txt" "hello"; assert_true  "file_contains: match"    "$?"
+file_contains "a.txt" "nomatch"; assert_false "file_contains: no match" "$?"
+file_contains "missing.txt" "x"; assert_false "file_contains: missing file" "$?"
+
+files_contain "*.txt" "hello"; assert_true "files_contain: glob match" "$?"
+files_contain "*.txt" "never_present_pattern_xyz"; assert_false "files_contain: no match" "$?"
+files_contain "sub/*.txt" "goodbye"; assert_true "files_contain: glob with slash" "$?"
+
+count_txt=$(count_files "*.txt")
+# Two .txt files: a.txt and sub/c.txt
+assert_eq "count_files: finds 2 .txt" "2" "$count_txt"
+count_env=$(count_files "*.env")
+assert_eq "count_files: finds 1 .env" "1" "$count_env"
+
+# Exclusions: files under excluded dirs should NOT be counted
+mkdir -p "$tmpdir/fs/node_modules" "$tmpdir/fs/.git" "$tmpdir/fs/.venv" "$tmpdir/fs/dist"
+echo "x" > "$tmpdir/fs/node_modules/junk.txt"
+echo "x" > "$tmpdir/fs/.git/junk.txt"
+echo "x" > "$tmpdir/fs/.venv/junk.txt"
+echo "x" > "$tmpdir/fs/dist/junk.txt"
+count_txt_after=$(count_files "*.txt")
+assert_eq "count_files: excludes vendored dirs" "2" "$count_txt_after"
+
+# files_contain should also skip excluded dirs
+echo "NEVER_COUNTED_PATTERN" > "$tmpdir/fs/node_modules/junk.txt"
+files_contain "*.txt" "NEVER_COUNTED_PATTERN"
+assert_false "files_contain: excludes vendored dir hits" "$?"
+
+# ============================================================================
+# is_git_repo() / git_remote_url()
+# ============================================================================
+echo ""
+echo "=== is_git_repo / git_remote_url ==="
+
+if command -v git >/dev/null 2>&1; then
+  mkdir -p "$tmpdir/gitrepo"
+  (cd "$tmpdir/gitrepo" && git init -q && git remote add origin https://example.com/fake/repo.git)
+  SCAN_DIR="$tmpdir/gitrepo"
+  is_git_repo; assert_true "is_git_repo: inside git repo" "$?"
+  url=$(git_remote_url)
+  assert_eq "git_remote_url: returns remote" "https://example.com/fake/repo.git" "$url"
+
+  SCAN_DIR="$tmpdir/fs"
+  is_git_repo; assert_false "is_git_repo: outside git repo" "$?"
+else
+  echo "  SKIP: git not available"
+fi
+
+# ============================================================================
+# aws_list_profiles / aws_list_sso_profiles / aws_default_or_first_profile
+# ============================================================================
+echo ""
+echo "=== aws_list_profiles / aws_list_sso_profiles / aws_default_or_first_profile ==="
+
+mkdir -p "$tmpdir/aws"
+cat > "$tmpdir/aws/credentials" <<'CREDS'
+[default]
+aws_access_key_id = AKIAEXAMPLE
+aws_secret_access_key = secret
+
+[profile staging]
+aws_access_key_id = AKIASTG
+aws_secret_access_key = secret
+
+[prod]
+aws_access_key_id = AKIAPROD
+aws_secret_access_key = secret
+CREDS
+export AWS_SHARED_CREDENTIALS_FILE="$tmpdir/aws/credentials"
+
+profiles=$(aws_list_profiles)
+assert_contains "aws_list_profiles: default first" "$(echo "$profiles" | head -1)" "default"
+assert_contains "aws_list_profiles: staging present" "$profiles" "staging"
+assert_contains "aws_list_profiles: prod present" "$profiles" "prod"
+
+first=$(aws_default_or_first_profile)
+assert_eq "aws_default_or_first_profile: default" "default" "$first"
+
+# Missing credentials file
+export AWS_SHARED_CREDENTIALS_FILE="$tmpdir/nonexistent/credentials"
+p_empty=$(aws_list_profiles)
+assert_eq "aws_list_profiles: missing file empty" "" "$p_empty"
+
+# SSO profiles in config
+cat > "$tmpdir/aws/config" <<'CFG'
+[default]
+region = us-east-1
+
+[profile sso-eng]
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 000000000001
+sso_role_name = Engineer
+
+[profile sso-prod]
+sso_session = team
+sso_account_id = 000000000002
+sso_role_name = Admin
+
+[profile keyed-only]
+region = eu-west-1
+output = json
+CFG
+export AWS_CONFIG_FILE="$tmpdir/aws/config"
+
+sso_list=$(aws_list_sso_profiles)
+assert_contains "aws_list_sso_profiles: sso-eng present" "$sso_list" "sso-eng"
+assert_contains "aws_list_sso_profiles: sso-prod present" "$sso_list" "sso-prod"
+assert_not_contains "aws_list_sso_profiles: keyed-only absent" "$sso_list" "keyed-only"
+
+# aws_profile_is_sso: positive / negative
+aws_profile_is_sso "sso-eng"; assert_true "aws_profile_is_sso: sso-eng yes" "$?"
+aws_profile_is_sso "keyed-only"; assert_false "aws_profile_is_sso: keyed-only no" "$?"
+aws_profile_is_sso ""; assert_false "aws_profile_is_sso: empty arg" "$?"
+
+# aws_ensure_profile_found
+unset AWS_PROFILE AWS_DEFAULT_PROFILE
+export AWS_SHARED_CREDENTIALS_FILE="$tmpdir/aws/credentials"
+aws_ensure_profile_found
+assert_eq "aws_ensure_profile_found: sets AWS_PROFILE to default" "default" "${AWS_PROFILE:-}"
+
+# Missing config file → no SSO profiles
+export AWS_CONFIG_FILE="$tmpdir/nonexistent/config"
+sso_empty=$(aws_list_sso_profiles)
+assert_eq "aws_list_sso_profiles: missing file empty" "" "$sso_empty"
+
+# ============================================================================
+# api_key_found()
+# ============================================================================
+echo ""
+echo "=== api_key_found() ==="
+
+unset MY_API_KEY
+api_key_found "MY_API_KEY"; assert_false "api_key_found: unset is false" "$?"
+
+export MY_API_KEY=""
+api_key_found "MY_API_KEY"; assert_false "api_key_found: empty is false" "$?"
+
+export MY_API_KEY="abc"
+api_key_found "MY_API_KEY"; assert_true "api_key_found: set returns true" "$?"
+unset MY_API_KEY
+
+# ============================================================================
+# has_gcp_credentials / gcp_ensure_credentials_found
+# ============================================================================
+echo ""
+echo "=== has_gcp_credentials / gcp_ensure_credentials_found ==="
+
+unset GOOGLE_APPLICATION_CREDENTIALS
+# Without gcloud in env, with no ADC path → false
+# We can't reliably mock gcloud CLI output. The ADC path branch is testable:
+export GOOGLE_APPLICATION_CREDENTIALS="$tmpdir/adc.json"
+echo '{}' > "$tmpdir/adc.json"
+has_gcp_credentials; assert_true "has_gcp_credentials: ADC file present" "$?"
+gcp_ensure_credentials_found; assert_true "gcp_ensure_credentials_found: ADC file present" "$?"
+
+export GOOGLE_APPLICATION_CREDENTIALS="$tmpdir/missing_adc.json"
+# ADC file missing; rely on gcloud branch. If gcloud missing, should return 1.
+if ! command -v gcloud >/dev/null 2>&1; then
+  has_gcp_credentials; assert_false "has_gcp_credentials: no gcloud, no ADC" "$?"
+  gcp_ensure_credentials_found; assert_false "gcp_ensure_credentials_found: no gcloud, no ADC" "$?"
+fi
+unset GOOGLE_APPLICATION_CREDENTIALS
+
+# ============================================================================
+# has_datadog_api_key / datadog_validate_api_key (key missing branch)
+# ============================================================================
+echo ""
+echo "=== has_datadog_api_key / datadog_validate_api_key ==="
+
+unset DD_API_KEY DATADOG_API_KEY
+has_datadog_api_key; assert_false "has_datadog_api_key: unset is false" "$?"
+datadog_validate_api_key; assert_false "datadog_validate_api_key: no key returns 1" "$?"
+
+export DD_API_KEY="dd-test-key"
+has_datadog_api_key; assert_true "has_datadog_api_key: DD_API_KEY set" "$?"
+unset DD_API_KEY
+
+export DATADOG_API_KEY="dd-test-key"
+has_datadog_api_key; assert_true "has_datadog_api_key: DATADOG_API_KEY set" "$?"
+unset DATADOG_API_KEY
+
+# ============================================================================
+# has_github_credentials / has_okta_credentials
+# ============================================================================
+echo ""
+echo "=== has_github_credentials / has_okta_credentials ==="
+
+unset GH_TOKEN GITHUB_TOKEN
+# Without gh CLI, should be false
+if ! command -v gh >/dev/null 2>&1; then
+  has_github_credentials; assert_false "has_github_credentials: no creds, no gh" "$?"
+fi
+export GITHUB_TOKEN="ghp_test"
+has_github_credentials; assert_true "has_github_credentials: GITHUB_TOKEN set" "$?"
+unset GITHUB_TOKEN
+export GH_TOKEN="ghp_test"
+has_github_credentials; assert_true "has_github_credentials: GH_TOKEN set" "$?"
+unset GH_TOKEN
+
+unset OKTA_API_TOKEN OKTA_OAUTH_TOKEN
+has_okta_credentials; assert_false "has_okta_credentials: unset false" "$?"
+export OKTA_API_TOKEN="okta-tok"
+has_okta_credentials; assert_true "has_okta_credentials: OKTA_API_TOKEN set" "$?"
+unset OKTA_API_TOKEN
+export OKTA_OAUTH_TOKEN="okta-oauth"
+has_okta_credentials; assert_true "has_okta_credentials: OKTA_OAUTH_TOKEN set" "$?"
+unset OKTA_OAUTH_TOKEN
+
+# ============================================================================
+# _kubectl_cmd()
+# ============================================================================
+echo ""
+echo "=== _kubectl_cmd() ==="
+
+unset KUBECONFIG CLAUDESEC_KUBECONTEXT
+cmd=$(_kubectl_cmd)
+assert_eq "_kubectl_cmd: plain" "kubectl" "$cmd"
+
+export KUBECONFIG="/tmp/fake/kubeconfig"
+cmd=$(_kubectl_cmd)
+assert_contains "_kubectl_cmd: includes --kubeconfig" "$cmd" "--kubeconfig"
+assert_contains "_kubectl_cmd: includes path"        "$cmd" "/tmp/fake/kubeconfig"
+unset KUBECONFIG
+
+export CLAUDESEC_KUBECONTEXT="my-ctx"
+cmd=$(_kubectl_cmd)
+assert_contains "_kubectl_cmd: includes --context" "$cmd" "--context"
+assert_contains "_kubectl_cmd: includes ctx name"  "$cmd" "my-ctx"
+unset CLAUDESEC_KUBECONTEXT
+
+# ============================================================================
+# kubectl_detect_cluster_type()
+# ============================================================================
+echo ""
+echo "=== kubectl_detect_cluster_type() ==="
+
+assert_eq "cluster_type: eks"             "eks"             "$(kubectl_detect_cluster_type "arn:aws:eks:us-east-1:123:cluster/my-cluster")"
+assert_eq "cluster_type: eks short"       "eks"             "$(kubectl_detect_cluster_type "my-eks-cluster")"
+assert_eq "cluster_type: gke"             "gke"             "$(kubectl_detect_cluster_type "gke_my-project_us-central1-a_my-cluster")"
+assert_eq "cluster_type: aks"             "aks"             "$(kubectl_detect_cluster_type "aks-dev")"
+assert_eq "cluster_type: azure"           "aks"             "$(kubectl_detect_cluster_type "azure-prod")"
+assert_eq "cluster_type: docker-desktop"  "docker-desktop"  "$(kubectl_detect_cluster_type "docker-desktop")"
+assert_eq "cluster_type: minikube"        "minikube"        "$(kubectl_detect_cluster_type "minikube")"
+assert_eq "cluster_type: kind"            "kind"            "$(kubectl_detect_cluster_type "kind-local")"
+assert_eq "cluster_type: rancher-desktop" "rancher-desktop" "$(kubectl_detect_cluster_type "rancher-desktop")"
+assert_eq "cluster_type: generic"         "generic"         "$(kubectl_detect_cluster_type "some-random-ctx")"
+
+# ============================================================================
+# kubectl_auto_find_kubeconfig()
+# ============================================================================
+echo ""
+echo "=== kubectl_auto_find_kubeconfig() ==="
+
+# No kubeconfig anywhere → returns 1
+kubectl_auto_find_kubeconfig "$tmpdir/empty_base" >/dev/null 2>&1
+assert_false "kubectl_auto_find_kubeconfig: empty returns 1" "$?"
+
+# Direct kubeconfig at base_dir
+mkdir -p "$tmpdir/kbase1"
+: > "$tmpdir/kbase1/kubeconfig"
+found=$(kubectl_auto_find_kubeconfig "$tmpdir/kbase1")
+assert_eq "kubectl_auto_find_kubeconfig: direct kubeconfig" "$tmpdir/kbase1/kubeconfig" "$found"
+
+# configs/dev/kubeconfig
+mkdir -p "$tmpdir/kbase2/configs/dev"
+: > "$tmpdir/kbase2/configs/dev/kubeconfig"
+found=$(kubectl_auto_find_kubeconfig "$tmpdir/kbase2")
+assert_eq "kubectl_auto_find_kubeconfig: configs/dev" "$tmpdir/kbase2/configs/dev/kubeconfig" "$found"
+
+# config/kubeconfig
+mkdir -p "$tmpdir/kbase3/config"
+: > "$tmpdir/kbase3/config/kubeconfig"
+found=$(kubectl_auto_find_kubeconfig "$tmpdir/kbase3")
+assert_eq "kubectl_auto_find_kubeconfig: config/kubeconfig" "$tmpdir/kbase3/config/kubeconfig" "$found"
+
+# Arbitrary configs/*/kubeconfig falls through to find
+mkdir -p "$tmpdir/kbase4/configs/custom"
+: > "$tmpdir/kbase4/configs/custom/kubeconfig"
+found=$(kubectl_auto_find_kubeconfig "$tmpdir/kbase4")
+assert_contains "kubectl_auto_find_kubeconfig: custom found" "$found" "kubeconfig"
+
+# ============================================================================
+# compliance_map()
+# ============================================================================
+echo ""
+echo "=== compliance_map() ==="
+
+assert_contains "compliance_map: IAM-*"      "$(compliance_map "IAM-001")"     "NIST:AC-2"
+assert_contains "compliance_map: NET-*"      "$(compliance_map "NET-042")"     "NIST:SC-7"
+assert_contains "compliance_map: CLOUD-*"    "$(compliance_map "CLOUD-013")"   "NIST:CM-6"
+assert_contains "compliance_map: CICD-*"     "$(compliance_map "CICD-007")"    "NIST:SA-11"
+assert_contains "compliance_map: AI-*"       "$(compliance_map "AI-002")"      "NIST-AI:MAP"
+assert_contains "compliance_map: INFRA-*"    "$(compliance_map "INFRA-001")"   "NIST:CM-6"
+assert_contains "compliance_map: MAC-*"      "$(compliance_map "MAC-001")"     "CIS:macOS-Benchmark"
+assert_contains "compliance_map: CIS-*"      "$(compliance_map "CIS-002")"     "CIS:macOS-Benchmark"
+assert_contains "compliance_map: SECRETS-*"  "$(compliance_map "SECRETS-001")" "NIST:IA-5"
+assert_contains "compliance_map: SAAS-API-*" "$(compliance_map "SAAS-API-01")" "NIST:AC-2"
+assert_contains "compliance_map: SAAS-*"     "$(compliance_map "SAAS-ZIA-01")" "NIST:AC-2"
+assert_contains "compliance_map: WIN-*"      "$(compliance_map "WIN-011")"     "KISA-W:W-01"
+assert_contains "compliance_map: PROWLER-*"  "$(compliance_map "PROWLER-1")"   "CIS:Benchmark"
+assert_eq       "compliance_map: unknown empty" "" "$(compliance_map "UNKNOWN-1")"
+
+# ============================================================================
+# kubectl_discover_kubeconfigs() — no HOME/.kube (uses real $HOME but tolerates)
+# ============================================================================
+echo ""
+echo "=== kubectl_discover_kubeconfigs() ==="
+
+# Point HOME at a throwaway location so we only see files we control
+orig_home="$HOME"
+export HOME="$tmpdir/fakehome"
+mkdir -p "$HOME/.kube"
+: > "$HOME/.kube/config"
+
+unset KUBECONFIG
+SCAN_DIR="$tmpdir/empty_base"
+out=$(kubectl_discover_kubeconfigs)
+assert_contains "kubectl_discover_kubeconfigs: finds ~/.kube/config" "$out" ".kube/config"
+
+# With KUBECONFIG pointing to existing file
+extra="$tmpdir/fakehome/extra_kubeconfig"
+: > "$extra"
+export KUBECONFIG="$extra"
+out=$(kubectl_discover_kubeconfigs)
+assert_contains "kubectl_discover_kubeconfigs: picks up KUBECONFIG file" "$out" "extra_kubeconfig"
+
+unset KUBECONFIG
+export HOME="$orig_home"
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1

--- a/scanner/tests/test_output_functions.sh
+++ b/scanner/tests/test_output_functions.sh
@@ -182,6 +182,544 @@ IFS='|' read -r _ _ _ _ _ f_loc2 <<< "$entry"
 assert_eq "pipe format: location field preserved" "/k8s/deployment.yaml" "$f_loc2"
 
 # ==============================================================================
+# Test Group 4: print_banner / section / category_label
+# ==============================================================================
+echo ""
+echo "=== print_banner / section / category_label ==="
+
+# Need VERSION, SCAN_DIR, CATEGORY, SEVERITY defined for print_banner
+CATEGORY="all"
+banner_out="$(print_banner 2>&1)"
+assert_contains "print_banner: name present"    "$banner_out" "ClaudeSec Scanner"
+assert_contains "print_banner: VERSION present" "$banner_out" "test"
+assert_contains "print_banner: scan dir shown"  "$banner_out" "$tmpdir"
+assert_contains "print_banner: category shown"  "$banner_out" "all"
+assert_contains "print_banner: severity shown"  "$banner_out" "low"
+
+section_out="$(section "Hello Title" 2>&1)"
+assert_contains "section: contains title"  "$section_out" "Hello Title"
+assert_contains "section: delimiter shown" "$section_out" "━"
+
+assert_eq "category_label: infra"          "Infrastructure Security"          "$(category_label infra)"
+assert_eq "category_label: ai"             "AI / LLM Security"                "$(category_label ai)"
+assert_eq "category_label: network"        "Network Security"                 "$(category_label network)"
+assert_eq "category_label: cloud"          "Cloud Security (AWS/GCP/Azure)"   "$(category_label cloud)"
+assert_eq "category_label: access-control" "Access Control & IAM"             "$(category_label access-control)"
+assert_eq "category_label: cicd"           "CI/CD Pipeline Security"          "$(category_label cicd)"
+assert_eq "category_label: code"           "Code Vulnerability Analysis (SAST)" "$(category_label code)"
+assert_eq "category_label: macos"          "macOS / CIS Benchmark Security"   "$(category_label macos)"
+assert_eq "category_label: saas"           "SaaS & Solutions Security"        "$(category_label saas)"
+assert_eq "category_label: windows"        "Windows Security (KISA)"          "$(category_label windows)"
+assert_eq "category_label: prowler"        "Prowler Deep Scan (Multi-Cloud)"  "$(category_label prowler)"
+assert_eq "category_label: unknown passes through" "mystery" "$(category_label mystery)"
+
+# ==============================================================================
+# Test Group 5: pass() / warn() / skip() + colored wrappers
+# ==============================================================================
+echo ""
+echo "=== pass / warn / skip / info / success / warning / error ==="
+
+# pass(): bumps counters and emits JSON entry; QUIET=1 means nothing printed.
+_reset_state
+pass "CHK-P1" "Good config" "all ok"
+assert_eq "pass: TOTAL_CHECKS=1" "1" "$TOTAL_CHECKS"
+assert_eq "pass: PASSED=1"       "1" "$PASSED"
+assert_contains "pass: JSON status" "$JSON_RESULTS" '"status":"pass"'
+assert_contains "pass: JSON id"     "$JSON_RESULTS" '"id":"CHK-P1"'
+
+# pass() with non-quiet output
+_reset_state
+QUIET=""
+pass_out="$(pass "CHK-P2" "Another good" "details here" 2>&1)"
+assert_contains "pass verbose: title in output"   "$pass_out" "Another good"
+assert_contains "pass verbose: details in output" "$pass_out" "details here"
+assert_contains "pass verbose: PASS marker"       "$pass_out" "PASS"
+QUIET=1
+
+# warn() appends to FINDINGS_WARN and bumps WARNINGS
+_reset_state
+warn "CHK-W1" "Best practice" "some detail"
+assert_eq "warn: WARNINGS=1"            "1" "$WARNINGS"
+assert_eq "warn: TOTAL_CHECKS=1"        "1" "$TOTAL_CHECKS"
+assert_eq "warn: FINDINGS_WARN has 1"   "1" "${#FINDINGS_WARN[@]}"
+assert_contains "warn: JSON warning status" "$JSON_RESULTS" '"status":"warning"'
+
+# warn() with non-quiet output
+_reset_state
+QUIET=""
+warn_out="$(warn "CHK-W2" "A warn title" "warn detail" 2>&1)"
+assert_contains "warn verbose: WARN marker" "$warn_out" "WARN"
+assert_contains "warn verbose: title shown" "$warn_out" "A warn title"
+assert_contains "warn verbose: detail shown" "$warn_out" "warn detail"
+QUIET=1
+
+# skip() bumps SKIPPED and TOTAL_CHECKS; does not write to JSON_RESULTS
+_reset_state
+skip "CHK-S1" "Skipped check" "no target host"
+assert_eq "skip: SKIPPED=1"       "1" "$SKIPPED"
+assert_eq "skip: TOTAL_CHECKS=1"  "1" "$TOTAL_CHECKS"
+assert_eq "skip: JSON untouched"  "[]" "$JSON_RESULTS"
+
+# skip() with non-quiet output prints the reason
+_reset_state
+QUIET=""
+skip_out="$(skip "CHK-S2" "Skipped again" "no host" 2>&1)"
+assert_contains "skip verbose: SKIP marker" "$skip_out" "SKIP"
+assert_contains "skip verbose: reason shown" "$skip_out" "no host"
+QUIET=1
+
+# info() emits only when FORMAT=text
+info_out="$(info "hello info" 2>&1)"
+assert_contains "info: text emits message" "$info_out" "hello info"
+
+OLD_FORMAT="$FORMAT"
+FORMAT="json"
+info_json_out="$(info "should not print" 2>&1)"
+assert_eq "info: json format produces no output" "" "$info_json_out"
+FORMAT="$OLD_FORMAT"
+
+# success / warning / error wrappers
+assert_contains "success: text emitted" "$(success "done!" 2>&1)" "done!"
+assert_contains "warning: text emitted" "$(warning "be careful" 2>&1)" "be careful"
+# error() writes to stderr
+error_out="$(error "oops" 2>&1 1>/dev/null)"
+assert_contains "error: text emitted on stderr" "$error_out" "oops"
+
+# ==============================================================================
+# Test Group 6: should_report() - all severity modes
+# ==============================================================================
+echo ""
+echo "=== should_report() ==="
+
+# Remove our earlier stub so the real function is tested
+unset -f should_report
+source "$LIB_DIR/output.sh" 2>/dev/null || true
+
+OLD_SEV="$SEVERITY"
+
+SEVERITY="all"
+should_report critical && sr_all_crit=true || sr_all_crit=false
+should_report low      && sr_all_low=true  || sr_all_low=false
+assert_eq "should_report all: critical passes" "true" "$sr_all_crit"
+assert_eq "should_report all: low passes"      "true" "$sr_all_low"
+
+SEVERITY="critical"
+should_report critical && r=true || r=false
+assert_eq "should_report critical: critical yes" "true" "$r"
+should_report high     && r=true || r=false
+assert_eq "should_report critical: high no"      "false" "$r"
+should_report medium   && r=true || r=false
+assert_eq "should_report critical: medium no"    "false" "$r"
+should_report low      && r=true || r=false
+assert_eq "should_report critical: low no"       "false" "$r"
+
+SEVERITY="high"
+should_report critical && r=true || r=false
+assert_eq "should_report high: critical yes" "true" "$r"
+should_report high     && r=true || r=false
+assert_eq "should_report high: high yes"     "true" "$r"
+should_report medium   && r=true || r=false
+assert_eq "should_report high: medium no"    "false" "$r"
+should_report low      && r=true || r=false
+assert_eq "should_report high: low no"       "false" "$r"
+
+SEVERITY="medium"
+should_report critical && r=true || r=false
+assert_eq "should_report medium: critical yes" "true" "$r"
+should_report high     && r=true || r=false
+assert_eq "should_report medium: high yes"     "true" "$r"
+should_report medium   && r=true || r=false
+assert_eq "should_report medium: medium yes"   "true" "$r"
+should_report low      && r=true || r=false
+assert_eq "should_report medium: low no"       "false" "$r"
+
+SEVERITY="low"
+should_report critical && r=true || r=false
+assert_eq "should_report low: critical yes" "true" "$r"
+should_report low      && r=true || r=false
+assert_eq "should_report low: low yes"      "true" "$r"
+
+SEVERITY="$OLD_SEV"
+# Restore stub for subsequent tests
+should_report() { return 0; }
+
+# ==============================================================================
+# Test Group 7: html_escape()
+# ==============================================================================
+echo ""
+echo "=== html_escape() ==="
+
+assert_eq "html_escape: amp"      "&amp;"             "$(html_escape '&')"
+assert_eq "html_escape: lt"       "&lt;"              "$(html_escape '<')"
+assert_eq "html_escape: gt"       "&gt;"              "$(html_escape '>')"
+assert_eq "html_escape: dquote"   "&quot;"            "$(html_escape '"')"
+assert_eq "html_escape: squote"   "&#x27;"            "$(html_escape "'")"
+assert_eq "html_escape: plain"    "Hello World"       "$(html_escape "Hello World")"
+assert_eq "html_escape: mixed"    "a&amp;b&lt;c&gt;d" "$(html_escape 'a&b<c>d')"
+assert_eq "html_escape: empty"    ""                  "$(html_escape '')"
+assert_contains "html_escape: script tag" "$(html_escape '<script>alert(1)</script>')" "&lt;script&gt;"
+
+# ==============================================================================
+# Test Group 8: _finding_ref_url() - ID prefix mapping
+# ==============================================================================
+echo ""
+echo "=== _finding_ref_url() ==="
+
+assert_contains "ref_url: CODE-INJ-*"     "$(_finding_ref_url CODE-INJ-001)"  "A03_2021-Injection"
+assert_contains "ref_url: CODE-SEC-001"   "$(_finding_ref_url CODE-SEC-001)"  "Cryptographic_Failures"
+assert_contains "ref_url: CODE-SEC-002"   "$(_finding_ref_url CODE-SEC-002)"  "Software_and_Data_Integrity"
+assert_contains "ref_url: CODE-SEC-003"   "$(_finding_ref_url CODE-SEC-003)"  "Authentication_Failures"
+assert_contains "ref_url: SECRETS-*"      "$(_finding_ref_url SECRETS-ENV)"   "Authentication_Failures"
+assert_contains "ref_url: CODE-SEC-other" "$(_finding_ref_url CODE-SEC-999)"  "owasp.org/Top10/"
+assert_contains "ref_url: CICD-*"         "$(_finding_ref_url CICD-001)"      "ci-cd-security-risks"
+assert_contains "ref_url: AI-*"           "$(_finding_ref_url AI-001)"        "large-language-model"
+assert_contains "ref_url: LLM-*"          "$(_finding_ref_url LLM-010)"       "large-language-model"
+assert_contains "ref_url: IAM-*"          "$(_finding_ref_url IAM-001)"       "A01_2021-Broken_Access_Control"
+assert_contains "ref_url: NET-*"          "$(_finding_ref_url NET-001)"       "Cryptographic_Failures"
+assert_contains "ref_url: TLS-*"          "$(_finding_ref_url TLS-002)"       "Cryptographic_Failures"
+assert_contains "ref_url: INFRA-*"        "$(_finding_ref_url INFRA-001)"     "cisecurity.org/benchmark/docker"
+assert_contains "ref_url: DOCKER-*"       "$(_finding_ref_url DOCKER-003)"    "cisecurity.org/benchmark/docker"
+assert_contains "ref_url: MAC-*"          "$(_finding_ref_url MAC-001)"       "cisecurity.org/benchmark/apple_os"
+assert_contains "ref_url: CIS-*"          "$(_finding_ref_url CIS-001)"       "cisecurity.org/benchmark/apple_os"
+assert_contains "ref_url: WIN-*"          "$(_finding_ref_url WIN-001)"       "kisa.or.kr"
+assert_contains "ref_url: KISA-*"         "$(_finding_ref_url KISA-001)"      "kisa.or.kr"
+assert_contains "ref_url: CLOUD-*"        "$(_finding_ref_url CLOUD-001)"     "aws.amazon.com/securityhub"
+assert_contains "ref_url: AWS-*"          "$(_finding_ref_url AWS-001)"       "aws.amazon.com/securityhub"
+assert_contains "ref_url: SAAS-ZIA-*"     "$(_finding_ref_url SAAS-ZIA-001)"  "help.zscaler.com"
+assert_contains "ref_url: SAAS-API-*"     "$(_finding_ref_url SAAS-API-001)"  "A01_2021-Broken_Access_Control"
+assert_contains "ref_url: SAAS-other"     "$(_finding_ref_url SAAS-OTHER)"    "A01_2021-Broken_Access_Control"
+assert_contains "ref_url: TRIVY-*"        "$(_finding_ref_url TRIVY-001)"     "aquasecurity.github.io/trivy"
+assert_contains "ref_url: PROWLER-*"      "$(_finding_ref_url PROWLER-001)"   "hub.prowler.com"
+assert_eq       "ref_url: unknown empty"  ""                                  "$(_finding_ref_url UNKNOWN-001)"
+
+# ==============================================================================
+# Test Group 9: _finding_id_to_category() - full branch matrix
+# ==============================================================================
+echo ""
+echo "=== _finding_id_to_category() ==="
+
+assert_eq "cat: IAM"     "access-control" "$(_finding_id_to_category IAM-001)"
+assert_eq "cat: INFRA"   "infra"          "$(_finding_id_to_category INFRA-001)"
+assert_eq "cat: NET"     "network"        "$(_finding_id_to_category NET-001)"
+assert_eq "cat: TLS"     "network"        "$(_finding_id_to_category TLS-002)"
+assert_eq "cat: CICD"    "cicd"           "$(_finding_id_to_category CICD-007)"
+assert_eq "cat: CODE"    "code"           "$(_finding_id_to_category CODE-INJ-1)"
+assert_eq "cat: SAST"    "code"           "$(_finding_id_to_category SAST-001)"
+assert_eq "cat: AI"      "ai"             "$(_finding_id_to_category AI-001)"
+assert_eq "cat: LLM"     "ai"             "$(_finding_id_to_category LLM-010)"
+assert_eq "cat: CLOUD"   "cloud"          "$(_finding_id_to_category CLOUD-001)"
+assert_eq "cat: AWS"     "cloud"          "$(_finding_id_to_category AWS-001)"
+assert_eq "cat: GCP"     "cloud"          "$(_finding_id_to_category GCP-001)"
+assert_eq "cat: AZURE"   "cloud"          "$(_finding_id_to_category AZURE-001)"
+assert_eq "cat: MAC"     "macos"          "$(_finding_id_to_category MAC-001)"
+assert_eq "cat: CIS"     "macos"          "$(_finding_id_to_category CIS-001)"
+assert_eq "cat: SAAS"    "saas"           "$(_finding_id_to_category SAAS-API-1)"
+assert_eq "cat: WIN"     "windows"        "$(_finding_id_to_category WIN-001)"
+assert_eq "cat: KISA"    "windows"        "$(_finding_id_to_category KISA-001)"
+assert_eq "cat: PROWLER" "prowler"        "$(_finding_id_to_category PROWLER-1)"
+assert_eq "cat: SECRETS" "code"           "$(_finding_id_to_category SECRETS-01)"
+assert_eq "cat: TRIVY"   "code"           "$(_finding_id_to_category TRIVY-CVE1)"
+assert_eq "cat: DOCKER"  "infra"          "$(_finding_id_to_category DOCKER-01)"
+assert_eq "cat: unknown" "other"          "$(_finding_id_to_category FOO-001)"
+
+# ==============================================================================
+# Test Group 10: _print_findings()
+# ==============================================================================
+echo ""
+echo "=== _print_findings() ==="
+
+_reset_state
+FINDINGS_HIGH+=("CHK-100|High finding title|high|fix this now|details")
+FINDINGS_HIGH+=("CHK-101|Second high|high|remediate me|more details")
+pf_out="$(_print_findings FINDINGS_HIGH "HIGH" true 2>&1)"
+assert_contains "_print_findings: first id"       "$pf_out" "CHK-100"
+assert_contains "_print_findings: second id"      "$pf_out" "CHK-101"
+assert_contains "_print_findings: first title"    "$pf_out" "High finding title"
+assert_contains "_print_findings: fix shown"      "$pf_out" "fix this now"
+assert_contains "_print_findings: label present"  "$pf_out" "HIGH"
+
+# show_fix=false suppresses fix text
+_reset_state
+FINDINGS_MEDIUM+=("CHK-200|Medium title|medium|should be hidden|d")
+pf_out2="$(_print_findings FINDINGS_MEDIUM "MED" false 2>&1)"
+assert_contains     "_print_findings(no fix): id shown"    "$pf_out2" "CHK-200"
+assert_not_contains "_print_findings(no fix): fix hidden"  "$pf_out2" "should be hidden"
+
+# Empty array → no output
+_reset_state
+pf_empty="$(_print_findings FINDINGS_LOW "LOW" true 2>&1)"
+assert_eq "_print_findings: empty array no output" "" "$pf_empty"
+
+# ==============================================================================
+# Test Group 11: print_summary()
+# ==============================================================================
+echo ""
+echo "=== print_summary() ==="
+
+# Grade A path (score >= 90)
+_reset_state
+TOTAL_CHECKS=10; PASSED=10; FAILED=0; WARNINGS=0; SKIPPED=0
+ps_a="$(print_summary 5 2>&1)"
+assert_contains "print_summary A: score 100" "$ps_a" "100"
+assert_contains "print_summary A: grade A"   "$ps_a" "Grade:"
+assert_contains "print_summary A: dashboard heading" "$ps_a" "SCAN DASHBOARD"
+assert_contains "print_summary A: seconds shown"     "$ps_a" "5s"
+
+# Grade B path (80 <= score < 90)
+_reset_state
+TOTAL_CHECKS=10; PASSED=8; FAILED=2; WARNINGS=0; SKIPPED=0
+ps_b="$(print_summary 10 2>&1)"
+assert_contains "print_summary B: score 80" "$ps_b" "80"
+
+# Grade C path (70 <= score < 80)
+_reset_state
+TOTAL_CHECKS=10; PASSED=7; FAILED=3; WARNINGS=0; SKIPPED=0
+ps_c="$(print_summary 10 2>&1)"
+assert_contains "print_summary C: score 70" "$ps_c" "70"
+
+# Grade D path (60 <= score < 70)
+_reset_state
+TOTAL_CHECKS=10; PASSED=6; FAILED=4; WARNINGS=0; SKIPPED=0
+ps_d="$(print_summary 10 2>&1)"
+assert_contains "print_summary D: score 60" "$ps_d" "60"
+
+# Grade F path (score < 60)
+_reset_state
+TOTAL_CHECKS=10; PASSED=3; FAILED=7; WARNINGS=0; SKIPPED=0
+ps_f="$(print_summary 10 2>&1)"
+assert_contains "print_summary F: score 30" "$ps_f" "30"
+
+# Zero-active edge case (score stays 0)
+_reset_state
+TOTAL_CHECKS=0; PASSED=0; FAILED=0; WARNINGS=0; SKIPPED=0
+ps_z="$(print_summary 0 2>&1)"
+assert_contains "print_summary zero: dashboard heading" "$ps_z" "SCAN DASHBOARD"
+assert_contains "print_summary zero: 0s duration"       "$ps_z" "0s"
+
+# Minute-scale duration formatter (>=60 seconds)
+_reset_state
+TOTAL_CHECKS=1; PASSED=1; FAILED=0; WARNINGS=0; SKIPPED=0
+ps_min="$(print_summary 125 2>&1)"
+assert_contains "print_summary: minutes in duration"  "$ps_min" "2m"
+assert_contains "print_summary: seconds in duration"  "$ps_min" "5s"
+
+# Severity breakdown with critical/high/med/low/warn all populated
+_reset_state
+TOTAL_CHECKS=5; PASSED=0; FAILED=4; WARNINGS=1; SKIPPED=0
+FINDINGS_CRITICAL+=("CHK-C1|Critical thing|critical|fix crit|d")
+FINDINGS_HIGH+=("CHK-H1|High thing|high|fix high|d")
+FINDINGS_MEDIUM+=("CHK-M1|Medium thing|medium|fix med|d")
+FINDINGS_LOW+=("CHK-L1|Low thing|low|fix low|d")
+FINDINGS_WARN+=("CHK-W1|Warn thing|medium||d")
+ps_sev="$(print_summary 3 2>&1)"
+assert_contains "print_summary sev: CRITICAL shown" "$ps_sev" "CRITICAL"
+assert_contains "print_summary sev: HIGH shown"     "$ps_sev" "HIGH"
+assert_contains "print_summary sev: MEDIUM shown"   "$ps_sev" "MEDIUM"
+assert_contains "print_summary sev: LOW shown"      "$ps_sev" "LOW"
+assert_contains "print_summary sev: WARNING shown"  "$ps_sev" "WARNING"
+assert_contains "print_summary sev: Action Required" "$ps_sev" "Action Required"
+assert_contains "print_summary sev: Recommended Fixes" "$ps_sev" "Recommended Fixes"
+assert_contains "print_summary sev: Warnings section"  "$ps_sev" "Warnings"
+
+# ==============================================================================
+# Test Group 12: print_json_summary()
+# ==============================================================================
+echo ""
+echo "=== print_json_summary() ==="
+
+_reset_state
+TOTAL_CHECKS=10; PASSED=9; FAILED=1; WARNINGS=0; SKIPPED=0
+JSON_RESULTS='[{"id":"CHK-1","status":"pass"}]'
+js_a="$(print_json_summary 42 2>&1)"
+assert_contains "print_json_summary: version"      "$js_a" '"version": "test"'
+assert_contains "print_json_summary: duration"     "$js_a" '"duration_seconds": 42'
+assert_contains "print_json_summary: total"        "$js_a" '"total": 10'
+assert_contains "print_json_summary: passed"       "$js_a" '"passed": 9'
+assert_contains "print_json_summary: failed"       "$js_a" '"failed": 1'
+assert_contains "print_json_summary: score 90"     "$js_a" '"score": 90'
+assert_contains "print_json_summary: grade A"      "$js_a" '"grade": "A"'
+assert_contains "print_json_summary: results array" "$js_a" '"results":'
+
+# Grade B
+_reset_state
+TOTAL_CHECKS=10; PASSED=8; FAILED=2; WARNINGS=0; SKIPPED=0
+js_b="$(print_json_summary 1 2>&1)"
+assert_contains "print_json_summary: grade B" "$js_b" '"grade": "B"'
+
+# Grade C
+_reset_state
+TOTAL_CHECKS=10; PASSED=7; FAILED=3; WARNINGS=0; SKIPPED=0
+js_c="$(print_json_summary 1 2>&1)"
+assert_contains "print_json_summary: grade C" "$js_c" '"grade": "C"'
+
+# Grade D
+_reset_state
+TOTAL_CHECKS=10; PASSED=6; FAILED=4; WARNINGS=0; SKIPPED=0
+js_d="$(print_json_summary 1 2>&1)"
+assert_contains "print_json_summary: grade D" "$js_d" '"grade": "D"'
+
+# Grade F
+_reset_state
+TOTAL_CHECKS=10; PASSED=0; FAILED=10; WARNINGS=0; SKIPPED=0
+js_f="$(print_json_summary 1 2>&1)"
+assert_contains "print_json_summary: grade F" "$js_f" '"grade": "F"'
+
+# Zero-active (SKIPPED==TOTAL) → score 0, grade F
+_reset_state
+TOTAL_CHECKS=3; PASSED=0; FAILED=0; WARNINGS=0; SKIPPED=3
+js_skip="$(print_json_summary 1 2>&1)"
+assert_contains "print_json_summary: skipped=total score 0" "$js_skip" '"score": 0'
+
+# ==============================================================================
+# Test Group 13: save_scan_history / load_scan_history / compute_trend
+# ==============================================================================
+echo ""
+echo "=== save_scan_history / load_scan_history / compute_trend ==="
+
+hist_base="$(mktemp -d)"
+OLD_SCAN_DIR="$SCAN_DIR"
+SCAN_DIR="$hist_base"
+
+# Empty history dir → load_scan_history returns "[]"
+assert_eq "load_scan_history: missing dir returns []" "[]" "$(load_scan_history)"
+
+# Save one scan
+_reset_state
+TOTAL_CHECKS=10; PASSED=8; FAILED=2; WARNINGS=0; SKIPPED=0
+save_scan_history
+hist_count=$(find "$hist_base/.claudesec-history" -name 'scan-*.json' | wc -l | tr -d ' ')
+assert_eq "save_scan_history: file created" "1" "$hist_count"
+
+# load_scan_history populates
+loaded="$(load_scan_history)"
+assert_contains "load_scan_history: starts with [" "$loaded" "["
+assert_contains "load_scan_history: ends with ]"   "$loaded" "]"
+assert_contains "load_scan_history: score field"   "$loaded" '"score":80'
+assert_contains "load_scan_history: passed field"  "$loaded" '"passed":8'
+
+# Save second scan (improved) → compute_trend produces deltas
+_reset_state
+TOTAL_CHECKS=10; PASSED=9; FAILED=1; WARNINGS=0; SKIPPED=0
+compute_trend
+assert_eq "compute_trend: TREND_HAS_PREV"      "true" "${TREND_HAS_PREV:-}"
+assert_eq "compute_trend: score delta +10"     "10"   "${TREND_SCORE_DELTA:-}"
+assert_eq "compute_trend: failed delta -1"     "-1"   "${TREND_FAILED_DELTA:-}"
+assert_eq "compute_trend: prev score=80"       "80"   "${TREND_PREV_SCORE:-}"
+
+# History pruning: force HISTORY_MAX=2 and create 5 files so 3 are pruned
+rm -rf "$hist_base/.claudesec-history"
+OLD_HISTORY_MAX="$HISTORY_MAX"
+HISTORY_MAX=2
+_reset_state
+TOTAL_CHECKS=1; PASSED=1; FAILED=0; WARNINGS=0; SKIPPED=0
+mkdir -p "$hist_base/.claudesec-history"
+# Pre-populate with 5 dummy files whose names sort lexicographically
+for i in 1 2 3 4 5; do
+  printf '{"timestamp":"2026-01-0%dT00:00:00Z","score":50,"passed":0,"failed":0,"warnings":0,"skipped":0,"total":0,"critical":0,"high":0,"medium":0,"low":0,"warn":0}\n' "$i" \
+    > "$hist_base/.claudesec-history/scan-2026010${i}T000000Z.json"
+done
+save_scan_history  # adds 6th, which should trigger prune down to HISTORY_MAX=2
+remaining=$(find "$hist_base/.claudesec-history" -name 'scan-*.json' | wc -l | tr -d ' ')
+assert_eq "save_scan_history: prunes to HISTORY_MAX" "2" "$remaining"
+HISTORY_MAX="$OLD_HISTORY_MAX"
+
+SCAN_DIR="$OLD_SCAN_DIR"
+
+# ==============================================================================
+# Test Group 14: generate_html_dashboard_legacy()
+# ==============================================================================
+echo ""
+echo "=== generate_html_dashboard_legacy() ==="
+
+legacy_file="$tmpdir/legacy.html"
+generate_html_dashboard_legacy "$legacy_file"
+assert_eq "legacy: file created" "true" "$([[ -f "$legacy_file" ]] && echo true || echo false)"
+legacy_content="$(cat "$legacy_file")"
+assert_contains "legacy: html tag"           "$legacy_content" "<html>"
+assert_contains "legacy: body tag"           "$legacy_content" "<body>"
+assert_contains "legacy: title heading"      "$legacy_content" "ClaudeSec Dashboard"
+assert_contains "legacy: fallback mention"   "$legacy_content" "fallback"
+assert_contains "legacy: install python hint" "$legacy_content" "Python 3"
+
+# ==============================================================================
+# Test Group 15: _html_findings_rows / _html_findings_rows_limited
+# ==============================================================================
+echo ""
+echo "=== _html_findings_rows / _html_findings_rows_limited ==="
+
+# Basic rows with details → row + detail-row
+_reset_state
+FINDINGS_HIGH+=("CHK-HR1|High <danger> &title|high|Fix it|extra details")
+findings_html=""
+_html_findings_rows FINDINGS_HIGH "high" "badge-high" "HIGH"
+assert_contains "html_rows: id in output"           "$findings_html" "CHK-HR1"
+assert_contains "html_rows: title escaped"          "$findings_html" "&lt;danger&gt;"
+assert_contains "html_rows: amp escaped"            "$findings_html" "&amp;title"
+assert_contains "html_rows: fix shown"              "$findings_html" "Fix it"
+assert_contains "html_rows: badge class"            "$findings_html" "badge-high"
+assert_contains "html_rows: sev class row"          "$findings_html" '"high clickable"'
+assert_contains "html_rows: detail-row present"     "$findings_html" "detail-row"
+assert_contains "html_rows: clickable handler"      "$findings_html" "toggleDetail"
+assert_contains "html_rows: expand icon"            "$findings_html" "expand-icon"
+
+# Row without details → no detail-row, non-clickable
+_reset_state
+FINDINGS_MEDIUM+=("CHK-HR2|Med title|medium|Fix med|")
+findings_html=""
+_html_findings_rows FINDINGS_MEDIUM "medium" "badge-med" "MED"
+assert_contains     "html_rows(no details): id shown"            "$findings_html" "CHK-HR2"
+assert_not_contains "html_rows(no details): no detail-row"       "$findings_html" "detail-row"
+assert_not_contains "html_rows(no details): no toggle"           "$findings_html" "toggleDetail"
+
+# Empty findings array → no html produced
+_reset_state
+findings_html=""
+_html_findings_rows FINDINGS_LOW "low" "badge-low" "LOW"
+assert_eq "html_rows: empty array produces nothing" "" "$findings_html"
+
+# _html_findings_rows_limited with max=0 (unlimited) emits every entry
+_reset_state
+FINDINGS_HIGH+=("CHK-L1|First|high|fix1|")
+FINDINGS_HIGH+=("CHK-L2|Second|high|fix2|")
+FINDINGS_HIGH+=("CHK-L3|Third|high|fix3|")
+out_unlim=""
+_html_findings_rows_limited out_unlim FINDINGS_HIGH "high" "badge-high" "HIGH" 0
+assert_contains "html_rows_limited(max=0): first"  "$out_unlim" "CHK-L1"
+assert_contains "html_rows_limited(max=0): second" "$out_unlim" "CHK-L2"
+assert_contains "html_rows_limited(max=0): third"  "$out_unlim" "CHK-L3"
+
+# max=1 caps at a single row
+out_capped=""
+_html_findings_rows_limited out_capped FINDINGS_HIGH "high" "badge-high" "HIGH" 1
+assert_contains     "html_rows_limited(max=1): first included"  "$out_capped" "CHK-L1"
+assert_not_contains "html_rows_limited(max=1): second excluded" "$out_capped" "CHK-L2"
+assert_not_contains "html_rows_limited(max=1): third excluded"  "$out_capped" "CHK-L3"
+
+# max=2 caps at two rows
+out_two=""
+_html_findings_rows_limited out_two FINDINGS_HIGH "high" "badge-high" "HIGH" 2
+assert_contains     "html_rows_limited(max=2): first"         "$out_two" "CHK-L1"
+assert_contains     "html_rows_limited(max=2): second"        "$out_two" "CHK-L2"
+assert_not_contains "html_rows_limited(max=2): third missing" "$out_two" "CHK-L3"
+
+# Preserves existing content in outvar (append semantics)
+_reset_state
+FINDINGS_MEDIUM+=("CHK-APP1|Append test|medium|fix|")
+out_existing="PRIOR-CONTENT"
+_html_findings_rows_limited out_existing FINDINGS_MEDIUM "medium" "badge-med" "MED" 0
+assert_contains "html_rows_limited: preserves prior content" "$out_existing" "PRIOR-CONTENT"
+assert_contains "html_rows_limited: appends new row"         "$out_existing" "CHK-APP1"
+
+# Row with details in limited variant → clickable + detail-row
+_reset_state
+FINDINGS_HIGH+=("CHK-LD1|Limited detail|high|fix|lots of details here")
+out_det=""
+_html_findings_rows_limited out_det FINDINGS_HIGH "high" "badge-high" "HIGH" 5
+assert_contains "html_rows_limited: detail-row present" "$out_det" "detail-row"
+assert_contains "html_rows_limited: toggleDetail"       "$out_det" "toggleDetail"
+assert_contains "html_rows_limited: details in output"  "$out_det" "lots of details here"
+
+# ==============================================================================
 # Summary
 # ==============================================================================
 echo ""


### PR DESCRIPTION
## Summary
Follow-up to #118 (kcov v42 from source, first real bash coverage = **37.05%**). Three commits:

1. **\`test: extend test_output_functions.sh\`** — 23 → 225 assertions (+202). Covers every undertested helper in \`scanner/lib/output.sh\`: print_banner/section/category_label, pass/warn/skip/info/success/warning/error, should_report (5 modes × 17 permutations), html_escape, _finding_ref_url (25 prefixes), _finding_id_to_category (23 branches), _print_findings, print_summary (Grade A-F + duration formatter), print_json_summary, save/load_scan_history + pruning, compute_trend, generate_html_dashboard_legacy, _html_findings_rows[_limited].

2. **\`test: add test_checks_helpers.sh\`** — 86 new assertions covering \`scanner/lib/checks.sh\` helpers: has_command, file/dir checks, glob + exclusion paths, git helpers, aws_list_profiles variants, gcp/datadog/github/okta credential checks, kubectl auto-discovery (all 4 branches), compliance_map (13 prefixes).

3. **\`docs: CI coverage journey\`** — retrospective of the four-day campaign covering #103-#118, documenting the xmlrunner→pytest switch, kcov tuning journey, and key gotchas.

Estimated kcov uplift: **37% → 60-65%** (exact number will be visible in the scanner-shell-coverage CI artifact).

## Test plan
- [x] All 8 scanner/tests/test_*.sh bash tests pass locally
- [x] Python pytest suite unaffected (no Python files touched)
- [x] docs/guides/ci-coverage-journey.md lint-clean (markdownlint)
- [ ] scanner-shell-coverage CI artifact shows bash coverage ≥ 60%
- [ ] Python coverage gate (95%) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)