### PR TITLE
ci: enforce 50% bash coverage gate on scanner-shell-coverage

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -164,13 +164,6 @@ jobs:
     # the default apt repos.
     runs-on: ubuntu-latest
     needs: scanner-unit-tests
-    # Soft-gated: kcov v42 writes the merged report into a nested subdir
-    # (kcov-merged/, merged-kcov-output/) that the original summary step
-    # never located, so the real bash-coverage baseline is still unknown.
-    # This PR fixes discovery so the number surfaces in logs; a follow-up
-    # PR will drop continue-on-error and enforce a threshold once we have
-    # evidence of a real baseline.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Install kcov v42 from source
@@ -224,6 +217,32 @@ jobs:
             echo "Contents of kcov-out/merged/ (top two levels):"
             find kcov-out/merged -maxdepth 2 -print 2>/dev/null || true
           fi
+      - name: Enforce bash coverage threshold (>=50%)
+        run: |
+          # Re-run the same find-based discovery as the summary step so this
+          # gate is robust to kcov's nested merge subdir names.
+          cov_json=$(find kcov-out/merged -name coverage.json -print -quit 2>/dev/null || true)
+          if [ -z "$cov_json" ]; then
+            cov_json=$(find kcov-out -name coverage.json -print -quit 2>/dev/null || true)
+          fi
+          if [ -z "$cov_json" ] || [ ! -f "$cov_json" ]; then
+            echo "::error::No coverage.json found under kcov-out/; cannot enforce bash coverage threshold"
+            exit 1
+          fi
+          python3 - "$cov_json" <<'PY'
+          import json
+          import sys
+
+          threshold = 50.0
+          path = sys.argv[1]
+          with open(path) as fh:
+              data = json.load(fh)
+          pct = float(data.get("percent_covered", 0.0))
+          if pct < threshold:
+              print(f"::error::Bash coverage {pct:.2f}% is below required threshold {threshold:.1f}%")
+              sys.exit(1)
+          print(f"Bash coverage {pct:.2f}% meets threshold {threshold:.1f}%. Bash coverage threshold met.")
+          PY
       - name: Upload kcov merged report
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7
@@ -462,6 +481,7 @@ jobs:
       - pip-audit
       - shell-lint
       - scanner-unit-tests
+      - scanner-shell-coverage
       - dashboard-regression-check
       - pii-check
       - gitleaks


### PR DESCRIPTION
## Summary

Promotes `scanner-shell-coverage` from a soft-gated informational job to a required gate with a 50% merged bash coverage floor, and wires it into `lint-gate`'s `needs` list so the Lint check blocks PRs that regress bash coverage or break kcov discovery.

Stacks on #120 (merged), which fixed kcov v42's nested `coverage.json` path discovery. The first real measurement on main reported **71.93%** merged bash coverage, leaving ~22 points of headroom before the 50% floor — enough to absorb normal test churn without flakiness. The threshold can be raised in a follow-up once we have several runs of history.

## Changes

- `.github/workflows/lint.yml`:
  - Drop `continue-on-error: true` (and the soft-gate comment block) from `scanner-shell-coverage`.
  - Add a new step `Enforce bash coverage threshold (>=50%)` directly after `Print bash coverage summary`. It re-uses the same `find kcov-out/merged -name coverage.json -print -quit` discovery (with `find kcov-out -name coverage.json` fallback) as the summary step, then parses `percent_covered` in a `python3 - <<'PY' ... PY` heredoc and fails the job with a `::error::` annotation if the value is below `50.0`. Missing `coverage.json` also fails with a `::error::`.
  - Add `scanner-shell-coverage` to `lint-gate`'s `needs` list (between `scanner-unit-tests` and `dashboard-regression-check`).

## Why 50% now

- Baseline `71.93%` observed on main run 24700540488 (the first kcov v42 run after #120's path-discovery fix).
- 50% gives ~22 points of headroom — comfortable for a first real floor.
- User explicitly authorized a 50% gate for this PR. Once we have several clean runs of history, a follow-up PR can ratchet toward 60-65%.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"` succeeds — YAML parses.
- [x] Local dry-run of the enforce step's Python logic against fixture `coverage.json`:
  - `{"percent_covered": 71.93}` → `Bash coverage 71.93% meets threshold 50.0%. Bash coverage threshold met.` (exit 0)
  - `{"percent_covered": 40.0}` → `::error::Bash coverage 40.00% is below required threshold 50.0%` (exit 1)
  - Missing file → shell-level `[ ! -f "$cov_json" ]` guard emits `::error::No coverage.json found under kcov-out/; cannot enforce bash coverage threshold` (exit 1) before python runs.
- [ ] CI run on this PR produces a green `scanner-shell-coverage` job and a green `Lint` gate, with the enforce step logging `Bash coverage 71.XX% meets threshold 50.0%.`
- [ ] `lint-gate` (name: `Lint`) now lists `scanner-shell-coverage` among its dependencies in the workflow visualization.

## Rollback

Revert the single-file change to restore the soft-gated behavior; no data migrations or external state involved.

Stacks on: #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)