### PR TITLE
chore(ci): add regression-prevention audit for pull_request_target fork-guard

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -348,6 +348,21 @@ jobs:
             ! -path './.claudesec-assets/*' ! -path './.claudesec-saas-best-practices/*' \
             -print0 | xargs -0 bash hooks/pii-check.sh
 
+  workflow-fork-guard:
+    # Regression-prevention: every job in a pull_request_target workflow must
+    # carry a head.repo.full_name == github.repository fork-guard (OWASP A08).
+    # The audit script exits 1 on any unguarded job.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.1.0
+        with:
+          python-version: "3.13"
+      - name: Install PyYAML
+        run: pip install --no-deps 'pyyaml>=6.0,<7'
+      - name: Audit pull_request_target workflows for fork-guard
+        run: python3 scripts/check-pull-request-target-guard.py
+
   gitleaks:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check-pull-request-target-guard.py
+++ b/scripts/check-pull-request-target-guard.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Audit .github/workflows/*.yml for pull_request_target triggers and ensure
+# every job in such workflows has a head.repo.full_name == github.repository
+# fork-guard in its `if:` expression.
+#
+# pull_request_target runs with the upstream's write-scoped GITHUB_TOKEN even
+# for fork PRs (OWASP A08 — Software & Data Integrity Failures). Without the
+# guard, malicious fork-origin PRs can run privileged jobs.
+#
+# Exit code: 0 if all guarded, 1 if any unguarded job found.
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+GUARD_TOKEN = "head.repo.full_name == github.repository"
+WORKFLOWS_DIR = Path(".github/workflows")
+
+
+def has_guard(if_expr: str | None) -> bool:
+    if not if_expr:
+        return False
+    normalized = " ".join(str(if_expr).split())
+    return GUARD_TOKEN in normalized
+
+
+def main() -> int:
+    workflows = sorted(WORKFLOWS_DIR.glob("*.yml")) + sorted(WORKFLOWS_DIR.glob("*.yaml"))
+    if not workflows:
+        print(f"::error::No workflows found under {WORKFLOWS_DIR}")
+        return 1
+
+    failures: list[str] = []
+    audited = 0
+
+    for wf in workflows:
+        with wf.open() as fh:
+            try:
+                doc = yaml.safe_load(fh)
+            except yaml.YAMLError as exc:
+                print(f"::error file={wf}::YAML parse error: {exc}")
+                failures.append(str(wf))
+                continue
+
+        if not isinstance(doc, dict):
+            continue
+        triggers = doc.get(True) or doc.get("on")
+        if not _has_pull_request_target(triggers):
+            continue
+
+        audited += 1
+        jobs = doc.get("jobs") or {}
+        if not isinstance(jobs, dict):
+            print(f"::error file={wf}::workflow has no parseable jobs map")
+            failures.append(str(wf))
+            continue
+
+        for job_name, job in jobs.items():
+            if not isinstance(job, dict):
+                continue
+            if has_guard(job.get("if")):
+                continue
+            failures.append(f"{wf}::{job_name}")
+            print(
+                f"::error file={wf}::job '{job_name}' is missing the fork-guard "
+                f"`{GUARD_TOKEN}` in its top-level `if:` expression"
+            )
+
+    if audited == 0:
+        print("No pull_request_target workflows found — audit passes by vacuity.")
+        return 0
+
+    if failures:
+        print(
+            f"\nFAIL: {len(failures)} unguarded job(s) across "
+            f"{audited} pull_request_target workflow(s).",
+            file=sys.stderr,
+        )
+        print(
+            "Add `if: github.event.pull_request.head.repo.full_name == github.repository`",
+            file=sys.stderr,
+        )
+        print(
+            "(or merge it into the existing `if:` with `&&`) to each listed job.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK: {audited} pull_request_target workflow(s) audited, all jobs fork-guarded.")
+    return 0
+
+
+def _has_pull_request_target(triggers: object) -> bool:
+    if triggers is None:
+        return False
+    if isinstance(triggers, str):
+        return triggers == "pull_request_target"
+    if isinstance(triggers, list):
+        return "pull_request_target" in triggers
+    if isinstance(triggers, dict):
+        return "pull_request_target" in triggers
+    return False
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Add a CI lint that fails the workflow when any future `pull_request_target` job lacks the `head.repo.full_name == github.repository` fork-guard.

| File | Purpose |
|---|---|
| `scripts/check-pull-request-target-guard.py` | Parses every `.github/workflows/*.yml`, checks each job in pull_request_target workflows, exits 1 with `::error::` on any unguarded job |
| `.github/workflows/lint.yml` | New `workflow-fork-guard` job: sets up Python, installs PyYAML, runs the audit script |

## Why

[OWASP A08 — Software & Data Integrity Failures](https://owasp.org/Top10/A08_2021-Software_and_Data_Integrity_Failures/) and [GitHub's security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-pull_request_target-or-workflow_run-from-untrusted-forks) both flag `pull_request_target` as dangerous because it runs with the upstream's write-scoped `GITHUB_TOKEN` even for fork PRs.

#168 added the guard to `dependabot-auto-merge.yml`. This PR locks that property in: any new `pull_request_target` workflow added without the guard fails CI before merge.

Current audit state on `main`: **1/1 workflow guarded** (regression-proof passes by vacuity if no `pull_request_target` workflows exist).

## Local verification

```bash
python3 scripts/check-pull-request-target-guard.py
# OK: 1 pull_request_target workflow(s) audited, all jobs fork-guarded.
# exit=0

# Regression test: temporarily strip the guard from dependabot-auto-merge.yml
python3 scripts/check-pull-request-target-guard.py
# ::error file=.github/workflows/dependabot-auto-merge.yml::job 'auto-merge' is missing the fork-guard
# FAIL: 1 unguarded job(s) across 1 pull_request_target workflow(s).
# exit=1
```

## Test plan

- [ ] CI runs the new `workflow-fork-guard` job
- [ ] Job exits 0 on this PR (existing guard is intact)
- [ ] All other jobs unchanged
- [ ] PyYAML pin is `>=6.0,<7` to keep the install minimal

🤖 Generated with [Claude Code](https://claude.com/claude-code)