### PR TITLE
chore(ci): raise scanner-unit-tests coverage gate 95→99 + close audit-sources gaps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -106,7 +106,7 @@ jobs:
         run: bash scanner/tests/test_check_network_tls.sh
       - name: Run bash unit tests (cicd/pipeline checks)
         run: bash scanner/tests/test_check_cicd_pipeline.sh
-      - name: Run scanner pytest + coverage gate (>=95%)
+      - name: Run scanner pytest + coverage gate (>=99%)
         id: scanner_tests
         env:
           PYTHONPATH: .
@@ -120,7 +120,7 @@ jobs:
             --cov=scanner/lib \
             --cov-report=term \
             --cov-report=xml:test-reports/coverage.xml \
-            --cov-fail-under=95 \
+            --cov-fail-under=99 \
             -q
           test_exit_code=$?
           echo "test_exit_code=$test_exit_code" >> "$GITHUB_OUTPUT"

--- a/scanner/tests/test_dashboard_audit_sources_unit.py
+++ b/scanner/tests/test_dashboard_audit_sources_unit.py
@@ -336,3 +336,54 @@ def test_saas_empty_product_slot_is_skipped():
     assert ">QueryPie<" not in html
     assert ">ArgoCD<" not in html
     assert ">IDE<" not in html
+
+
+# ===========================================================================
+# Coverage gap closure: previously-missing branches in dashboard_html_audit_sources
+# (lines 56, 121, 181-184) — see term-missing report 2026-05-22.
+# ===========================================================================
+
+def test_ms_unknown_trust_level_initializes_counts_bucket():
+    """MS source with an unrecognised trust_level lazily seeds its bucket in trust_counts
+    (covers line 56 'trust_counts[level] = 0').
+    """
+    data = {
+        "sources": [_ms_source(trust_level="Vendor Custom")],
+        "source_filter": "all",
+    }
+    html = build_ms_sources_html(data)
+    # Unknown trust level still falls back to the community chip class…
+    assert "trust-community" in html
+    # …and the original label is preserved in the rendered entry.
+    assert "Vendor Custom" in html
+
+
+def test_ms_source_with_more_than_25_files_renders_truncation_notice():
+    """MS source with >25 files renders the '… and N more files' truncation notice
+    (covers line 121).
+    """
+    files = [{"path": f"path/file-{i}.md", "url": f"https://example.com/{i}"} for i in range(28)]
+    data = {
+        "sources": [_ms_source(files=files)],
+        "source_filter": "all",
+    }
+    html = build_ms_sources_html(data)
+    assert "and 3 more files" in html
+
+
+def test_saas_source_with_files_renders_file_rows():
+    """SaaS source carrying file entries renders one bp-audit-item-row per file
+    (covers lines 181-184: url/path resolution and per-file checkbox markup).
+    """
+    files = [
+        {"path": "docs/setup.md", "url": "https://example.com/setup"},
+        {"name": "rules.yaml", "raw_url": "https://example.com/rules"},
+        {},
+    ]
+    data = {"sources": [_saas_source(product="Okta", files=files)]}
+    html = build_saas_sources_html(data)
+    assert "saas-file-checkbox" in html
+    assert "docs/setup.md" in html
+    assert "rules.yaml" in html
+    assert ">file<" in html
+    assert 'href="#"' in html


### PR DESCRIPTION
## Summary
- Tighten the scanner pytest gate from \`--cov-fail-under=95\` to \`--cov-fail-under=99\` in \`.github/workflows/lint.yml\` so any regression below 99% blocks CI automatically.
- Cover the previously-uncovered branches in \`scanner/lib/dashboard_html_audit_sources.py\` (lines 56, 121, 181-184): unknown trust level lazily seeding the bucket, MS source truncation notice past 25 files, and SaaS file-row rendering. Module climbs 95% → 99%.
- Full suite stays green at **1133 passed**, total coverage **99.12%** (3389/3419), so the new floor has ~0.12% (≈4 lines) of headroom.

## Test plan
- [x] \`PYTHONPATH=. CLAUDESEC_DASHBOARD_OFFLINE=1 python3 -m pytest scanner/tests/test_dashboard_audit_sources_unit.py -q\` → 30 passed
- [x] \`PYTHONPATH=. CLAUDESEC_DASHBOARD_OFFLINE=1 python3 -m pytest scanner/tests/ --cov=scanner/lib --cov-fail-under=99 -q\` → \`Required test coverage of 99% reached. Total coverage: 99.12%\`, 1133 passed
- [ ] CI \`scanner-unit-tests\` job hits the new 99% gate and stays green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)