### PR TITLE
ci: raise bash coverage floor from 50% to 65%

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -217,7 +217,7 @@ jobs:
             echo "Contents of kcov-out/merged/ (top two levels):"
             find kcov-out/merged -maxdepth 2 -print 2>/dev/null || true
           fi
-      - name: Enforce bash coverage threshold (>=50%)
+      - name: Enforce bash coverage threshold (>=65%)
         run: |
           # Re-run the same find-based discovery as the summary step so this
           # gate is robust to kcov's nested merge subdir names.
@@ -233,7 +233,7 @@ jobs:
           import json
           import sys
 
-          threshold = 50.0
+          threshold = 65.0
           path = sys.argv[1]
           with open(path) as fh:
               data = json.load(fh)


### PR DESCRIPTION
## Summary

Step 1 of the bash-coverage ratchet plan: raise the `scanner-shell-coverage` enforcement threshold from **50% → 65%**.

## Evidence

- Main run 24700540488 (after PR #120 path fix): **71.93%**
- Main run 24701523866 (after PR #121 fixture tests + PR #123 gate): **76.38%**
- Two consecutive green main runs with coverage ≥70% satisfies the ratchet plan's stability gate.
- 76.38% at a 65% floor leaves ~11pt of headroom.

## Changes

- `.github/workflows/lint.yml:220` — step name `>=50%` → `>=65%`
- `.github/workflows/lint.yml:236` — `threshold = 50.0` → `threshold = 65.0`

No other changes. No file outside `.github/workflows/lint.yml` is touched.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"` passes.
- [x] Local dry-run with `percent_covered=76.38` → exit 0, prints `Bash coverage 76.38% meets threshold 65.0%.`
- [x] Local dry-run with `percent_covered=64.99` → exit 1, prints `::error::Bash coverage 64.99% is below required threshold 65.0%`
- [ ] CI run on this PR shows `scanner-shell-coverage: SUCCESS` with `Bash coverage 76.XX% meets threshold 65.0%.`

## Next steps

- Monitor 2 consecutive main runs at ≥70% coverage.
- Then open Step 2: raise floor 65% → 70%.
- Stop at 72% unless coverage is actively lifted by new fixture work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)