### PR TITLE
feat(dast): add docker-compose.staging.yml reference target

### DIFF
--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -1,0 +1,37 @@
+version: "3.9"
+
+# DAST Staging Environment for ZAP Scanning
+# Used by: .github/workflows/dast-baseline.yml
+#
+# Override target app image/port via environment variables:
+#   APP_IMAGE  - Docker image for the target application (default: app:latest)
+#   APP_PORT   - Port the app listens on (default: 8080)
+
+services:
+  app:
+    image: ${APP_IMAGE:-app:latest}
+    ports:
+      - "${APP_PORT:-8080}:${APP_PORT:-8080}"
+    environment:
+      - NODE_ENV=staging
+      - PORT=${APP_PORT:-8080}
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:${APP_PORT:-8080}/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    networks:
+      - dast-net
+
+  # ZAP rules directory mount point
+  # The .zap/rules.tsv file is loaded by ZAP scan actions
+  zap-config:
+    image: busybox
+    volumes:
+      - ./templates/zap-rules.tsv:/zap/rules.tsv:ro
+    command: ["true"]
+
+networks:
+  dast-net:
+    driver: bridge


### PR DESCRIPTION
## Summary

- Add `docker-compose.staging.yml` at the repo root. This is the example DAST staging compose file that `docs/devsecops/dast-testing.md:139` and `:161` already reference.
- Salvaged from the now-closed #58 — the only net-new file in that PR that hadn't been independently re-implemented on `main`.

## Why

The DAST guide tells contributors to spin up the target app via `docker compose -f docker-compose.staging.yml up -d`, but the file itself was missing from `main`. PR #58 was too far behind (19/23 files in heavy collision with subsequent main commits — `.github/workflows/lint.yml` alone had 26 conflicting commits), so rebasing it would have cost more than it returns. This PR cherry-picks the single file that still has unique value.

Defines:
- `app` service parameterized via `APP_IMAGE` / `APP_PORT` env vars, with a `/health` healthcheck
- `zap-config` sidecar that mounts `templates/zap-rules.tsv` into ZAP's rules path
- `dast-net` bridge network

No GitHub Actions workflow consumes this file yet — it's documentation-grade scaffolding for users following the DAST guide.

## Test plan

- [ ] `docker compose -f docker-compose.staging.yml config` validates schema (lint stage)
- [ ] gitleaks / link-check / markdown-lint / pii-check pass on PR
- [ ] No regression in `dast-baseline` workflow (already uses ZAP directly without this compose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)