### PR TITLE
fix(a11y): override jekyll-minimal theme to fix Lighthouse axe failures

### DIFF
--- a/docs/_includes/head-custom.html
+++ b/docs/_includes/head-custom.html
@@ -1,0 +1,57 @@
+<!--
+  Accessibility overrides for jekyll-theme-minimal.
+  Addresses Lighthouse a11y failures on the live Pages homepage:
+    - color-contrast            (WCAG 1.4.3 AA)
+    - link-in-text-block        (WCAG 1.4.1 AA)
+    - target-size               (WCAG 2.5.8 AA)
+  Loaded after the theme's style.css so these rules win the cascade.
+-->
+<style>
+  /* color-contrast: theme uses #666 on white (~5.7:1, fails for small text near images);
+     darken body text and headings to comfortably exceed 7:1 for AAA-grade contrast. */
+  body, .wrapper, section, p, li, td, th, dt, dd, blockquote {
+    color: #1f2937;
+  }
+  header h1 a, header h1 a:visited,
+  section h1, section h2, section h3, section h4, section h5, section h6 {
+    color: #0f172a;
+  }
+  header p, header p small {
+    color: #1f2937;
+  }
+  /* Code / muted text need explicit darker tone; the theme's default gray fails AA. */
+  code, pre, kbd, samp, .highlight, .language-bash, .language-plaintext {
+    color: #0f172a;
+  }
+
+  /* link-in-text-block: in-content links must be visually distinct from surrounding
+     text without relying on color alone — add an underline. */
+  section a,
+  section a:visited {
+    color: #1d4ed8;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+  section a:hover,
+  section a:focus-visible {
+    color: #1e3a8a;
+    text-decoration-thickness: 2px;
+  }
+  /* Visible focus ring for keyboard users. */
+  a:focus-visible, button:focus-visible {
+    outline: 2px solid #1d4ed8;
+    outline-offset: 2px;
+    border-radius: 2px;
+  }
+
+  /* target-size: inline links and list-item links should give at least 24x24px
+     touch area (WCAG 2.5.8 AA minimum). Lists inside the page often render
+     as compact rows that fail this rule. */
+  section li a,
+  section td a,
+  header .view a {
+    display: inline-block;
+    min-height: 24px;
+    padding: 2px 0;
+  }
+</style>

--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -1,0 +1,6 @@
+---
+layout: default
+---
+<main id="main-content">
+  {{ content }}
+</main>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,5 @@
 ---
-layout: default
+layout: page
 title: ClaudeSec — DevSecOps 통합 보안 대시보드
 description: AI 보조 보안 개발 도구킷. 보안 스캐너 · ISMS-P PDCA 대시보드 · 자산 관리 · 컴플라이언스 자동화. KakaoTalk·Slack·SNS 링크 공유 미리보기 지원.
 tags: [claudesec, devsecops, security, isms-p, pdca, dashboard, documentation]


### PR DESCRIPTION
## Summary
Live Pages homepage scored **0.78 accessibility** on Lighthouse, blocked by four axe rules from the `jekyll-theme-minimal` defaults. This PR overrides the theme without forking it.

Verified via local Lighthouse run against `https://twodragon0.github.io/claudesec/`:
- ❌ `color-contrast` — light gray body text fails AA contrast
- ❌ `link-in-text-block` — links rely on color alone (no underline)
- ❌ `target-size` — list/table links smaller than 24×24 CSS px
- ❌ `landmark-one-main` — page has no `<main>` landmark

## Changes
- **`docs/_includes/head-custom.html`** — theme-aware CSS override loaded after the theme stylesheet:
  - body/heading text → `#1f2937` / `#0f172a` (well past 7:1 on white)
  - in-content links → underlined `#1d4ed8` with focus ring
  - list/table links → `min-height: 24px` for target size
- **`docs/_layouts/page.html`** — minimal wrapper that places `{{ content }}` inside `<main id="main-content">` so the landmark rule passes without copying the whole theme layout
- **`docs/index.md`** — frontmatter `layout: default` → `layout: page` to use the new wrapper

## Why not raise the lighthouserc.json floor in this PR?
Pages publishes from merged `main` only — the gate audits the live URL, not PR content. The floor stays at 0.75 here so this PR can merge. After the daily cron confirms the new live score crosses 0.90, a follow-up PR raises the floor to 0.90.

## Test plan
- [ ] CI Lint, markdownlint, link-check pass on this PR
- [ ] Lighthouse gate still passes against the current (pre-merge) live baseline (0.78 ≥ 0.75)
- [ ] After merge, manually trigger Lighthouse workflow OR wait for daily cron
- [ ] Confirm new live score ≥ 0.90 across SEO and Accessibility
- [ ] Open follow-up PR raising `lighthouserc.json` accessibility floor 0.75 → 0.90

🤖 Generated with [Claude Code](https://claude.com/claude-code)