### PR TITLE
ci: fix bash-coverage.json path discovery (discovery-only, no gate change)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -164,6 +164,12 @@ jobs:
     # the default apt repos.
     runs-on: ubuntu-latest
     needs: scanner-unit-tests
+    # Soft-gated: kcov v42 writes the merged report into a nested subdir
+    # (kcov-merged/, merged-kcov-output/) that the original summary step
+    # never located, so the real bash-coverage baseline is still unknown.
+    # This PR fixes discovery so the number surfaces in logs; a follow-up
+    # PR will drop continue-on-error and enforce a threshold once we have
+    # evidence of a real baseline.
     continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -201,12 +207,22 @@ jobs:
           kcov --merge kcov-out/merged kcov-out/*/
       - name: Print bash coverage summary
         run: |
-          if [ -f kcov-out/merged/coverage.json ]; then
-            pct=$(python3 -c "import json; d=json.load(open('kcov-out/merged/coverage.json')); print(d.get('percent_covered','?'))")
+          # kcov v42's --merge writes coverage.json into a nested subdir
+          # (kcov-merged/ on current runners) rather than kcov-out/merged/
+          # directly, so locate it with find. Fall back to any coverage.json
+          # anywhere under kcov-out/ if the merge subdir ever changes names.
+          cov_json=$(find kcov-out/merged -name coverage.json -print -quit 2>/dev/null || true)
+          if [ -z "$cov_json" ]; then
+            cov_json=$(find kcov-out -name coverage.json -print -quit 2>/dev/null || true)
+          fi
+          if [ -n "$cov_json" ] && [ -f "$cov_json" ]; then
+            echo "Found merged coverage.json: $cov_json"
+            pct=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('percent_covered','?'))" "$cov_json")
             echo "Bash coverage (merged): ${pct}%"
           else
-            echo "WARN: kcov merged coverage.json not found"
-            ls -la kcov-out/merged/ || true
+            echo "WARN: no coverage.json found under kcov-out/"
+            echo "Contents of kcov-out/merged/ (top two levels):"
+            find kcov-out/merged -maxdepth 2 -print 2>/dev/null || true
           fi
       - name: Upload kcov merged report
         if: always()


### PR DESCRIPTION
## Summary

**Discovery-only PR.** Rewrites the `Print bash coverage summary` step to locate kcov v42's merged `coverage.json` via `find`, since kcov v42 writes it into a nested subdir (`kcov-merged/`, `merged-kcov-output/`) rather than directly to `kcov-out/merged/coverage.json`. The original step has been silently hitting the `WARN` branch since kcov v42 landed in #118 — `continue-on-error: true` masked this.

## What changed

- `Print bash coverage summary` now probes with `find kcov-out/merged -name coverage.json -print -quit`, falls back to `find kcov-out -name coverage.json`, and on miss dumps the actual layout (`find kcov-out/merged -maxdepth 2 -print`) so the path can be identified.
- `continue-on-error: true` is explicitly preserved (with a comment explaining why).
- `lint-gate` `needs` list is **unchanged**.

## What this PR does NOT do

- Does **not** drop `continue-on-error`.
- Does **not** add a threshold/enforcement step.
- Does **not** make `scanner-shell-coverage` required.

Those are deferred to a follow-up PR after we observe the real coverage percentage in this run's logs.

## Why split this way

The prior version of this PR promoted the job to a required gate with a 50% floor. Investigation of the failing run surfaced that the originally-cited 71.93% baseline was never actually measured — every previous main-branch run of this step produced `WARN: kcov merged coverage.json not found`. Enforcing a threshold against an unverified baseline is unsafe, so this PR is split: (1) surface the truth, (2) enforce the truth in a follow-up.

## Test plan

- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"`).
- [ ] CI run produces a non-WARN log line of the form `Bash coverage (merged): <N>%`.
- [ ] If the first `find` returns empty, fallback locates it; otherwise the diagnostic `find ... -maxdepth 2` lists the real subdir so we can patch.
- [ ] `continue-on-error: true` still keeps the lint gate green regardless of the number observed.

## Follow-up

Once this lands on main and the real `<N>%` is observed for 1–2 runs, open a second PR to:
1. Drop `continue-on-error: true`.
2. Add an `Enforce bash coverage threshold` step with the threshold set slightly below the observed baseline.
3. Add `scanner-shell-coverage` to the `lint-gate` `needs` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)