### PR TITLE
ci: raise accessibility floor to 0.90

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -9,7 +9,7 @@ name: Lighthouse SEO & Accessibility Gate
 #
 # Thresholds (tune in lighthouserc.json):
 #   SEO           >= 0.90
-#   Accessibility >= 0.75   # current baseline ~0.78; raise as a11y issues are fixed
+#   Accessibility >= 0.90   # live baseline 0.93 after PR #152 theme overrides
 
 on:
   pull_request:

--- a/lighthouserc.json
+++ b/lighthouserc.json
@@ -6,7 +6,7 @@
     "assert": {
       "assertions": {
         "categories:seo": ["error", { "minScore": 0.9 }],
-        "categories:accessibility": ["error", { "minScore": 0.75 }]
+        "categories:accessibility": ["error", { "minScore": 0.9 }]
       }
     },
     "upload": {


### PR DESCRIPTION
## Summary
PR #152 brought the live Pages homepage a11y score from **0.78 → 0.93** via `jekyll-theme-minimal` overrides. This PR raises the Lighthouse gate floor accordingly so future regressions trip the gate at the higher bar.

Verified scores (local Lighthouse run against `https://twodragon0.github.io/claudesec/`, 2026-05-02 post-merge):
- **Accessibility: 0.93** (was 0.78)
- **SEO: 1.00**

## Changes
- `lighthouserc.json`: accessibility `minScore` 0.75 → 0.90 (matches SEO floor)
- `.github/workflows/lighthouse.yml`: header comment updated to reflect new floor + provenance note

## Why 0.90 not higher?
- 0.93 leaves a 3-point buffer for normal CI noise
- One residual a11y rule (`color-contrast` on a single element) blocks pushing past 0.95 without further theme work — out of scope here

## Test plan
- [ ] CI Lint, markdownlint, link-check pass
- [ ] Lighthouse gate on this PR audits live (post-#152) baseline → expect pass at the new 0.90 floor
- [ ] After merge, daily cron continues to enforce the higher bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)