### PR TITLE
ci: raise bash coverage floor from 70% to 72% (final ratchet step)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -217,7 +217,7 @@ jobs:
             echo "Contents of kcov-out/merged/ (top two levels):"
             find kcov-out/merged -maxdepth 2 -print 2>/dev/null || true
           fi
-      - name: Enforce bash coverage threshold (>=70%)
+      - name: Enforce bash coverage threshold (>=72%)
         run: |
           # Re-run the same find-based discovery as the summary step so this
           # gate is robust to kcov's nested merge subdir names.
@@ -233,7 +233,7 @@ jobs:
           import json
           import sys
 
-          threshold = 70.0
+          threshold = 72.0
           path = sys.argv[1]
           with open(path) as fh:
               data = json.load(fh)


### PR DESCRIPTION
## Summary

Step 3 (final) of the bash-coverage ratchet plan: raise the `scanner-shell-coverage` enforcement threshold from **70% → 72%**.

## Evidence (unlock condition met)

Two consecutive main lint runs on the 70% floor observed at ≥75% bash coverage:

- Run [24758615740](https://github.com/Twodragon0/claudesec/actions/runs/24758615740) (after PR #126 merge, SHA `1abb222`): **76.38%**
- Run [24762887061](https://github.com/Twodragon0/claudesec/actions/runs/24762887061) (after PR #127 merge, SHA `ab43974`): **76.38%**

## Why this is the final step

Per the ratchet plan stop-rule: do not ratchet above `(observed baseline − 4pt)` without first lifting coverage via new fixture work.

- Observed baseline: **76.38%**
- Upper bound: 76.38 − 4.00 = **72.38%**
- This PR sets the floor to **72.0%**, landing just inside that boundary with ~4.38pt of headroom.

Any future ratchet beyond 72% requires a prior PR that adds fixture tests to lift the observed baseline meaningfully.

## Changes

- `.github/workflows/lint.yml:220` — step name `>=70%` → `>=72%`
- `.github/workflows/lint.yml:236` — `threshold = 70.0` → `threshold = 72.0`

No other changes.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/lint.yml'))"` passes.
- [x] Local dry-run with `percent_covered=76.38` → exit 0.
- [x] Local dry-run with `percent_covered=71.99` → exit 1.
- [ ] CI run on this PR shows `scanner-shell-coverage: SUCCESS` with `Bash coverage 76.XX% meets threshold 72.0%.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)