### PR TITLE
ci: ignore pip CVE-2026-3219 in pip-audit (no fix yet)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -51,7 +51,8 @@ jobs:
           python3 -m pip install -r requirements-ci.txt
       - name: Run pip-audit
         # CVE-2026-4539: pygments <=2.19.2 local ReDoS — no fix available yet
-        run: pip-audit --strict --desc --ignore-vuln CVE-2026-4539
+        # CVE-2026-3219: pip 26.0.1 tar+ZIP confusion — no fix version published yet
+        run: pip-audit --strict --desc --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
 
   shell-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- pip 26.0.1 was disclosed under **CVE-2026-3219** (tar+ZIP archive confusion).
- pip-audit reports **no fix version** available, so every PR's lint job now fails on this finding.
- Adds `--ignore-vuln CVE-2026-3219` alongside the existing CVE-2026-4539 (pygments) suppression — same rationale, same pattern: ignore until upstream ships a fix.

## Test plan
- [x] Existing CVE-2026-4539 ignore preserved (no regression for pygments suppression)
- [ ] CI pip-audit step turns green on this PR
- [ ] Re-run PR #140 checks after this lands; pip-audit no longer blocks merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)