### PR TITLE
ci: raise bash coverage floor from 72% to 78%

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -217,7 +217,7 @@ jobs:
             echo "Contents of kcov-out/merged/ (top two levels):"
             find kcov-out/merged -maxdepth 2 -print 2>/dev/null || true
           fi
-      - name: Enforce bash coverage threshold (>=72%)
+      - name: Enforce bash coverage threshold (>=78%)
         run: |
           # Re-run the same find-based discovery as the summary step so this
           # gate is robust to kcov's nested merge subdir names.
@@ -233,7 +233,7 @@ jobs:
           import json
           import sys
 
-          threshold = 72.0
+          threshold = 78.0
           path = sys.argv[1]
           with open(path) as fh:
               data = json.load(fh)


### PR DESCRIPTION
## Summary

Fourth floor ratchet following PR #131's coverage lift (76.38% → 82.69%). New floor 78% sits 0.69pt below the stop-rule ceiling (observed_baseline − 4pt = 78.69%).

## Evidence

- Post-#131 main run: `Bash coverage (merged): 82.69%`
- Headroom at 78% floor: 4.69pt

## Changes

- `.github/workflows/lint.yml` — step name `>=72%` → `>=78%`; `threshold = 72.0` → `threshold = 78.0`

## Test plan

- [x] YAML valid
- [x] Dry-run 82.69 passes, 77.99 fails
- [ ] CI `scanner-shell-coverage` shows `Bash coverage 82.XX% meets threshold 78.0%.`

## Next

No more ratcheting above 78% without first adding fixture tests to raise baseline above ~83%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)