### PR TITLE
fix(docs): wrap ZAP YAML in {% raw %} to unblock Jekyll Liquid parser

### DIFF
--- a/docs/devsecops/dast-testing.md
+++ b/docs/devsecops/dast-testing.md
@@ -82,6 +82,7 @@ docker run --rm ghcr.io/zaproxy/zaproxy:stable \
 ### ZAP 컨텍스트 설정 (인증 필요 엔드포인트)
 
 {% raw %}
+
 ```yaml
 # .zap/context.yaml
 context:
@@ -104,6 +105,7 @@ context:
         username: "${ZAP_TEST_USER}"
         password: "${ZAP_TEST_PASSWORD}"
 ```
+
 {% endraw %}
 
 ---

--- a/docs/devsecops/dast-testing.md
+++ b/docs/devsecops/dast-testing.md
@@ -81,6 +81,7 @@ docker run --rm ghcr.io/zaproxy/zaproxy:stable \
 
 ### ZAP 컨텍스트 설정 (인증 필요 엔드포인트)
 
+{% raw %}
 ```yaml
 # .zap/context.yaml
 context:
@@ -103,6 +104,7 @@ context:
         username: "${ZAP_TEST_USER}"
         password: "${ZAP_TEST_PASSWORD}"
 ```
+{% endraw %}
 
 ---
 


### PR DESCRIPTION
## Summary
GitHub Pages가 다음 에러로 빌드에 실패하면서 SNS 링크 공유 미리보기에 필요한 og:image와 사이트 자체가 모두 배포되지 않고 있었습니다(여러 빌드 연속 실패):

\`\`\`
Liquid Exception: Liquid syntax error (line 91): Unknown tag 'username' in devsecops/dast-testing.md
\`\`\`

\`docs/devsecops/dast-testing.md\` 의 YAML 코드 블록(84-105) 안에 ZAP의 form-based 인증 placeholder인 \`{%username%}\` / \`{%password%}\`가 들어 있는데, Jekyll Liquid 파서는 fenced code block을 파싱 단계에서 건너뛰지 않습니다. 결과적으로 \`{%username%}\`을 \`username\`이라는 Liquid 태그로 해석해 사이트 전체 빌드를 중단시켰습니다.

같은 파일 다른 블록(162-222)과 \`docs/github/actions-security.md\`, \`docs/devsecops/supply-chain-security.md\`, \`docs/devsecops/pipeline.md\` 등은 이미 동일한 목적으로 \`{% raw %}…{% endraw %}\` 패턴을 적용하고 있습니다. 동일 패턴을 누락된 블록에 적용했습니다.

## Why this matters
- PR #144(SNS 공유 미리보기 OG/Twitter 메타) 머지 후 Pages 재배포가 일어나야 \`/claudesec/assets/claudesec-logo.png\`이 200으로 서빙되어 KakaoTalk·Slack·FB 카드가 정상 렌더됩니다.
- 현재 Pages는 이 Liquid 에러로 한참 전부터 깨져 있었고, og:image뿐 아니라 \`https://twodragon0.github.io/claudesec/\` 자체가 갱신되지 않고 있습니다.

## Test plan
- [x] gitleaks clean (placeholder 변경 없음)
- [x] 동일 파일의 다른 \`{% raw %}\` 블록 패턴과 일관 (다른 파일들도 같은 컨벤션)
- [ ] 머지 후 \`pages-build-deployment\` 워크플로우 success 확인
- [ ] 머지 후 \`curl -I https://twodragon0.github.io/claudesec/\` 응답에서 신규 og:image·twitter:card 메타 확인
- [ ] \`curl -I https://twodragon0.github.io/claudesec/assets/claudesec-logo.png\` 200 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)