### PR TITLE
ci: add public.cyber.mil to lychee exclude list (transient flake fix)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -465,6 +465,7 @@ jobs:
             --exclude 'securityscorecards.dev'
             --exclude 'in-toto.io'
             --exclude 'sigstore.dev'
+            --exclude 'public.cyber.mil'
             --exclude 'localhost'
             --accept '100..=599'
             --timeout 20


### PR DESCRIPTION
## Summary

Adds `public.cyber.mil` to the `lychee --exclude` list in `.github/workflows/lint.yml` to stop recurring transient link-check failures.

## Evidence

The DoD STIG download portal (`public.cyber.mil`) has produced `Network error: Connection reset by peer (os error 104)` failures on the `link-check` job in multiple recent main runs, e.g.:

- Run 24701523866 (main after #122 merge) — caused a `Lint` gate failure, required rerun.
- Run 24756798072 (main after #125 merge) — caused another `Lint` gate failure.

The URL is reachable from a browser; the server appears to throttle or drop connections from CI IP ranges. Continuing to include it as a checked link produces false negatives without any safety benefit.

## Changes

- `.github/workflows/lint.yml:468` — inserted `--exclude 'public.cyber.mil'` in the existing exclude list (alongside other flaky external hosts like `atlas.mitre.org`, `jamf.com`, etc.).

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"` passes.
- [ ] CI `link-check` and `Lint` jobs pass on this PR without touching public.cyber.mil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)