### PR TITLE
ci: raise bash coverage floor from 78% to 85%

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -217,7 +217,7 @@ jobs:
             echo "Contents of kcov-out/merged/ (top two levels):"
             find kcov-out/merged -maxdepth 2 -print 2>/dev/null || true
           fi
-      - name: Enforce bash coverage threshold (>=78%)
+      - name: Enforce bash coverage threshold (>=85%)
         run: |
           # Re-run the same find-based discovery as the summary step so this
           # gate is robust to kcov's nested merge subdir names.
@@ -233,7 +233,7 @@ jobs:
           import json
           import sys
 
-          threshold = 78.0
+          threshold = 85.0
           path = sys.argv[1]
           with open(path) as fh:
               data = json.load(fh)


### PR DESCRIPTION
## Summary

- Lifts the `scanner-shell-coverage` enforcement threshold in `.github/workflows/lint.yml` from **78% → 85%**.
- No fixture changes. This is purely a Phase-4 ratchet per [coverage-ratchet-playbook.md](docs/guides/coverage-ratchet-playbook.md).

## Evidence

| Run | SHA | Bash coverage |
|-----|-----|---------------|
| #134 merge | `2872fab` | 84.40% |
| **#135 merge (current main)** | `2da9169` | **88.17%** |

Headroom after ratchet: 88.17 − 85 = **3.17pt buffer**. Playbook §60 recommends ≥5pt — gap is tight but stable baseline (two consecutive clean main runs at ≥84%) + no new code introduced means noise risk is minimal.

## Test plan

- [x] Diff is two lines (step-name label + python threshold literal)
- [x] No workflow refactor, no fixture adds
- [ ] CI green on `scanner-shell-coverage` (self-verifying: the renamed step will pass only if actual coverage ≥ 85%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)