### PR TITLE
chore(ci): exclude test self-coverage from kcov measurement

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -190,7 +190,12 @@ jobs:
           # script's bash lines, producing 0 total_lines.
           # Filename-substring --include-pattern so the `../lib` sourced
           # paths match (see commit history for why /scanner/lib/ patterns
-          # failed).
+          # failed). We intentionally measure only the SUT (checks.sh,
+          # output.sh) and NOT each test_*.sh's own line coverage — kcov
+          # cannot reliably trace into multi-line `$(...)` command-
+          # substitution subshells that some tests rely on for stub
+          # scoping, which would otherwise pollute the overall percentage
+          # with false-negative uncovered lines in test code.
           chmod +x scanner/tests/test_*.sh
           for sh in scanner/tests/test_*.sh; do
             name=$(basename "$sh" .sh)
@@ -198,11 +203,11 @@ jobs:
             # true inside the TTY-gated functions they exercise.
             if [[ "$name" == *_tty ]]; then
               python3 scanner/tests/pty_run.py \
-                kcov --include-pattern=checks.sh,output.sh,"$name".sh \
+                kcov --include-pattern=checks.sh,output.sh \
                   "kcov-out/$name" "$sh" \
                 || echo "WARN: $sh exited non-zero under kcov (pty)"
             else
-              kcov --include-pattern=checks.sh,output.sh,"$name".sh \
+              kcov --include-pattern=checks.sh,output.sh \
                 "kcov-out/$name" "$sh" \
                 || echo "WARN: $sh exited non-zero under kcov"
             fi


### PR DESCRIPTION
## Summary

Drop `\"\$name\".sh` from kcov's `--include-pattern` in the `scanner-shell-coverage` job so coverage measurement counts only the SUT (`checks.sh`, `output.sh`) and not each test file's own line coverage.

```diff
-kcov --include-pattern=checks.sh,output.sh,"\$name".sh
+kcov --include-pattern=checks.sh,output.sh
```

## Why

kcov v42 cannot reliably trace lines inside **multi-line `\$(...)`** command-substitution subshells — the parent-process DEBUG trap doesn't inherit into the forked subshell. When a test file uses `var=\$( source ...; cmd; echo \"rc=\$?\" )` for stub scoping (a legitimate pattern for keeping function overrides scoped), kcov marks those internal lines as uncovered.

This produced a false-negative regression in PR #171: `test_checks_coverage.sh` landed at 71.67% self-coverage purely because of multi-line `\$(...)` usage, dragging overall kcov from 91.19% → 91.14% even though the actual SUT (`output.sh` 87→92, `checks.sh` 88→91) clearly improved.

After this change the percentage reflects pure SUT coverage — what we actually care about. The 85% floor still applies and is comfortably met:

- `output.sh` 92.44% (440/476)
- `checks.sh` 91.48% (451/493)
- Lib-only ≈ 891/969 = **91.95%**

## Test plan

- [ ] `scanner-shell-coverage` job still passes (kcov runs same tests, only filters differently)
- [ ] New baseline shown in summary step (expect ~91.95% — down from 91.14% _only because the test self-coverage that was previously pulling DOWN the average no longer counts_)
- [ ] 85% floor gate still passes
- [ ] No change to which tests run, only what gets measured

🤖 Generated with [Claude Code](https://claude.com/claude-code)