### PR TITLE
test: add fixture tests to lift bash coverage toward 85%

### DIFF
--- a/scanner/tests/test_aws_identity_sso.sh
+++ b/scanner/tests/test_aws_identity_sso.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC1091
+# Unit tests for AWS identity + SSO helpers in checks.sh.
+# Covers:
+#   - aws_identity_info()             (parses aws sts get-caller-identity JSON)
+#   - aws_sso_login_with_timeout()    (early-return branches; no real login)
+#   - aws_sso_ensure_login()          (CLAUDESEC_NONINTERACTIVE and non-TTY guards,
+#                                      plus missing-aws-CLI guard)
+#   - aws_sso_login_all_profiles()    (same guards; never triggers a real login)
+#
+# All AWS CLI invocations are stubbed via a throwaway PATH-prepended directory
+# so no network/browser/login ever happens.
+# Run: bash scanner/tests/test_aws_identity_sso.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    echo "    actual: $haystack"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_true() {
+  local label="$1" rc="$2"
+  if [[ "$rc" == "0" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label (rc=$rc)"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_false() {
+  local label="$1" rc="$2"
+  if [[ "$rc" != "0" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label (rc=$rc)"
+    ((TEST_FAILED++))
+  fi
+}
+
+# Color codes some helpers reference (silenced for test output)
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+
+source "$LIB_DIR/checks.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stub `aws` CLI via PATH so no real AWS calls ever happen.
+# Default stub: a dispatcher keyed off $AWS_STUB_MODE.
+#   sts-ok      → sts get-caller-identity returns valid JSON
+#   sts-fail    → sts returns non-zero, empty output
+#   sso-ok      → sso login exits 0
+#   sso-fail    → sso login exits 1
+#   sso-timeout → sso login exits 124 (timeout)
+# ──────────────────────────────────────────────────────────────────────────────
+stub_dir="$tmpdir/bin"
+mkdir -p "$stub_dir"
+
+cat > "$stub_dir/aws" <<'STUB'
+#!/usr/bin/env bash
+mode="${AWS_STUB_MODE:-sts-fail}"
+# Flatten argv so we can pattern-match regardless of argument order
+args="$*"
+case "$args" in
+  *"sts get-caller-identity"*)
+    case "$mode" in
+      sts-ok)
+        cat <<JSON
+{
+  "UserId": "AIDAEXAMPLE:abc",
+  "Account": "123456789012",
+  "Arn": "arn:aws:iam::123456789012:user/test"
+}
+JSON
+        exit 0
+        ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  *"sso login"*)
+    case "$mode" in
+      sso-ok) exit 0 ;;
+      sso-timeout) exit 124 ;;
+      *) exit 1 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$stub_dir/aws"
+
+# Stub `timeout` to just exec its command so we can exercise the
+# has_command timeout branch of aws_sso_login_with_timeout deterministically.
+cat > "$stub_dir/timeout" <<'STUB'
+#!/usr/bin/env bash
+# timeout <secs> <cmd> [args...] → drop the secs arg and run the rest.
+shift
+"$@"
+STUB
+chmod +x "$stub_dir/timeout"
+
+# Put stubs first on PATH so has_command/run_with_timeout pick them up.
+export PATH="$stub_dir:$PATH"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# aws_identity_info()
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== aws_identity_info() ==="
+
+# 1. Happy path: valid JSON parsed into "account|arn"
+export AWS_STUB_MODE="sts-ok"
+info=$(aws_identity_info)
+assert_eq       "aws_identity_info: account field"  "123456789012" "$(echo "$info" | cut -d'|' -f1)"
+assert_contains "aws_identity_info: arn field"      "$info"         "arn:aws:iam::123456789012:user/test"
+assert_contains "aws_identity_info: pipe delimiter" "$info"         "|"
+
+# 2. Failure path: sts returns non-zero → fallback "unknown|unknown"
+export AWS_STUB_MODE="sts-fail"
+info_fail=$(aws_identity_info)
+assert_eq "aws_identity_info: fallback account" "unknown" "$(echo "$info_fail" | cut -d'|' -f1)"
+assert_eq "aws_identity_info: fallback arn"     "unknown" "$(echo "$info_fail" | cut -d'|' -f2)"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# aws_sso_login_with_timeout()
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== aws_sso_login_with_timeout() ==="
+
+# 1. Empty profile → returns 1 without invoking aws
+aws_sso_login_with_timeout "" >/dev/null 2>&1
+assert_false "aws_sso_login_with_timeout: empty profile returns 1" "$?"
+
+# 2. Missing arg (defaults to "") → returns 1
+aws_sso_login_with_timeout >/dev/null 2>&1
+assert_false "aws_sso_login_with_timeout: missing arg returns 1" "$?"
+
+# 3. Success path with stubbed timeout + aws
+export AWS_STUB_MODE="sso-ok"
+aws_sso_login_with_timeout "dev" >/dev/null 2>&1
+assert_true "aws_sso_login_with_timeout: sso-ok returns 0" "$?"
+
+# 4. Failure path (non-timeout)
+export AWS_STUB_MODE="sso-fail"
+aws_sso_login_with_timeout "dev" >/dev/null 2>&1
+assert_false "aws_sso_login_with_timeout: sso-fail returns nonzero" "$?"
+
+# 5. Timeout path (rc=124 passes through)
+export AWS_STUB_MODE="sso-timeout"
+aws_sso_login_with_timeout "dev" >/dev/null 2>&1
+assert_eq "aws_sso_login_with_timeout: preserves rc=124" "124" "$?"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# aws_sso_ensure_login() — guard branches only (never actually logs in)
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== aws_sso_ensure_login() ==="
+
+# 1. Non-interactive mode → early return 1, no aws calls attempted
+export CLAUDESEC_NONINTERACTIVE=1
+aws_sso_ensure_login </dev/null >/dev/null 2>&1
+assert_false "aws_sso_ensure_login: CLAUDESEC_NONINTERACTIVE=1 returns 1" "$?"
+unset CLAUDESEC_NONINTERACTIVE
+
+# 2. Missing aws CLI branch: simulate by pointing PATH at an empty dir
+orig_path="$PATH"
+empty_dir="$tmpdir/empty_path"
+mkdir -p "$empty_dir"
+PATH="$empty_dir"
+aws_sso_ensure_login </dev/null >/dev/null 2>&1
+assert_false "aws_sso_ensure_login: no aws CLI returns 1" "$?"
+PATH="$orig_path"
+
+# 3. Non-TTY branch (stdin is a file, not a tty): CLAUDESEC_NONINTERACTIVE
+#    must be unset and aws CLI must be on PATH to reach the non-TTY guard.
+export AWS_STUB_MODE="sts-fail"
+unset CLAUDESEC_NONINTERACTIVE
+out=$(aws_sso_ensure_login </dev/null 2>&1)
+rc=$?
+assert_false "aws_sso_ensure_login: non-TTY returns nonzero" "$rc"
+assert_contains "aws_sso_ensure_login: non-TTY prints hint" "$out" "interactive terminal"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# aws_sso_login_all_profiles() — guard branches
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== aws_sso_login_all_profiles() ==="
+
+# 1. CLAUDESEC_NONINTERACTIVE=1 blocks even with aws present
+export CLAUDESEC_NONINTERACTIVE=1
+aws_sso_login_all_profiles </dev/null >/dev/null 2>&1
+assert_false "aws_sso_login_all_profiles: NONINTERACTIVE blocks" "$?"
+unset CLAUDESEC_NONINTERACTIVE
+
+# 2. Non-TTY with no sso profiles → returns 1 after printing hint
+out2=$(aws_sso_login_all_profiles </dev/null 2>&1)
+rc2=$?
+assert_false "aws_sso_login_all_profiles: non-TTY returns 1" "$rc2"
+assert_contains "aws_sso_login_all_profiles: non-TTY prints hint" "$out2" "interactive terminal"
+
+# 3. No aws CLI on PATH → returns 1 before other guards
+PATH="$empty_dir"
+aws_sso_login_all_profiles </dev/null >/dev/null 2>&1
+assert_false "aws_sso_login_all_profiles: no aws CLI returns 1" "$?"
+PATH="$orig_path"
+
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1

--- a/scanner/tests/test_aws_identity_sso.sh
+++ b/scanner/tests/test_aws_identity_sso.sh
@@ -99,8 +99,8 @@ case "$args" in
         cat <<JSON
 {
   "UserId": "AIDAEXAMPLE:abc",
-  "Account": "123456789012",
-  "Arn": "arn:aws:iam::123456789012:user/test"
+  "Account": "FIXTURE-ACCT-01",
+  "Arn": "arn:aws:iam::FIXTURE-ACCT-01:user/test"
 }
 JSON
         exit 0
@@ -142,8 +142,8 @@ echo "=== aws_identity_info() ==="
 # 1. Happy path: valid JSON parsed into "account|arn"
 export AWS_STUB_MODE="sts-ok"
 info=$(aws_identity_info)
-assert_eq       "aws_identity_info: account field"  "123456789012" "$(echo "$info" | cut -d'|' -f1)"
-assert_contains "aws_identity_info: arn field"      "$info"         "arn:aws:iam::123456789012:user/test"
+assert_eq       "aws_identity_info: account field"  "FIXTURE-ACCT-01" "$(echo "$info" | cut -d'|' -f1)"
+assert_contains "aws_identity_info: arn field"      "$info"         "arn:aws:iam::FIXTURE-ACCT-01:user/test"
 assert_contains "aws_identity_info: pipe delimiter" "$info"         "|"
 
 # 2. Failure path: sts returns non-zero → fallback "unknown|unknown"

--- a/scanner/tests/test_collect_environment_info.sh
+++ b/scanner/tests/test_collect_environment_info.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC1091
+# Unit tests for checks.sh::collect_environment_info().
+# Focus: the many env-var branches (M365, GWS, Cloudflare, NHN, LLM, Datadog,
+# GitHub, Okta, identifier toggle, Kubernetes/AWS/GCP/Azure "connected" flags).
+# No external CLI is ever invoked: kubectl/aws/az/gcloud/promptfoo/curl are all
+# stubbed via a throwaway PATH-prepended directory.
+# Run: bash scanner/tests/test_collect_environment_info.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+# Color codes referenced by sourced lib
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+
+source "$LIB_DIR/checks.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stubs for every CLI collect_environment_info() can reach. All stubs exit 1
+# so the "not connected" branches are exercised by default. Individual tests
+# toggle behaviour by swapping in replacements.
+# ──────────────────────────────────────────────────────────────────────────────
+stub_dir="$tmpdir/bin"
+mkdir -p "$stub_dir"
+
+make_stub_fail() {
+  cat > "$stub_dir/$1" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$stub_dir/$1"
+}
+
+make_stub_ok() {
+  cat > "$stub_dir/$1" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$stub_dir/$1"
+}
+
+for tool in kubectl aws az gcloud curl gh; do
+  make_stub_fail "$tool"
+done
+# promptfoo is intentionally NOT created so has_command promptfoo returns false
+# by default; individual tests create/remove it to flip the LLM branch.
+
+# `timeout` passthrough so run_with_timeout doesn't swallow stubs
+cat > "$stub_dir/timeout" <<'STUB'
+#!/usr/bin/env bash
+shift
+"$@"
+STUB
+chmod +x "$stub_dir/timeout"
+
+export PATH="$stub_dir:$PATH"
+
+# Helper: clear every CLAUDESEC_ENV_* export between scenarios
+reset_env_vars() {
+  while IFS= read -r var; do
+    unset "$var"
+  done < <(env | grep -oE '^CLAUDESEC_ENV_[A-Z0-9_]+' | sort -u)
+  # Also reset inputs
+  unset CLAUDESEC_DASHBOARD_SHOW_IDENTIFIERS
+  unset AZURE_CLIENT_ID AZURE_TENANT_ID AZURE_CLIENT_SECRET
+  unset GOOGLE_WORKSPACE_CUSTOMER_ID GOOGLE_APPLICATION_CREDENTIALS
+  unset CLOUDFLARE_API_TOKEN CF_API_TOKEN CLOUDFLARE_API_KEY CLOUDFLARE_API_EMAIL
+  unset OS_AUTH_URL NHN_API_URL
+  unset OPENAI_API_KEY ANTHROPIC_API_KEY
+  unset DD_API_KEY DATADOG_API_KEY
+  unset GH_TOKEN GITHUB_TOKEN
+  unset OKTA_API_TOKEN OKTA_OAUTH_TOKEN
+  unset AWS_PROFILE AWS_DEFAULT_PROFILE
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 1: everything disconnected (all stubs fail, no env creds)
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 1: fully disconnected ==="
+
+reset_env_vars
+collect_environment_info >/dev/null 2>&1 || true
+
+assert_eq "s1: SHOW_IDENTIFIERS default false" "false" "${CLAUDESEC_ENV_SHOW_IDENTIFIERS:-}"
+assert_eq "s1: K8S_CONNECTED false"            "false" "${CLAUDESEC_ENV_K8S_CONNECTED:-}"
+assert_eq "s1: AWS_CONNECTED false"            "false" "${CLAUDESEC_ENV_AWS_CONNECTED:-}"
+assert_eq "s1: AWS_SSO_CONFIGURED false"       "false" "${CLAUDESEC_ENV_AWS_SSO_CONFIGURED:-}"
+assert_eq "s1: GCP_CONNECTED false"            "false" "${CLAUDESEC_ENV_GCP_CONNECTED:-}"
+assert_eq "s1: AZ_CONNECTED false"             "false" "${CLAUDESEC_ENV_AZ_CONNECTED:-}"
+assert_eq "s1: M365_CONNECTED false"           "false" "${CLAUDESEC_ENV_M365_CONNECTED:-}"
+assert_eq "s1: GWS_CONNECTED false"            "false" "${CLAUDESEC_ENV_GWS_CONNECTED:-}"
+assert_eq "s1: CF_CONNECTED false"             "false" "${CLAUDESEC_ENV_CF_CONNECTED:-}"
+assert_eq "s1: NHN_CONNECTED false"            "false" "${CLAUDESEC_ENV_NHN_CONNECTED:-}"
+assert_eq "s1: LLM_CONNECTED false"            "false" "${CLAUDESEC_ENV_LLM_CONNECTED:-}"
+assert_eq "s1: DATADOG_CONNECTED false"        "false" "${CLAUDESEC_ENV_DATADOG_CONNECTED:-}"
+assert_eq "s1: GITHUB_CONNECTED false"         "false" "${CLAUDESEC_ENV_GITHUB_CONNECTED:-}"
+assert_eq "s1: OKTA_CONNECTED false"           "false" "${CLAUDESEC_ENV_OKTA_CONNECTED:-}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 2: SHOW_IDENTIFIERS=1 opt-in
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 2: SHOW_IDENTIFIERS toggle ==="
+
+reset_env_vars
+export CLAUDESEC_DASHBOARD_SHOW_IDENTIFIERS=1
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s2: SHOW_IDENTIFIERS true" "true" "${CLAUDESEC_ENV_SHOW_IDENTIFIERS:-}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 3: M365 via service-principal env vars only (no az CLI needed)
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 3: M365 via SP env vars ==="
+
+reset_env_vars
+export AZURE_CLIENT_ID="cid"
+export AZURE_TENANT_ID="tid"
+export AZURE_CLIENT_SECRET="sec"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s3: M365_CONNECTED true"  "true"  "${CLAUDESEC_ENV_M365_CONNECTED:-}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 4: Google Workspace via customer id + ADC file
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 4: Google Workspace ==="
+
+reset_env_vars
+export GOOGLE_WORKSPACE_CUSTOMER_ID="C01abcd"
+export GOOGLE_APPLICATION_CREDENTIALS="$tmpdir/adc.json"
+echo '{}' > "$GOOGLE_APPLICATION_CREDENTIALS"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s4: GWS_CONNECTED true"          "true"      "${CLAUDESEC_ENV_GWS_CONNECTED:-}"
+# GCP is also "connected" through ADC
+assert_eq "s4: GCP_CONNECTED true (via ADC)" "true"     "${CLAUDESEC_ENV_GCP_CONNECTED:-}"
+# GWS_CUSTOMER_ID only exported when SHOW_IDENTIFIERS=true
+assert_eq "s4: GWS_CUSTOMER_ID hidden"      ""          "${CLAUDESEC_ENV_GWS_CUSTOMER_ID:-}"
+
+reset_env_vars
+export GOOGLE_WORKSPACE_CUSTOMER_ID="C01abcd"
+export GOOGLE_APPLICATION_CREDENTIALS="$tmpdir/adc.json"
+export CLAUDESEC_DASHBOARD_SHOW_IDENTIFIERS=1
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s4b: GWS_CUSTOMER_ID shown when opted in" "C01abcd" "${CLAUDESEC_ENV_GWS_CUSTOMER_ID:-}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 5: Cloudflare — token form
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 5: Cloudflare ==="
+
+reset_env_vars
+export CLOUDFLARE_API_TOKEN="cf-token-xyz"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s5a: CF_CONNECTED via CLOUDFLARE_API_TOKEN" "true" "${CLAUDESEC_ENV_CF_CONNECTED:-}"
+
+# Legacy key + email form
+reset_env_vars
+export CLOUDFLARE_API_KEY="legacy-key"
+export CLOUDFLARE_API_EMAIL="user@example.com"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s5b: CF_CONNECTED via key+email" "true" "${CLAUDESEC_ENV_CF_CONNECTED:-}"
+
+# CF_API_TOKEN alias
+reset_env_vars
+export CF_API_TOKEN="alt-token"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s5c: CF_CONNECTED via CF_API_TOKEN" "true" "${CLAUDESEC_ENV_CF_CONNECTED:-}"
+
+# Key without email → NOT connected
+reset_env_vars
+export CLOUDFLARE_API_KEY="legacy-key"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s5d: CF_CONNECTED false (key but no email)" "false" "${CLAUDESEC_ENV_CF_CONNECTED:-}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 6: NHN Cloud via OS_AUTH_URL pattern / NHN_API_URL
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 6: NHN Cloud ==="
+
+reset_env_vars
+export OS_AUTH_URL="https://api-identity.infrastructure.nhncloud.com/v2.0/"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s6a: NHN via nhncloud URL" "true" "${CLAUDESEC_ENV_NHN_CONNECTED:-}"
+
+reset_env_vars
+export OS_AUTH_URL="https://identity.toastcloud.example/v3"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s6b: NHN via toast URL" "true" "${CLAUDESEC_ENV_NHN_CONNECTED:-}"
+
+reset_env_vars
+export NHN_API_URL="https://nhn-api.example"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s6c: NHN via NHN_API_URL" "true" "${CLAUDESEC_ENV_NHN_CONNECTED:-}"
+
+reset_env_vars
+export OS_AUTH_URL="https://unrelated.example/v3"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s6d: NHN false for unrelated URL" "false" "${CLAUDESEC_ENV_NHN_CONNECTED:-}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 7: LLM (requires promptfoo on PATH + OpenAI/Anthropic key)
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 7: LLM ==="
+
+reset_env_vars
+# Without promptfoo on PATH → not connected even with key
+export OPENAI_API_KEY="sk-test"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s7a: LLM false (no promptfoo)" "false" "${CLAUDESEC_ENV_LLM_CONNECTED:-}"
+
+# Promote promptfoo stub to success + provide key → connected
+make_stub_ok promptfoo
+reset_env_vars
+export ANTHROPIC_API_KEY="sk-ant"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s7b: LLM true (promptfoo + ANTHROPIC_API_KEY)" "true" "${CLAUDESEC_ENV_LLM_CONNECTED:-}"
+
+# Promptfoo present but no API key → not connected
+reset_env_vars
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s7c: LLM false (promptfoo but no key)" "false" "${CLAUDESEC_ENV_LLM_CONNECTED:-}"
+
+# Remove promptfoo stub so has_command returns false in later scenarios
+rm -f "$stub_dir/promptfoo"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 8: Datadog — key present but curl stub fails validation
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 8: Datadog ==="
+
+reset_env_vars
+export DD_API_KEY="dd-test"
+collect_environment_info >/dev/null 2>&1 || true
+# Function sets DATADOG_CONNECTED=true whether validation passes or not
+# (comment in source: "Key present but validation failed"). Both branches
+# set "true".
+assert_eq "s8a: DATADOG_CONNECTED true (DD_API_KEY)" "true" "${CLAUDESEC_ENV_DATADOG_CONNECTED:-}"
+
+reset_env_vars
+export DATADOG_API_KEY="dd-test"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s8b: DATADOG_CONNECTED true (DATADOG_API_KEY)" "true" "${CLAUDESEC_ENV_DATADOG_CONNECTED:-}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 9: GitHub + Okta credentials via env
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 9: GitHub + Okta ==="
+
+reset_env_vars
+export GITHUB_TOKEN="ghp_test"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s9a: GITHUB_CONNECTED true" "true" "${CLAUDESEC_ENV_GITHUB_CONNECTED:-}"
+
+reset_env_vars
+export GH_TOKEN="ghp_test"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s9b: GITHUB_CONNECTED true (GH_TOKEN)" "true" "${CLAUDESEC_ENV_GITHUB_CONNECTED:-}"
+
+reset_env_vars
+export OKTA_API_TOKEN="okta-tok"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s9c: OKTA_CONNECTED true" "true" "${CLAUDESEC_ENV_OKTA_CONNECTED:-}"
+
+reset_env_vars
+export OKTA_OAUTH_TOKEN="okta-oauth"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s9d: OKTA_CONNECTED true (OAUTH)" "true" "${CLAUDESEC_ENV_OKTA_CONNECTED:-}"
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scenario 10: AWS_SSO_CONFIGURED flag when profile is SSO
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Scenario 10: AWS SSO configured flag ==="
+
+reset_env_vars
+# Build a fake ~/.aws/config pointing at an SSO profile
+aws_dir="$tmpdir/aws"
+mkdir -p "$aws_dir"
+cat > "$aws_dir/config" <<CFG
+[profile ssoprof]
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_role_name = Engineer
+CFG
+export AWS_CONFIG_FILE="$aws_dir/config"
+export AWS_PROFILE="ssoprof"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s10a: AWS_SSO_CONFIGURED=true for SSO profile" "true" "${CLAUDESEC_ENV_AWS_SSO_CONFIGURED:-}"
+# Since aws CLI stub fails, AWS is NOT "connected" → SSO_SESSION reports "expired"
+assert_eq "s10b: AWS_SSO_SESSION=expired"                  "expired" "${CLAUDESEC_ENV_AWS_SSO_SESSION:-}"
+
+# Non-SSO profile → SSO_CONFIGURED=false, SSO_SESSION=unknown
+reset_env_vars
+cat > "$aws_dir/config" <<CFG
+[profile keyonly]
+region = us-east-1
+CFG
+export AWS_CONFIG_FILE="$aws_dir/config"
+export AWS_PROFILE="keyonly"
+collect_environment_info >/dev/null 2>&1 || true
+assert_eq "s10c: AWS_SSO_CONFIGURED=false for non-SSO" "false"   "${CLAUDESEC_ENV_AWS_SSO_CONFIGURED:-}"
+assert_eq "s10d: AWS_SSO_SESSION=unknown"              "unknown" "${CLAUDESEC_ENV_AWS_SSO_SESSION:-}"
+
+unset AWS_CONFIG_FILE AWS_PROFILE
+
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1

--- a/scanner/tests/test_kubectl_cluster_query.sh
+++ b/scanner/tests/test_kubectl_cluster_query.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC1091
+# Unit tests for kubectl cluster query helpers in checks.sh.
+# Covers:
+#   - kubectl_cluster_info()    (returns "context|server" using kubectl config)
+#   - kubectl_server_version()  (parses kubectl version -o json gitVersion)
+#
+# No real kubectl is ever invoked. A throwaway PATH-prepended stub kubectl
+# replays canned responses based on which subcommand is called.
+# Run: bash scanner/tests/test_kubectl_cluster_query.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected to contain: $needle"
+    echo "    actual: $haystack"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected NOT to contain: $needle"
+    echo "    actual: $haystack"
+    ((TEST_FAILED++))
+  fi
+}
+
+# Color codes some helpers reference (silenced for test output)
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+
+source "$LIB_DIR/checks.sh"
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stub `kubectl` via PATH. Behaviour keyed off KCTL_STUB_MODE:
+#   normal    → current-context=prod, server=https://kube.example/, v1.29.2
+#   empty-ctx → current-context empty, server missing (parsing fallbacks)
+#   fail      → all subcommands exit non-zero (triggers || true fallbacks)
+#   badjson   → version emits non-parseable output (triggers "unknown" fallback)
+# ──────────────────────────────────────────────────────────────────────────────
+stub_dir="$tmpdir/bin"
+mkdir -p "$stub_dir"
+
+cat > "$stub_dir/kubectl" <<'STUB'
+#!/usr/bin/env bash
+mode="${KCTL_STUB_MODE:-normal}"
+args="$*"
+
+case "$args" in
+  *"config current-context"*)
+    case "$mode" in
+      normal)   echo "prod-cluster" ;;
+      empty-ctx) echo "" ;;
+      fail)     exit 1 ;;
+      badjson)  echo "prod-cluster" ;;
+      *) echo "" ;;
+    esac
+    ;;
+  *"config view --minify"*)
+    case "$mode" in
+      normal)   echo "https://kube.example.com:6443" ;;
+      empty-ctx) echo "" ;;
+      fail)     exit 1 ;;
+      badjson)  echo "https://kube.example.com:6443" ;;
+      *) echo "" ;;
+    esac
+    ;;
+  *"version"*)
+    case "$mode" in
+      normal|empty-ctx)
+        # Compact form matches checks.sh grep pattern '"gitVersion":"[^"]*"'
+        echo '{"serverVersion":{"gitVersion":"v1.29.2","gitCommit":"abc1234"}}'
+        ;;
+      fail)    exit 1 ;;
+      badjson) echo "not json" ;;
+      *) echo "" ;;
+    esac
+    ;;
+  *"cluster-info"*)
+    case "$mode" in
+      normal) echo "Kubernetes control plane is running"; exit 0 ;;
+      fail)   exit 1 ;;
+      *)      exit 0 ;;
+    esac
+    ;;
+  *) exit 0 ;;
+esac
+STUB
+chmod +x "$stub_dir/kubectl"
+
+# `timeout` passthrough so run_with_timeout picks our stubbed kubectl.
+cat > "$stub_dir/timeout" <<'STUB'
+#!/usr/bin/env bash
+shift
+"$@"
+STUB
+chmod +x "$stub_dir/timeout"
+
+export PATH="$stub_dir:$PATH"
+
+# Clear kube-related overrides between tests
+unset KUBECONFIG CLAUDESEC_KUBECONTEXT || true
+
+# ──────────────────────────────────────────────────────────────────────────────
+# kubectl_cluster_info()
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== kubectl_cluster_info() ==="
+
+# 1. Normal: "ctx|server"
+export KCTL_STUB_MODE="normal"
+info=$(kubectl_cluster_info)
+assert_eq       "kubectl_cluster_info: context"    "prod-cluster"                 "$(echo "$info" | cut -d'|' -f1)"
+assert_eq       "kubectl_cluster_info: server"     "https://kube.example.com:6443" "$(echo "$info" | cut -d'|' -f2)"
+assert_contains "kubectl_cluster_info: pipe"        "$info" "|"
+
+# 2. Empty context / server → "unknown|unknown" fallback
+export KCTL_STUB_MODE="empty-ctx"
+info_empty=$(kubectl_cluster_info)
+assert_eq "kubectl_cluster_info: empty ctx fallback"    "unknown" "$(echo "$info_empty" | cut -d'|' -f1)"
+assert_eq "kubectl_cluster_info: empty server fallback" "unknown" "$(echo "$info_empty" | cut -d'|' -f2)"
+
+# 3. Command failure → still "unknown|unknown"
+export KCTL_STUB_MODE="fail"
+info_fail=$(kubectl_cluster_info)
+assert_eq "kubectl_cluster_info: fail ctx"    "unknown" "$(echo "$info_fail" | cut -d'|' -f1)"
+assert_eq "kubectl_cluster_info: fail server" "unknown" "$(echo "$info_fail" | cut -d'|' -f2)"
+
+# 4. With KUBECONFIG override, _kubectl_cmd builds args that our stub ignores;
+#    the function should still produce "ctx|server" from the stub.
+export KUBECONFIG="$tmpdir/fake_kubeconfig"
+: > "$KUBECONFIG"
+export KCTL_STUB_MODE="normal"
+info_kcfg=$(kubectl_cluster_info)
+assert_contains "kubectl_cluster_info: KUBECONFIG still returns pipe" "$info_kcfg" "|"
+assert_eq       "kubectl_cluster_info: KUBECONFIG ctx"                "prod-cluster" "$(echo "$info_kcfg" | cut -d'|' -f1)"
+unset KUBECONFIG
+
+# 5. With CLAUDESEC_KUBECONTEXT override — kubectl_current_context honours
+#    this env var directly and short-circuits the stubbed kubectl call.
+export CLAUDESEC_KUBECONTEXT="custom-ctx"
+info_ctx=$(kubectl_cluster_info)
+assert_eq "kubectl_cluster_info: CLAUDESEC_KUBECONTEXT ctx" "custom-ctx" "$(echo "$info_ctx" | cut -d'|' -f1)"
+unset CLAUDESEC_KUBECONTEXT
+
+# ──────────────────────────────────────────────────────────────────────────────
+# kubectl_server_version()
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== kubectl_server_version() ==="
+
+# 1. Normal path parses gitVersion
+export KCTL_STUB_MODE="normal"
+ver=$(kubectl_server_version)
+assert_eq "kubectl_server_version: v1.29.2" "v1.29.2" "$ver"
+assert_not_contains "kubectl_server_version: no quotes" "$ver" '"'
+
+# 2. Command failure → "unknown"
+export KCTL_STUB_MODE="fail"
+ver_fail=$(kubectl_server_version)
+assert_eq "kubectl_server_version: fail returns unknown" "unknown" "$ver_fail"
+
+# 3. Malformed JSON → grep finds no gitVersion match; with pipefail active
+#    in the caller, the pipeline exits nonzero and the "|| echo unknown"
+#    fallback produces "unknown". Without pipefail, it prints empty. Either
+#    is an acceptable "no version" signal.
+export KCTL_STUB_MODE="badjson"
+ver_bad=$(kubectl_server_version)
+if [[ -z "$ver_bad" || "$ver_bad" == "unknown" ]]; then
+  echo "  PASS: kubectl_server_version: bad json no-version"
+  ((TEST_PASSED++))
+else
+  echo "  FAIL: kubectl_server_version: bad json no-version (got '$ver_bad')"
+  ((TEST_FAILED++))
+fi
+
+# 4. Works with KUBECONFIG override (same stub response)
+export KUBECONFIG="$tmpdir/fake_kubeconfig"
+export KCTL_STUB_MODE="normal"
+ver_kcfg=$(kubectl_server_version)
+assert_eq "kubectl_server_version: with KUBECONFIG" "v1.29.2" "$ver_kcfg"
+unset KUBECONFIG
+
+# ──────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Adds three new bash test files covering previously-untested helpers in `scanner/lib/checks.sh`. All tests are pure bash, fixture-driven, and stub every external CLI (aws, kubectl, az, gcloud, promptfoo, curl, gh, timeout) via a throwaway `PATH`-prepended directory — no network, no Docker, no real login flows.

## Target functions (scanner/lib/checks.sh)

| Function | Location | Reason safe to fixture-test |
| --- | --- | --- |
| `aws_identity_info` | `checks.sh:347` | Pure JSON text parsing of `aws sts get-caller-identity` output |
| `aws_sso_login_with_timeout` | `checks.sh:143` | Early-return + `timeout`/`aws` subprocess; fully stubbable |
| `aws_sso_ensure_login` | `checks.sh:253` | Guards (CLAUDESEC_NONINTERACTIVE, non-TTY, missing aws CLI) return early before any network I/O |
| `aws_sso_login_all_profiles` | `checks.sh:163` | Same guard pattern |
| `kubectl_cluster_info` | `checks.sh:742` | Delegates to `_kubectl_cmd` subshell; fallbacks on missing ctx/server |
| `kubectl_server_version` | `checks.sh:751` | Grep-based gitVersion extraction with `|| echo unknown` fallback |
| `collect_environment_info` | `checks.sh:760` | Pure env-var exporter; branches keyed off env vars (M365, GWS, Cloudflare, NHN, LLM, Datadog, GitHub, Okta) |

## Test files added

| File | Asserts | Covers |
| --- | --- | --- |
| `scanner/tests/test_aws_identity_sso.sh` | **18** | `aws_identity_info`, `aws_sso_login_with_timeout`, `aws_sso_ensure_login` + `aws_sso_login_all_profiles` guard branches |
| `scanner/tests/test_kubectl_cluster_query.sh` | **15** | `kubectl_cluster_info` (ctx\|server, KUBECONFIG + CLAUDESEC_KUBECONTEXT overrides, fallbacks), `kubectl_server_version` (gitVersion parse, unknown fallback, malformed JSON) |
| `scanner/tests/test_collect_environment_info.sh` | **41** | `collect_environment_info` across 10 scenarios: fully disconnected, SHOW_IDENTIFIERS toggle, M365 SP env vars, Google Workspace (+SHOW_IDENTIFIERS customer-id gate), Cloudflare (token / key+email / CF_API_TOKEN / partial), NHN Cloud (nhncloud URL / toast / NHN_API_URL / unrelated), LLM (promptfoo + key combos), Datadog (DD_API_KEY + DATADOG_API_KEY), GitHub + Okta env shapes, AWS SSO configured flag |

Total: **74 new assertions** across 3 files.

## CI integration (no workflow changes)

The `scanner-shell-coverage` job in `.github/workflows/lint.yml` already loops every `scanner/tests/test_*.sh` under kcov with
`--include-pattern=checks.sh,output.sh,$name.sh`, so each new test file is automatically merged into kcov coverage without any workflow edits.

## Notes

- **No ratchet in this PR.** The next ratchet window opens after the baseline rises to `>=80%`; this PR only lifts coverage.
- **No production code touched.** `scanner/lib/*.sh` is unchanged.
- **No workflow changes.** `.github/workflows/*.yml` untouched.

## Test plan

- [x] `bash scanner/tests/test_aws_identity_sso.sh` → 18 passed, 0 failed
- [x] `bash scanner/tests/test_kubectl_cluster_query.sh` → 15 passed, 0 failed
- [x] `bash scanner/tests/test_collect_environment_info.sh` → 41 passed, 0 failed
- [x] `shellcheck` on all three new files → exit 0
- [x] All 13 existing `scanner/tests/test_*.sh` → still pass (no regression)
- [ ] CI `scanner-shell-coverage` job picks up new files and produces higher merged coverage percentage
- [ ] Merged bash coverage rises above the `72.38%` baseline