### PR TITLE
ci: OG Meta Verify hook — auto-attach curl validation to og-touching PRs

### DIFF
--- a/.github/workflows/og-meta-verify.yml
+++ b/.github/workflows/og-meta-verify.yml
@@ -1,0 +1,42 @@
+name: OG Meta Verify
+
+# Runs on PRs that touch any file capable of changing the SNS link-share
+# preview (KakaoTalk · Slack · Facebook · LinkedIn · Twitter/X). Posts a
+# sticky comment with curl-verified og:image headers + deployed meta so
+# reviewers can see what the SNS crawlers will see.
+#
+# This verifies the **currently deployed** Pages state, not the PR's
+# unmerged content — KakaoTalk reads absolute URLs and only the merged
+# main branch is published. The comment makes that explicit.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'docs/_config.yml'
+      - 'docs/index.md'
+      - 'docs/assets/claudesec-og-card.*'
+      - 'docs/assets/claudesec-logo*.png'
+      - 'claudesec-asset-dashboard.html'
+      - 'scanner/lib/dashboard-template.html'
+      - 'scripts/og-meta-verify.sh'
+      - '.github/workflows/og-meta-verify.yml'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - name: Run og-meta-verify and sticky-comment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PAGE_URL: https://twodragon0.github.io/claudesec/
+          IMAGE_URL: https://twodragon0.github.io/claudesec/assets/claudesec-og-card.png
+        run: ./scripts/og-meta-verify.sh

--- a/docs/branding.md
+++ b/docs/branding.md
@@ -121,6 +121,25 @@ OG 메타나 이미지를 변경한 뒤에는 각 SNS 캐시를 명시적으로 
 - [ ] Facebook Sharing Debugger의 **Open Graph Object Debugger** 결과에 `og:image` 정상 등록
 - [ ] (선택) 본인 KakaoTalk 채팅에 URL 전송 후 카드 시각 확인
 
+### 자동 검증 (CI hook)
+
+`docs/_config.yml`, `docs/index.md`, `docs/assets/claudesec-og-card.*`, `docs/assets/claudesec-logo*.png`, `claudesec-asset-dashboard.html`, `scanner/lib/dashboard-template.html` 중 하나라도 변경된 PR은 `OG Meta Verify` 워크플로우(`.github/workflows/og-meta-verify.yml`)가 자동 실행되어 PR 본문에 sticky 코멘트로 다음을 첨부합니다:
+
+- `og:image` URL 200/404 + `content-type` 헤더
+- 배포된 페이지의 `og:*` / `twitter:*` 메타 (현재 main 기준)
+- 페이지가 광고하는 og:image URL이 기대값과 일치하는지 ✅/⚠️
+- 머지 후 캐시 갱신 단축 링크 (KakaoTalk · Facebook 디버거)
+
+⚠️ 이 검증은 **현재 배포된** Pages 상태를 대상으로 하므로, PR이 머지되어 Pages가 재배포되기 전까지는 PR diff 내용이 반영되지 않습니다. 코멘트가 그 점을 명시합니다.
+
+로컬에서 동일 검증 실행:
+
+```bash
+PAGE_URL=https://twodragon0.github.io/claudesec/ \
+IMAGE_URL=https://twodragon0.github.io/claudesec/assets/claudesec-og-card.png \
+  ./scripts/og-meta-verify.sh --no-comment
+```
+
 ### 참고
 
 - Open Graph Protocol — <https://ogp.me/>

--- a/scripts/og-meta-verify.sh
+++ b/scripts/og-meta-verify.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# og-meta-verify.sh — fetch the deployed page's OG/Twitter meta + image
+# headers, format a markdown report, and sticky-comment it on a PR so
+# contributors can see what KakaoTalk/FB/Slack will see *before* they
+# request review.
+#
+# Usage (CI):
+#   PR_NUMBER=42 PAGE_URL=https://twodragon0.github.io/claudesec/ \
+#     IMAGE_URL=https://twodragon0.github.io/claudesec/assets/claudesec-og-card.png \
+#     scripts/og-meta-verify.sh
+#
+# Usage (local sanity check, no comment):
+#   PAGE_URL=https://twodragon0.github.io/claudesec/ \
+#     IMAGE_URL=https://twodragon0.github.io/claudesec/assets/claudesec-og-card.png \
+#     scripts/og-meta-verify.sh --no-comment
+#
+# Note: this verifies the **currently deployed** state, not the contents
+# of the PR diff. KakaoTalk/FB read absolute URLs, so we have to point at
+# the live origin. For unmerged changes, the report will reflect main
+# until the PR merges and Pages redeploys.
+
+set -euo pipefail
+
+NO_COMMENT=0
+if [[ "${1:-}" == "--no-comment" ]]; then
+  NO_COMMENT=1
+fi
+
+PAGE_URL="${PAGE_URL:-https://twodragon0.github.io/claudesec/}"
+IMAGE_URL="${IMAGE_URL:-https://twodragon0.github.io/claudesec/assets/claudesec-og-card.png}"
+MARKER="<!-- og-meta-verify:v1 -->"
+
+tmp_report="$(mktemp)"
+trap 'rm -f "$tmp_report"' EXIT
+
+# Image headers — keep status line, content-type, content-length
+img_headers="$(curl -sI --max-time 10 "$IMAGE_URL" | head -10 | tr -d '\r')"
+img_status="$(printf '%s\n' "$img_headers" | head -1)"
+
+# Page meta tags — pull og:* and twitter:* lines
+page_html="$(curl -s --max-time 15 "$PAGE_URL")"
+og_meta="$(printf '%s\n' "$page_html" | grep -E 'og:|twitter:' | head -20 || true)"
+
+# Detect the og:image URL the page actually advertises
+advertised_image="$(printf '%s\n' "$og_meta" | grep -m1 'og:image"' | sed -E 's/.*content="([^"]+)".*/\1/' || true)"
+
+# Status badges
+img_ok="❌"
+if printf '%s' "$img_status" | grep -q '200'; then
+  img_ok="✅"
+fi
+
+advertised_match="❌"
+if [[ -n "$advertised_image" && "$advertised_image" == "$IMAGE_URL" ]]; then
+  advertised_match="✅"
+elif [[ -n "$advertised_image" ]]; then
+  advertised_match="⚠️ (deployed advertises a different URL — check if PR changes the og:image path)"
+fi
+
+cat > "$tmp_report" <<EOF
+${MARKER}
+## 🖼️ OG Meta Verification — KakaoTalk · Slack · Facebook · LinkedIn · X
+
+Verifies the **currently deployed** \`${PAGE_URL}\` (Pages reflects \`main\`; this PR's edits land after merge).
+
+### og:image reachability ${img_ok}
+
+\`\`\`
+${img_headers}
+\`\`\`
+
+- Expected URL: \`${IMAGE_URL}\`
+- Page advertises: \`${advertised_image:-<not found>}\` ${advertised_match}
+
+### Deployed page meta
+
+\`\`\`html
+${og_meta:-<no og: or twitter: meta found>}
+\`\`\`
+
+### After merge — refresh platform caches
+
+| Platform | Tool |
+|----------|------|
+| KakaoTalk | <https://developers.kakao.com/tool/debugger/sharing> → URL → **초기화** |
+| Facebook (+ Slack, LinkedIn) | <https://developers.facebook.com/tools/debug/> → URL → **Scrape Again** |
+| Twitter/X | New tweet auto-recrawls (cards-dev.twitter.com retired) |
+
+Reference: [docs/branding.md § SNS 링크 공유 미리보기](../docs/branding.md#sns-링크-공유-미리보기-kakaotalk--slack--facebook--linkedin--twitterx)
+EOF
+
+# Local mode: just print, do not comment
+if [[ "$NO_COMMENT" -eq 1 ]]; then
+  cat "$tmp_report"
+  exit 0
+fi
+
+: "${PR_NUMBER:?PR_NUMBER env required (set by CI from github.event.pull_request.number)}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY env required}"
+: "${GH_TOKEN:?GH_TOKEN env required (use \${{ secrets.GITHUB_TOKEN }} in CI)}"
+
+# Sticky-comment: find prior bot comment by marker, edit it; otherwise create
+existing_id="$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" \
+  --jq "[.[] | select(.body | startswith(\"${MARKER}\"))][0].id" 2>/dev/null || echo '')"
+
+body="$(cat "$tmp_report")"
+
+if [[ -n "$existing_id" && "$existing_id" != "null" ]]; then
+  echo "Updating existing comment ${existing_id}…"
+  gh api --method PATCH "repos/${GITHUB_REPOSITORY}/issues/comments/${existing_id}" \
+    -f body="$body" >/dev/null
+  echo "✅ Comment updated"
+else
+  echo "Creating new comment on PR #${PR_NUMBER}…"
+  gh pr comment "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" --body "$body" >/dev/null
+  echo "✅ Comment posted"
+fi


### PR DESCRIPTION
## Summary
PR이 SNS 링크 미리보기에 영향을 주는 파일을 건드릴 때마다 \`OG Meta Verify\` 워크플로우가 자동 실행되어 PR에 sticky 코멘트로 다음을 첨부합니다:

- \`og:image\` URL의 HTTP 상태 + \`content-type\` 헤더
- 배포된 페이지의 \`og:*\` / \`twitter:*\` 메타
- 페이지가 광고하는 og:image URL이 기대값과 일치하는지 ✅/⚠️
- 머지 후 캐시 갱신 단축 링크 (KakaoTalk · Facebook)

## Trigger paths
- \`docs/_config.yml\`
- \`docs/index.md\`
- \`docs/assets/claudesec-og-card.*\`
- \`docs/assets/claudesec-logo*.png\`
- \`claudesec-asset-dashboard.html\`
- \`scanner/lib/dashboard-template.html\`
- \`scripts/og-meta-verify.sh\` · \`.github/workflows/og-meta-verify.yml\` (self-test)

## Files
| File | Role |
|------|------|
| \`scripts/og-meta-verify.sh\` (NEW) | curl + 마크다운 리포트 생성 + sticky 코멘트 (\`gh api PATCH\` 직접 호출 — 외부 액션 의존 없음) |
| \`.github/workflows/og-meta-verify.yml\` (NEW) | \`pull_request\` 트리거 · paths 필터 · \`pull-requests: write\` 권한 |
| \`docs/branding.md\` | § \"자동 검증 (CI hook)\" 서브섹션 추가 (트리거 경로 · 코멘트 내용 · 로컬 호출법) |

## Sticky-comment 설계
\`<!-- og-meta-verify:v1 -->\` 마커로 동일 코멘트를 찾아 PATCH합니다. push마다 새 코멘트가 쌓이지 않으며, 버전(v1) 접미어로 향후 포맷 변경 시 기존 코멘트와 공존 가능합니다.

## Caveats (코멘트 본문에 명시)
- 배포된 main 기준 검증 — PR diff 내용은 머지 후에만 라이브 반영됨 (KakaoTalk이 절대 URL을 읽고 main만 publish되기 때문)
- 캐시 갱신은 수동 단계 (Kakao/FB는 cache-bust API 미공개)

## Test plan
- [x] \`bash -n scripts/og-meta-verify.sh\` 통과
- [x] 로컬 \`--no-comment\` 모드로 실행 → HTTP 200 + ko_KR + summary_large_image 라이브 확인
- [x] gitleaks clean
- [ ] 이 PR이 자체적으로 워크플로우를 트리거하면서 첫 sticky 코멘트 자동 게시 확인 (self-bootstrap)
- [ ] 동일 PR에 dummy 푸시 후 코멘트가 새로 생기지 않고 PATCH로 갱신되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)