### PR TITLE
test: fixture tests for generate_html_dashboard and _prowler_dashboard_summary

### DIFF
--- a/scanner/tests/test_generate_html_dashboard.sh
+++ b/scanner/tests/test_generate_html_dashboard.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Unit tests for output.sh::generate_html_dashboard()
+# Focus: scan-report.json persistence + HTML output (legacy fallback path)
+# Run: bash scanner/tests/test_generate_html_dashboard.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR_REAL="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    ((TEST_FAILED++))
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Stub color codes so sourcing output.sh does not inject ANSI escapes
+RED="" YELLOW="" CYAN="" GREEN="" DIM="" NC="" BOLD="" BLUE="" MAGENTA=""
+
+FORMAT="text"
+QUIET=1
+SEVERITY="low"
+VERSION="test"
+SCAN_DIR="$tmpdir"
+
+source "$LIB_DIR_REAL/output.sh" 2>/dev/null || true
+
+should_report() { return 0; }
+
+# ==============================================================================
+# Test Group 1: legacy fallback path (python generator unavailable)
+# ==============================================================================
+echo ""
+echo "=== generate_html_dashboard() — legacy fallback ==="
+
+# Force legacy fallback by pointing LIB_DIR at a directory without dashboard-gen.py
+LIB_DIR="$tmpdir/no-py"
+mkdir -p "$LIB_DIR"
+
+# Minimal state: no findings, trivial counters
+TOTAL_CHECKS=2
+PASSED=2
+FAILED=0
+WARNINGS=0
+SKIPPED=0
+FINDINGS_CRITICAL=()
+FINDINGS_HIGH=()
+FINDINGS_MEDIUM=()
+FINDINGS_LOW=()
+FINDINGS_WARN=()
+
+# Disable diagram generation side effect (diagram-gen.py may not exist in test LIB_DIR)
+CLAUDESEC_GENERATE_DIAGRAMS=0
+
+out_html="$tmpdir/dashboard.html"
+generate_html_dashboard "$out_html"
+
+assert_eq "empty findings: html file created" "true" "$([[ -f "$out_html" ]] && echo true || echo false)"
+html_content="$(cat "$out_html")"
+assert_contains "empty findings: legacy html tag"        "$html_content" "<html>"
+assert_contains "empty findings: legacy body tag"        "$html_content" "<body>"
+assert_contains "empty findings: legacy dashboard title" "$html_content" "ClaudeSec Dashboard"
+
+# scan-report.json is always written, regardless of dashboard generator availability
+scan_report="$SCAN_DIR/scan-report.json"
+assert_eq "scan-report.json created" "true" "$([[ -f "$scan_report" ]] && echo true || echo false)"
+report_content="$(cat "$scan_report")"
+assert_contains "scan-report: passed field"  "$report_content" '"passed":2'
+assert_contains "scan-report: failed field"  "$report_content" '"failed":0'
+assert_contains "scan-report: total field"   "$report_content" '"total":2'
+assert_contains "scan-report: score=100"     "$report_content" '"score":100'
+assert_contains "scan-report: grade=A"       "$report_content" '"grade":"A"'
+assert_contains "scan-report: findings key"  "$report_content" '"findings":['
+
+# ==============================================================================
+# Test Group 2: findings are serialized into scan-report.json
+# ==============================================================================
+echo ""
+echo "=== generate_html_dashboard() — findings serialization ==="
+
+rm -f "$scan_report" "$out_html"
+
+TOTAL_CHECKS=4
+PASSED=1
+FAILED=3
+WARNINGS=0
+SKIPPED=0
+FINDINGS_CRITICAL=("IAM-001|Root key exposed|critical|Rotate now|Key present in .env|/app/.env")
+FINDINGS_HIGH=("NET-010|TLS 1.0 enabled|high|Disable TLS 1.0|Legacy protocol|")
+FINDINGS_MEDIUM=("CICD-020|No branch protection|medium|Enable protection||")
+FINDINGS_LOW=()
+FINDINGS_WARN=()
+
+generate_html_dashboard "$out_html"
+
+assert_eq "with findings: html file created" "true" "$([[ -f "$out_html" ]] && echo true || echo false)"
+assert_eq "with findings: scan-report.json created" "true" "$([[ -f "$scan_report" ]] && echo true || echo false)"
+
+report_content="$(cat "$scan_report")"
+# active = TOTAL_CHECKS - SKIPPED = 4; score = PASSED*100/active = 25
+assert_contains "scan-report: score=25"              "$report_content" '"score":25'
+assert_contains "scan-report: grade=F"               "$report_content" '"grade":"F"'
+assert_contains "scan-report: failed=3"              "$report_content" '"failed":3'
+assert_contains "scan-report: critical id present"   "$report_content" '"id":"IAM-001"'
+assert_contains "scan-report: high id present"       "$report_content" '"id":"NET-010"'
+assert_contains "scan-report: medium id present"     "$report_content" '"id":"CICD-020"'
+assert_contains "scan-report: critical severity"     "$report_content" '"severity":"critical"'
+assert_contains "scan-report: high severity"         "$report_content" '"severity":"high"'
+assert_contains "scan-report: medium severity"       "$report_content" '"severity":"medium"'
+# Category mapping (IAM→access-control, NET→network, CICD→cicd)
+assert_contains "scan-report: IAM→access-control"    "$report_content" '"category":"access-control"'
+assert_contains "scan-report: NET→network"           "$report_content" '"category":"network"'
+assert_contains "scan-report: CICD→cicd"             "$report_content" '"category":"cicd"'
+# Location passthrough for entries that have one
+assert_contains "scan-report: location preserved"    "$report_content" '"location":"/app/.env"'
+
+# ==============================================================================
+# Test Group 3: grade thresholds
+# ==============================================================================
+echo ""
+echo "=== generate_html_dashboard() — grade thresholds ==="
+
+_check_grade() {
+  local label="$1" passed="$2" total="$3" expected_grade="$4" expected_score="$5"
+  rm -f "$scan_report" "$out_html"
+  TOTAL_CHECKS="$total"
+  PASSED="$passed"
+  FAILED=$(( total - passed ))
+  WARNINGS=0
+  SKIPPED=0
+  FINDINGS_CRITICAL=()
+  FINDINGS_HIGH=()
+  FINDINGS_MEDIUM=()
+  FINDINGS_LOW=()
+  FINDINGS_WARN=()
+  generate_html_dashboard "$out_html"
+  local rc; rc="$(cat "$scan_report")"
+  assert_contains "$label: grade"  "$rc" "\"grade\":\"$expected_grade\""
+  assert_contains "$label: score"  "$rc" "\"score\":$expected_score"
+}
+
+_check_grade "grade A (95/100)"   95  100 A 95
+_check_grade "grade B (85/100)"   85  100 B 85
+_check_grade "grade C (75/100)"   75  100 C 75
+_check_grade "grade D (65/100)"   65  100 D 65
+_check_grade "grade F (40/100)"   40  100 F 40
+
+# ==============================================================================
+# Summary
+# ==============================================================================
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+exit "$TEST_FAILED"

--- a/scanner/tests/test_prowler_dashboard_summary.sh
+++ b/scanner/tests/test_prowler_dashboard_summary.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Unit tests for output.sh::_prowler_dashboard_summary()
+# Run: bash scanner/tests/test_prowler_dashboard_summary.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected NOT to contain: $needle"
+    ((TEST_FAILED++))
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+RED="" YELLOW="" CYAN="" GREEN="" DIM="" NC="" BOLD="" BLUE="" MAGENTA=""
+
+FORMAT="text"
+QUIET=1
+SEVERITY="low"
+VERSION="test"
+SCAN_DIR="$tmpdir"
+
+source "$LIB_DIR/output.sh" 2>/dev/null || true
+
+should_report() { return 0; }
+
+# ==============================================================================
+# Test Group 1: no prowler directory → returns 0 with no output
+# ==============================================================================
+echo ""
+echo "=== _prowler_dashboard_summary() — missing directory ==="
+
+out="$(_prowler_dashboard_summary)"
+assert_eq "missing dir: returns empty output" "" "$out"
+
+# ==============================================================================
+# Test Group 2: empty prowler directory → returns 0 with no output
+# ==============================================================================
+echo ""
+echo "=== _prowler_dashboard_summary() — empty directory ==="
+
+prowler_dir="$tmpdir/.claudesec-prowler"
+mkdir -p "$prowler_dir"
+
+out="$(_prowler_dashboard_summary)"
+assert_eq "empty dir: returns empty output" "" "$out"
+
+# ==============================================================================
+# Test Group 3: single AWS provider file with mixed severity findings
+# ==============================================================================
+echo ""
+echo "=== _prowler_dashboard_summary() — AWS provider ==="
+
+# Fixture: 1 Critical FAIL, 2 High FAIL, 1 Medium FAIL, 1 Low FAIL, 1 PASS (ignored)
+# Format follows what the function greps/awks for: "severity": "X" and "status_code": "FAIL"
+cat > "$prowler_dir/prowler-aws.ocsf.json" <<'AWSEOF'
+{"finding_info":{"title":"f1"},"severity": "Critical","status_code": "FAIL"}
+{"finding_info":{"title":"f2"},"severity": "High","status_code": "FAIL"}
+{"finding_info":{"title":"f3"},"severity": "High","status_code": "FAIL"}
+{"finding_info":{"title":"f4"},"severity": "Medium","status_code": "FAIL"}
+{"finding_info":{"title":"f5"},"severity": "Low","status_code": "FAIL"}
+{"finding_info":{"title":"f6"},"severity": "High","status_code": "PASS"}
+AWSEOF
+
+out="$(_prowler_dashboard_summary)"
+
+# Outer wrapper markers
+assert_contains "aws: wrapper div class"       "$out" "class=\"findings prowler-report\""
+assert_contains "aws: header emoji+text"       "$out" "Prowler 클라우드 리포트"
+assert_contains "aws: provider column header"  "$out" "프로바이더"
+assert_contains "aws: critical column header"  "$out" "치명적"
+
+# Provider label transformation: aws → AWS
+assert_contains "aws: label 'AWS'"             "$out" ">AWS<"
+
+# Severity counts (5 FAILs total; 1C, 2H, 1M, 1L)
+assert_contains "aws: total FAIL=5"            "$out" ">5<"
+# Critical cell color marker + value
+assert_contains "aws: critical cell color"     "$out" "color:#dc2626"
+assert_contains "aws: high cell color"         "$out" "color:#ef4444"
+assert_contains "aws: medium cell color"       "$out" "color:#eab308"
+
+# Footer note references the artifact path
+assert_contains "aws: footer artifact hint"    "$out" ".claudesec-prowler/prowler-*.ocsf.json"
+assert_contains "aws: footer rerun command"    "$out" "claudesec scan -c prowler"
+
+# ==============================================================================
+# Test Group 4: multiple providers — labels & ordering
+# ==============================================================================
+echo ""
+echo "=== _prowler_dashboard_summary() — multiple providers ==="
+
+# Add kubernetes and github provider files
+cat > "$prowler_dir/prowler-kubernetes.ocsf.json" <<'KUBEEOF'
+{"severity": "High","status_code": "FAIL"}
+KUBEEOF
+
+cat > "$prowler_dir/prowler-github.ocsf.json" <<'GHEOF'
+{"severity": "Medium","status_code": "FAIL"}
+{"severity": "Medium","status_code": "FAIL"}
+GHEOF
+
+out="$(_prowler_dashboard_summary)"
+
+assert_contains "multi: AWS label"        "$out" ">AWS<"
+assert_contains "multi: Kubernetes label" "$out" ">Kubernetes<"
+assert_contains "multi: GitHub label"     "$out" ">GitHub<"
+
+# Each provider gets its own <tr> row
+rows=$(grep -c '<tr><td style="padding:0.5rem 0.75rem' <<< "$out" || true)
+assert_eq "multi: three provider rows rendered" "3" "$rows"
+
+# ==============================================================================
+# Test Group 5: unknown provider name falls through to raw name
+# ==============================================================================
+echo ""
+echo "=== _prowler_dashboard_summary() — unknown provider ==="
+
+# Start with a clean dir so only our unknown file is picked up
+rm -f "$prowler_dir"/prowler-*.ocsf.json
+
+cat > "$prowler_dir/prowler-madeupcloud.ocsf.json" <<'UEOF'
+{"severity": "Low","status_code": "FAIL"}
+UEOF
+
+out="$(_prowler_dashboard_summary)"
+assert_contains "unknown: raw provider name rendered" "$out" ">madeupcloud<"
+assert_contains "unknown: total=1"                    "$out" ">1<"
+
+# ==============================================================================
+# Summary
+# ==============================================================================
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+exit "$TEST_FAILED"


### PR DESCRIPTION
## Summary

Adds two bash fixture tests targeting previously-uncovered `scanner/lib/output.sh` functions, to lift observable bash coverage from the current 71.93% baseline (now CI-visible thanks to PR #120's path-discovery fix).

## Tests added

### `scanner/tests/test_generate_html_dashboard.sh` (36 assertions)

Exercises:
- `scan-report.json` serialization (counters, score, grade, findings array)
- Legacy HTML fallback path (via `LIB_DIR` redirect so `dashboard-gen.py` is absent, forcing the deterministic legacy branch)
- Internal `_id_to_category` branches: `IAM` → `access-control`, `NET` → `network`, `CICD` → `cicd`
- Internal `_emit_finding_json` with and without a `location` field
- All five grade thresholds (A/B/C/D/F) driven by score math

### `scanner/tests/test_prowler_dashboard_summary.sh` (19 assertions)

Exercises:
- Early-return: missing `.claudesec-prowler/` directory
- Early-return: empty directory (no `prowler-*.ocsf.json`)
- Happy path: severity tally via `grep` / `awk` over OCSF-style fixtures
- Provider label mapping (`aws` → `AWS`, `kubernetes` → `Kubernetes`, `github` → `GitHub`)
- Multi-provider row rendering
- Unknown-provider fallthrough (raw name retained)

## Design notes

- Pure bash + filesystem fixtures. No network, no Docker, no Python.
- Pattern matches `scanner/tests/test_output_functions.sh`: source the lib, invoke the function, assert on captured output with `[[ ... ]] || { echo FAIL; exit 1; }`.
- Fixtures are created in `mktemp -d` and cleaned up on exit.
- Compatible with the existing kcov `--include-pattern=checks.sh,output.sh,<testname>.sh` pattern in `.github/workflows/lint.yml` — no workflow change needed.

## Test plan

- [x] `bash scanner/tests/test_generate_html_dashboard.sh` → `36 passed, 0 failed`
- [x] `bash scanner/tests/test_prowler_dashboard_summary.sh` → `19 passed, 0 failed`
- [ ] CI `scanner-unit-tests` job continues to pass.
- [ ] CI `scanner-shell-coverage` log shows `Bash coverage (merged): <N>%` higher than 71.93%.

## Related

- Stacks on top of #120 (kcov path-discovery fix).
- Prepares the repo for a follow-up PR that promotes `scanner-shell-coverage` to a required gate with a threshold slightly below the new baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)