### PR TITLE
chore(ci): guard dependabot auto-merge against fork-origin PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,13 @@ jobs:
   auto-merge:
     name: Auto-merge Dependabot PR
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    # Defense-in-depth: only run when the PR head is a branch in THIS repo,
+    # not a fork. pull_request_target runs with write-scoped GITHUB_TOKEN, so
+    # we refuse to auto-approve/merge anything that didn't originate inside
+    # the repository even if the actor spoofing checks were bypassed.
+    if: >-
+      github.actor == 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
## Summary

Add a head-repo equality guard to `.github/workflows/dependabot-auto-merge.yml` so the auto-merge job refuses to run when the PR head ref lives in a fork.

```yaml
if: >-
  github.actor == 'dependabot[bot]' &&
  github.event.pull_request.head.repo.full_name == github.repository
```

## Why

`pull_request_target` runs with the upstream's write-scoped `GITHUB_TOKEN`. Dependabot only ever opens branches inside the repository, so any fork-origin PR carrying the `dependabot[bot]` actor would be a spoofing attempt. This guard makes the auto-approve and auto-merge logic refuse such payloads even if the actor check is bypassed (OWASP A08 — Software & Data Integrity Failures).

No behavior change for legitimate Dependabot PRs.

## Test plan

- [ ] CI passes on this PR
- [ ] Next Dependabot patch update still auto-merges (head repo = `Twodragon0/claudesec` → guard evaluates true)
- [ ] Workflow YAML still parses (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dependabot-auto-merge.yml'))"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)