### PR TITLE
ci: bump pip to 26.1+ in pip-audit to clear CVE-2026-6357

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,6 +47,8 @@ jobs:
           python-version: '3.11'
       - name: Install pip-audit and project dependencies
         run: |
+          # Upgrade pip first to clear CVE-2026-6357 (fix in pip 26.1)
+          python3 -m pip install --upgrade 'pip>=26.1'
           python3 -m pip install --upgrade pip-audit
           python3 -m pip install -r requirements-ci.txt
       - name: Run pip-audit

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ __pycache__/
 .venv*/
 venv*/
 test-reports/
+.coverage
+.coverage.*
+htmlcov/
 
 # Environment & Secrets
 .env


### PR DESCRIPTION
## Summary

- Bump `pip` to `>=26.1` inside the `pip-audit` job so the strict scan no longer flags its own install (CVE-2026-6357, fix=26.1).
- Gitignore `.coverage`, `.coverage.*`, and `htmlcov/` so local pytest-cov runs don't clutter `git status`.

## Why

`actions/setup-python@a309ff8` provisions Python 3.11 with pip 26.0.1. After the recent CVE-2026-6357 disclosure (pip self-update wheel-import ordering), every `pip-audit --strict` run started failing on the runner's own pip. PR #155 is currently blocked on this. The upstream fix is pip 26.1, so bumping at install time is preferred over adding yet another `--ignore-vuln` entry.

## Test plan

- [ ] CI green: `pip-audit` step succeeds on this PR
- [ ] Re-run #155 after merge — Lint gate should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)