### PR TITLE
ci: raise bash coverage floor from 65% to 70%

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -217,7 +217,7 @@ jobs:
             echo "Contents of kcov-out/merged/ (top two levels):"
             find kcov-out/merged -maxdepth 2 -print 2>/dev/null || true
           fi
-      - name: Enforce bash coverage threshold (>=65%)
+      - name: Enforce bash coverage threshold (>=70%)
         run: |
           # Re-run the same find-based discovery as the summary step so this
           # gate is robust to kcov's nested merge subdir names.
@@ -233,7 +233,7 @@ jobs:
           import json
           import sys
 
-          threshold = 65.0
+          threshold = 70.0
           path = sys.argv[1]
           with open(path) as fh:
               data = json.load(fh)


### PR DESCRIPTION
## Summary

Step 2 of the bash-coverage ratchet plan: raise the `scanner-shell-coverage` enforcement threshold from **65% → 70%**.

## Evidence (unlock condition met)

Two consecutive main lint runs on the 65% floor observed at ≥73% bash coverage:

- Run [24755252996](https://github.com/Twodragon0/claudesec/actions/runs/24755252996) (after PR #124 merge, SHA `e43603b`): **76.38%**
- Run [24756798072](https://github.com/Twodragon0/claudesec/actions/runs/24756798072) (after PR #125 merge, SHA `6b442d9`): **76.38%**

76.38% at a 70% floor leaves ~6.4pt of headroom.

## Changes

- `.github/workflows/lint.yml:220` — step name `>=65%` → `>=70%`
- `.github/workflows/lint.yml:236` — `threshold = 65.0` → `threshold = 70.0`

No other changes.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"` passes.
- [x] Local dry-run with `percent_covered=76.38` → exit 0, prints `Bash coverage 76.38% meets threshold 70.0%.`
- [x] Local dry-run with `percent_covered=69.99` → exit 1, prints `::error::Bash coverage 69.99% is below required threshold 70.0%`
- [ ] CI run on this PR shows `scanner-shell-coverage: SUCCESS` with `Bash coverage 76.XX% meets threshold 70.0%.`

## Next steps

- Step 3 (final): 70% → 72%. Unlock condition: 2 consecutive clean main runs with coverage ≥75% on the 70% floor.
- Stop at 72% unless a future PR lifts coverage above 76% via new fixture work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)