### PR TITLE
chore(ci): SHA-pin remaining DAST/CodeQL actions

### DIFF
--- a/.github/workflows/dast-baseline.yml
+++ b/.github/workflows/dast-baseline.yml
@@ -37,7 +37,7 @@ jobs:
         run: chmod -R a+w .
 
       - name: ZAP Baseline Scan
-        uses: zaproxy/action-baseline@v0.15.0
+        uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25  # v0.15.0
         continue-on-error: true
         with:
           target: "http://localhost:11777"

--- a/.github/workflows/dast-full-scan.yml
+++ b/.github/workflows/dast-full-scan.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: ZAP Full Scan
-        uses: zaproxy/action-full-scan@v0.13.0
+        uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c  # v0.13.0
         id: zap
         continue-on-error: true
         with:
@@ -53,14 +53,14 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always() && hashFiles('zap_scan.sarif') != ''
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4
         with:
           sarif_file: zap_scan.sarif
           category: "DAST"
 
       - name: Notify on Critical Findings
         if: steps.zap.outcome == 'failure'
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
             github.rest.issues.create({


### PR DESCRIPTION
## Summary

Pin the last 4 floating action references in the DAST workflows to commit SHAs with version comments, matching the existing pinning style. Closes the remaining supply-chain regression vector (repo goes from 45/49 → 49/49 SHA-pinned).

| Action | Tag | Pinned SHA | File:Line |
|---|---|---|---|
| `zaproxy/action-baseline` | v0.15.0 | `de8ad96…b8b25` | `dast-baseline.yml:40` |
| `zaproxy/action-full-scan` | v0.13.0 | `3c58388…6c27c` | `dast-full-scan.yml:31` |
| `github/codeql-action/upload-sarif` | v4 | `7211b7c…5fbfa` | `dast-full-scan.yml:56` |
| `actions/github-script` | v9 | `3a2844b…da1b3` | `dast-full-scan.yml:63` |

## Why

Both DAST jobs hold `security-events: write` and `issues: write`. A malicious retag on a floating tag could write SARIF and create issues — closing this is OWASP A08 (Software & Data Integrity Failures) hygiene.

No behavior change. The SHA each tag resolved to at PR time is exactly the current tip of that tag.

## Test plan

- [ ] CI runs Security Scan Gate / dependency-review on the PR
- [ ] DAST Baseline workflow still parses (no YAML syntax change)
- [ ] No new `uses:` floating-tag matches in the two files: `grep -nE "uses: " .github/workflows/dast-{baseline,full-scan}.yml | grep -vE "@[0-9a-f]{40}"` returns empty
- [ ] Next scheduled `DAST Full Scan (Nightly)` run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)