### PR TITLE
refactor(output.sh): extract pure helpers and add targeted tests

### DIFF
--- a/scanner/lib/output.sh
+++ b/scanner/lib/output.sh
@@ -241,6 +241,43 @@ _print_findings() {
   done
 }
 
+# Map a numeric score (0-100) to a grade letter + color code pair ("grade color").
+# Pure: reads only the args and the color globals (which are constants after source).
+# Consumers parse the single-line "grade color" result with `read`.
+_print_summary_score_to_grade() {
+  local score="$1"
+  local grade_color="$RED" grade="F"
+  if [[ $score -ge 90 ]]; then grade="A"; grade_color="$GREEN"
+  elif [[ $score -ge 80 ]]; then grade="B"; grade_color="$GREEN"
+  elif [[ $score -ge 70 ]]; then grade="C"; grade_color="$YELLOW"
+  elif [[ $score -ge 60 ]]; then grade="D"; grade_color="$YELLOW"
+  fi
+  echo "$grade $grade_color"
+}
+
+# Render a unicode progress bar for a score (0-100) given a bar width.
+# Pure: deterministic string built from score + width.
+_print_summary_render_progress_bar() {
+  local score="$1" bar_width="$2"
+  local filled=$(( (score * bar_width) / 100 ))
+  local empty=$((bar_width - filled))
+  local bar=""
+  for ((i=0; i<filled; i++)); do bar+="█"; done
+  for ((i=0; i<empty; i++)); do bar+="░"; done
+  printf '%s' "$bar"
+}
+
+# Format a duration in seconds as "Xm Ys" (>=60s) or "Zs".
+# Pure: deterministic function of the single integer argument.
+_print_summary_format_duration() {
+  local duration="$1"
+  if [[ $duration -ge 60 ]]; then
+    echo "$((duration / 60))m $((duration % 60))s"
+  else
+    echo "${duration}s"
+  fi
+}
+
 print_summary() {
   local duration="$1"
 
@@ -251,12 +288,8 @@ print_summary() {
     score=$(( (PASSED * 100) / active ))
   fi
 
-  local grade_color="$RED" grade="F"
-  if [[ $score -ge 90 ]]; then grade="A"; grade_color="$GREEN"
-  elif [[ $score -ge 80 ]]; then grade="B"; grade_color="$GREEN"
-  elif [[ $score -ge 70 ]]; then grade="C"; grade_color="$YELLOW"
-  elif [[ $score -ge 60 ]]; then grade="D"; grade_color="$YELLOW"
-  fi
+  local grade_color grade
+  read -r grade grade_color <<< "$(_print_summary_score_to_grade "$score")"
 
   echo ""
   echo -e "${BOLD}╔══════════════════════════════════════════════════════════╗${NC}"
@@ -266,11 +299,8 @@ print_summary() {
 
   # Score + progress bar
   local bar_width=30
-  local filled=$(( (score * bar_width) / 100 ))
-  local empty=$((bar_width - filled))
-  local bar=""
-  for ((i=0; i<filled; i++)); do bar+="█"; done
-  for ((i=0; i<empty; i++)); do bar+="░"; done
+  local bar
+  bar="$(_print_summary_render_progress_bar "$score" "$bar_width")"
 
   echo -e "  ${BOLD}Security Score${NC}  ${grade_color}${BOLD}${score}${NC}/100  ${grade_color}${bar}${NC}  Grade: ${grade_color}${BOLD}${grade}${NC}"
   echo ""
@@ -327,11 +357,7 @@ print_summary() {
   fi
 
   local duration_str
-  if [[ $duration -ge 60 ]]; then
-    duration_str="$((duration / 60))m $((duration % 60))s"
-  else
-    duration_str="${duration}s"
-  fi
+  duration_str="$(_print_summary_format_duration "$duration")"
   echo -e "  ${DIM}Scanned in ${duration_str} · $(date '+%Y-%m-%d %H:%M:%S') · claudesec v${VERSION}${NC}"
   echo ""
 }
@@ -478,6 +504,30 @@ compute_trend() {
   export TREND_HAS_PREV="true"
 }
 
+# Map a prowler provider slug (from filename) to a human-readable label.
+# Pure: deterministic string → string mapping, no I/O.
+_prowler_dashboard_summary_provider_label() {
+  case "$1" in
+    aws) echo "AWS" ;;
+    kubernetes) echo "Kubernetes" ;;
+    azure) echo "Azure" ;;
+    gcp) echo "GCP" ;;
+    github) echo "GitHub" ;;
+    googleworkspace) echo "Google Workspace" ;;
+    m365) echo "Microsoft 365" ;;
+    cloudflare) echo "Cloudflare" ;;
+    nhn) echo "NHN Cloud" ;;
+    iac) echo "IaC" ;;
+    llm) echo "LLM" ;;
+    image) echo "Container Image" ;;
+    oraclecloud) echo "Oracle Cloud" ;;
+    alibabacloud) echo "Alibaba Cloud" ;;
+    openstack) echo "OpenStack" ;;
+    mongodbatlas) echo "MongoDB Atlas" ;;
+    *) echo "$1" ;;
+  esac
+}
+
 # Build Prowler report summary HTML from .claudesec-prowler/*.ocsf.json (for dashboard)
 _prowler_dashboard_summary() {
   local prowler_dir="${SCAN_DIR:-.}/.claudesec-prowler"
@@ -496,25 +546,7 @@ _prowler_dashboard_summary() {
     [[ -f "$f" ]] || continue
     local provider label total c h m l
     provider=$(basename "$f" .ocsf.json | sed 's/^prowler-//')
-    case "$provider" in
-      aws) label="AWS" ;;
-      kubernetes) label="Kubernetes" ;;
-      azure) label="Azure" ;;
-      gcp) label="GCP" ;;
-      github) label="GitHub" ;;
-      googleworkspace) label="Google Workspace" ;;
-      m365) label="Microsoft 365" ;;
-      cloudflare) label="Cloudflare" ;;
-      nhn) label="NHN Cloud" ;;
-      iac) label="IaC" ;;
-      llm) label="LLM" ;;
-      image) label="Container Image" ;;
-      oraclecloud) label="Oracle Cloud" ;;
-      alibabacloud) label="Alibaba Cloud" ;;
-      openstack) label="OpenStack" ;;
-      mongodbatlas) label="MongoDB Atlas" ;;
-      *) label="$provider" ;;
-    esac
+    label="$(_prowler_dashboard_summary_provider_label "$provider")"
     total=$(grep -c '"status_code": *"FAIL"' "$f" 2>/dev/null || echo 0)
     read -r c h m l <<< "$(awk '
       BEGIN { c=0; h=0; m=0; l=0 }

--- a/scanner/tests/test_print_summary_format_duration.sh
+++ b/scanner/tests/test_print_summary_format_duration.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Unit tests for output.sh::_print_summary_format_duration()
+# Extracted pure helper: formats integer seconds as "Xm Ys" (>=60) or "Zs".
+# Run: bash scanner/tests/test_print_summary_format_duration.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+RED="" YELLOW="" CYAN="" GREEN="" DIM="" NC="" BOLD="" BLUE="" MAGENTA=""
+FORMAT="text"
+QUIET=1
+SEVERITY="low"
+VERSION="test"
+SCAN_DIR="$tmpdir"
+
+# shellcheck disable=SC1091
+source "$LIB_DIR/output.sh" 2>/dev/null || true
+
+echo ""
+echo "=== _print_summary_format_duration() ==="
+
+# Sub-minute values → "Zs"
+assert_eq "0 seconds"  "0s"  "$(_print_summary_format_duration 0)"
+assert_eq "1 second"   "1s"  "$(_print_summary_format_duration 1)"
+assert_eq "30 seconds" "30s" "$(_print_summary_format_duration 30)"
+assert_eq "59 seconds" "59s" "$(_print_summary_format_duration 59)"
+
+# 60s boundary → "1m 0s" (not "60s")
+assert_eq "60 boundary" "1m 0s" "$(_print_summary_format_duration 60)"
+
+# Minute + second combinations
+assert_eq "61 seconds"   "1m 1s"  "$(_print_summary_format_duration 61)"
+assert_eq "90 seconds"   "1m 30s" "$(_print_summary_format_duration 90)"
+assert_eq "119 seconds"  "1m 59s" "$(_print_summary_format_duration 119)"
+assert_eq "120 seconds"  "2m 0s"  "$(_print_summary_format_duration 120)"
+assert_eq "125 seconds"  "2m 5s"  "$(_print_summary_format_duration 125)"
+assert_eq "3600 seconds" "60m 0s" "$(_print_summary_format_duration 3600)"
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+exit "$TEST_FAILED"

--- a/scanner/tests/test_print_summary_render_progress_bar.sh
+++ b/scanner/tests/test_print_summary_render_progress_bar.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Unit tests for output.sh::_print_summary_render_progress_bar()
+# Extracted pure helper: builds a unicode progress bar from (score, width).
+# Run: bash scanner/tests/test_print_summary_render_progress_bar.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: [$expected]"
+    echo "    actual:   [$actual]"
+    ((TEST_FAILED++))
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+RED="" YELLOW="" CYAN="" GREEN="" DIM="" NC="" BOLD="" BLUE="" MAGENTA=""
+FORMAT="text"
+QUIET=1
+SEVERITY="low"
+VERSION="test"
+SCAN_DIR="$tmpdir"
+
+# shellcheck disable=SC1091
+source "$LIB_DIR/output.sh" 2>/dev/null || true
+
+# Helper to count occurrences of a substring
+_count() {
+  local s="$1" needle="$2"
+  awk -v n="$needle" '{ c += gsub(n, n) } END { print c+0 }' <<< "$s"
+}
+
+echo ""
+echo "=== _print_summary_render_progress_bar() ==="
+
+# Score 0 with width 30 → all empty
+bar0="$(_print_summary_render_progress_bar 0 30)"
+assert_eq "score 0 width 30: 0 filled"  "0"  "$(_count "$bar0" "█")"
+assert_eq "score 0 width 30: 30 empty"  "30" "$(_count "$bar0" "░")"
+
+# Score 100 with width 30 → all filled
+bar100="$(_print_summary_render_progress_bar 100 30)"
+assert_eq "score 100 width 30: 30 filled" "30" "$(_count "$bar100" "█")"
+assert_eq "score 100 width 30: 0 empty"   "0"  "$(_count "$bar100" "░")"
+
+# Score 50 with width 30 → 15 filled + 15 empty (integer math: 50*30/100=15)
+bar50="$(_print_summary_render_progress_bar 50 30)"
+assert_eq "score 50 width 30: 15 filled" "15" "$(_count "$bar50" "█")"
+assert_eq "score 50 width 30: 15 empty"  "15" "$(_count "$bar50" "░")"
+
+# Score 75 with width 30 → 22 filled + 8 empty (75*30/100=22 via int math)
+bar75="$(_print_summary_render_progress_bar 75 30)"
+assert_eq "score 75 width 30: 22 filled" "22" "$(_count "$bar75" "█")"
+assert_eq "score 75 width 30: 8 empty"   "8"  "$(_count "$bar75" "░")"
+
+# Total bar length always equals width (sum of filled + empty)
+assert_eq "score 33 width 10: total length = 10" "10" "$(_count "$(_print_summary_render_progress_bar 33 10)" "[█░]")"
+
+# Custom width 10, score 10 → 1 filled + 9 empty
+bar_w10="$(_print_summary_render_progress_bar 10 10)"
+assert_eq "score 10 width 10: 1 filled" "1" "$(_count "$bar_w10" "█")"
+assert_eq "score 10 width 10: 9 empty"  "9" "$(_count "$bar_w10" "░")"
+
+# Produces no trailing newline (printf, not echo)
+captured="$(_print_summary_render_progress_bar 100 3)"
+# In a command substitution, trailing newlines are stripped, so this is a
+# structural check: the raw bytes should only be box-drawing chars, no spaces.
+assert_eq "score 100 width 3 body exact" "███" "$captured"
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+exit "$TEST_FAILED"

--- a/scanner/tests/test_print_summary_score_to_grade.sh
+++ b/scanner/tests/test_print_summary_score_to_grade.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Unit tests for output.sh::_print_summary_score_to_grade()
+# Extracted pure helper: maps a numeric score (0-100) to "grade color".
+# Run: bash scanner/tests/test_print_summary_score_to_grade.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+FORMAT="text"
+QUIET=1
+SEVERITY="low"
+VERSION="test"
+SCAN_DIR="$tmpdir"
+
+# shellcheck disable=SC1091
+source "$LIB_DIR/output.sh" 2>/dev/null || true
+
+# Override color sentinels AFTER source (output.sh assigns them unconditionally).
+# Using distinct placeholders lets us assert which color branch was selected
+# without depending on raw ANSI escape bytes.
+RED="RED" GREEN="GREEN" YELLOW="YELLOW" BLUE="" CYAN="" DIM="" NC="" BOLD="" MAGENTA=""
+
+# Parse "grade color" into two variables.
+_parse() {
+  local out="$1"
+  read -r _G _C <<< "$out"
+  echo "$_G|$_C"
+}
+
+echo ""
+echo "=== _print_summary_score_to_grade() ==="
+
+# Grade A boundary (>=90)
+assert_eq "score 100 → A GREEN" "A|GREEN" "$(_parse "$(_print_summary_score_to_grade 100)")"
+assert_eq "score 95  → A GREEN" "A|GREEN" "$(_parse "$(_print_summary_score_to_grade 95)")"
+assert_eq "score 90  → A GREEN" "A|GREEN" "$(_parse "$(_print_summary_score_to_grade 90)")"
+
+# Grade B boundary (80..89)
+assert_eq "score 89  → B GREEN" "B|GREEN" "$(_parse "$(_print_summary_score_to_grade 89)")"
+assert_eq "score 80  → B GREEN" "B|GREEN" "$(_parse "$(_print_summary_score_to_grade 80)")"
+
+# Grade C boundary (70..79)
+assert_eq "score 79  → C YELLOW" "C|YELLOW" "$(_parse "$(_print_summary_score_to_grade 79)")"
+assert_eq "score 70  → C YELLOW" "C|YELLOW" "$(_parse "$(_print_summary_score_to_grade 70)")"
+
+# Grade D boundary (60..69)
+assert_eq "score 69  → D YELLOW" "D|YELLOW" "$(_parse "$(_print_summary_score_to_grade 69)")"
+assert_eq "score 60  → D YELLOW" "D|YELLOW" "$(_parse "$(_print_summary_score_to_grade 60)")"
+
+# Grade F (<60)
+assert_eq "score 59  → F RED" "F|RED" "$(_parse "$(_print_summary_score_to_grade 59)")"
+assert_eq "score 30  → F RED" "F|RED" "$(_parse "$(_print_summary_score_to_grade 30)")"
+assert_eq "score 0   → F RED" "F|RED" "$(_parse "$(_print_summary_score_to_grade 0)")"
+
+# Single-line output (exactly one line)
+lines=$(_print_summary_score_to_grade 85 | wc -l | tr -d ' ')
+assert_eq "output is exactly 1 line" "1" "$lines"
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+exit "$TEST_FAILED"

--- a/scanner/tests/test_prowler_dashboard_summary_provider_label.sh
+++ b/scanner/tests/test_prowler_dashboard_summary_provider_label.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Unit tests for output.sh::_prowler_dashboard_summary_provider_label()
+# Extracted pure helper: prowler provider slug → human-readable label.
+# Run: bash scanner/tests/test_prowler_dashboard_summary_provider_label.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+RED="" YELLOW="" CYAN="" GREEN="" DIM="" NC="" BOLD="" BLUE="" MAGENTA=""
+FORMAT="text"
+QUIET=1
+SEVERITY="low"
+VERSION="test"
+SCAN_DIR="$tmpdir"
+
+# shellcheck disable=SC1091
+source "$LIB_DIR/output.sh" 2>/dev/null || true
+
+echo ""
+echo "=== _prowler_dashboard_summary_provider_label() ==="
+
+# Known single-word providers
+assert_eq "aws"         "AWS"         "$(_prowler_dashboard_summary_provider_label aws)"
+assert_eq "kubernetes"  "Kubernetes"  "$(_prowler_dashboard_summary_provider_label kubernetes)"
+assert_eq "azure"       "Azure"       "$(_prowler_dashboard_summary_provider_label azure)"
+assert_eq "gcp"         "GCP"         "$(_prowler_dashboard_summary_provider_label gcp)"
+assert_eq "github"      "GitHub"      "$(_prowler_dashboard_summary_provider_label github)"
+assert_eq "cloudflare"  "Cloudflare"  "$(_prowler_dashboard_summary_provider_label cloudflare)"
+assert_eq "nhn"         "NHN Cloud"   "$(_prowler_dashboard_summary_provider_label nhn)"
+assert_eq "iac"         "IaC"         "$(_prowler_dashboard_summary_provider_label iac)"
+assert_eq "llm"         "LLM"         "$(_prowler_dashboard_summary_provider_label llm)"
+assert_eq "openstack"   "OpenStack"   "$(_prowler_dashboard_summary_provider_label openstack)"
+
+# Providers whose labels contain spaces
+assert_eq "googleworkspace" "Google Workspace" "$(_prowler_dashboard_summary_provider_label googleworkspace)"
+assert_eq "m365"            "Microsoft 365"    "$(_prowler_dashboard_summary_provider_label m365)"
+assert_eq "image"           "Container Image"  "$(_prowler_dashboard_summary_provider_label image)"
+assert_eq "oraclecloud"     "Oracle Cloud"     "$(_prowler_dashboard_summary_provider_label oraclecloud)"
+assert_eq "alibabacloud"    "Alibaba Cloud"    "$(_prowler_dashboard_summary_provider_label alibabacloud)"
+assert_eq "mongodbatlas"    "MongoDB Atlas"    "$(_prowler_dashboard_summary_provider_label mongodbatlas)"
+
+# Unknown slugs pass through unchanged (fallthrough case)
+assert_eq "unknown pass-through"     "madeupcloud"      "$(_prowler_dashboard_summary_provider_label madeupcloud)"
+assert_eq "empty string pass-through" ""                "$(_prowler_dashboard_summary_provider_label "")"
+
+# Case-sensitivity: the helper matches lowercase slugs only; upper-case passes through.
+assert_eq "uppercase AWS pass-through" "AWS" "$(_prowler_dashboard_summary_provider_label AWS)"
+assert_eq "mixed-case passes through"  "Kubernetes-Foo" "$(_prowler_dashboard_summary_provider_label Kubernetes-Foo)"
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+exit "$TEST_FAILED"


### PR DESCRIPTION
## Summary

**Refactor only — no behavior change, no new features, no bug fixes, no style cleanup of surrounding code.**

Extracts 4 inline pure-logic blocks from `scanner/lib/output.sh` into private, underscore-prefixed helpers placed immediately above their original callers. Adds 4 targeted test files (56 new assertions total) that exercise each helper directly, improving the testability of logic that was previously only reachable through long execution paths in `print_summary` and `_prowler_dashboard_summary`.

## Extracted Helpers

| Helper | file:line | Origin (caller) | Purity |
|---|---|---|---|
| `_print_summary_score_to_grade` | `scanner/lib/output.sh:247` | `print_summary` (was inline at old L254-259) | Deterministic score→`grade color` string; reads only args + color globals |
| `_print_summary_render_progress_bar` | `scanner/lib/output.sh:260` | `print_summary` (was inline at old L268-273) | Deterministic (score,width)→unicode bar string |
| `_print_summary_format_duration` | `scanner/lib/output.sh:272` | `print_summary` (was inline at old L329-334) | Deterministic int→`"Xm Ys"` or `"Zs"` |
| `_prowler_dashboard_summary_provider_label` | `scanner/lib/output.sh:509` | `_prowler_dashboard_summary` (was inline at old L499-517) | Pure slug→label `case` mapping |

Each helper has no network/FS/CLI side effects. Naming convention (`_<original_function>_<purpose>`) was followed per spec.

## Behavior Preservation Evidence

Captured stdout+stderr of all 15 existing bash test files **before** and **after** the refactor and diffed every pair. All 15 outputs are **byte-for-byte identical**:

```
test_aws_identity_sso: IDENTICAL
test_check_access_control: IDENTICAL
test_check_cicd_pipeline: IDENTICAL
test_check_code_injection: IDENTICAL
test_check_infra_docker: IDENTICAL
test_check_network_tls: IDENTICAL
test_checks_helpers: IDENTICAL
test_cloud_credential_probes: IDENTICAL
test_collect_environment_info: IDENTICAL
test_generate_html_dashboard: IDENTICAL
test_kube_discovery: IDENTICAL
test_kubectl_cluster_query: IDENTICAL
test_kubectl_context_helpers: IDENTICAL
test_output_functions: IDENTICAL   (225 assertions)
test_prowler_dashboard_summary: IDENTICAL   (19 assertions)
```

No public function signatures changed; no functions were reordered or renamed.

## New Test Files

| File | Assertions | Target helper |
|---|---:|---|
| `scanner/tests/test_print_summary_score_to_grade.sh` | **13** | `_print_summary_score_to_grade` (full A/B/C/D/F boundary matrix + color selection) |
| `scanner/tests/test_print_summary_render_progress_bar.sh` | **12** | `_print_summary_render_progress_bar` (0/50/75/100 scores, custom widths, total-length invariant) |
| `scanner/tests/test_print_summary_format_duration.sh` | **11** | `_print_summary_format_duration` (0/1/59/60/61/90/119/120/125/3600 seconds) |
| `scanner/tests/test_prowler_dashboard_summary_provider_label.sh` | **20** | `_prowler_dashboard_summary_provider_label` (all 16 known slugs + 4 fallthrough cases) |
| **Total** | **56** new assertions | |

All 4 new tests meet the ≥8-assertion minimum. Fixture inputs contain no 12-digit account-ID-like strings.

## Verification

- `bash scanner/tests/test_*.sh` one-by-one: **19/19 exit 0** (15 existing + 4 new)
- `shellcheck -x scanner/lib/output.sh scanner/tests/test_*.sh` (new files): **clean** (`-e SC2153` applied only to ignore pre-existing `CATEGORY`/`SEVERITY` warnings in the file, unchanged by this PR)
- `bash hooks/pii-check.sh` on every new/modified file: **exit 0**
- `gitleaks detect`: **no leaks found** (also ran during pre-commit hook)
- Byte-for-byte diff vs. baseline across all 15 existing tests: **0 differences**

## Expected Coverage Impact

The 56 new assertions exercise short, pure helpers that were previously only indirectly covered through `print_summary` / `_prowler_dashboard_summary` paths. Rough estimate: **+0.5 to +1.5 percentage points** on `scanner/lib/output.sh` (and thus on overall bash coverage, currently 83.52%). Primary value is test clarity and direct fixture coverage of branch boundaries (grade thresholds, 60s duration boundary, all 16 provider slugs), not raw line coverage.

## Test Plan

- [x] All 15 existing bash tests pass before and after (byte-for-byte identical output)
- [x] 4 new test files each run standalone with `bash scanner/tests/test_<name>.sh` and exit 0
- [x] `shellcheck -x` clean on modified + new files
- [x] `hooks/pii-check.sh` clean on new + modified files
- [x] `gitleaks` clean
- [x] No 12-digit account-ID-like fixtures in new tests
- [x] No non-test files outside `scanner/tests/` touched (besides `scanner/lib/output.sh`)
- [x] No `.github/workflows/*.yml` touched
- [x] No public function signatures changed
- [x] No existing functions reordered or renamed

Do not merge — opening for review only, per task instructions.