### PR TITLE
chore(ci): raise scanner-shell-coverage kcov floor 85% → 90%

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -232,7 +232,7 @@ jobs:
             echo "Contents of kcov-out/merged/ (top two levels):"
             find kcov-out/merged -maxdepth 2 -print 2>/dev/null || true
           fi
-      - name: Enforce bash coverage threshold (>=85%)
+      - name: Enforce bash coverage threshold (>=90%)
         run: |
           # Re-run the same find-based discovery as the summary step so this
           # gate is robust to kcov's nested merge subdir names.
@@ -248,7 +248,10 @@ jobs:
           import json
           import sys
 
-          threshold = 85.0
+          # Floor raised from 85 -> 90 after PR #171/#173/#174 lifted SUT
+          # coverage from 91.19% -> 92.36% (lib-only methodology). Current
+          # safety margin: ~2.36pp.
+          threshold = 90.0
           path = sys.argv[1]
           with open(path) as fh:
               data = json.load(fh)


### PR DESCRIPTION
## Summary

Bump the bash-coverage gate in `.github/workflows/lint.yml::scanner-shell-coverage` from **85.0%** to **90.0%**, locking in the gains from #171 / #173 / #174.

## Current state

| File | Coverage |
|---|---|
| `scanner/lib/output.sh` | 93.28% (444/476) |
| `scanner/lib/checks.sh` | 91.48% (451/493) |
| **Overall (lib-only, post-#173)** | **92.36%** (895/969) |

Safety margin above the new floor: **~2.36pp**. Comfortable, not knife-edge.

## Why now

- Three back-to-back PRs lifted lib SUT coverage materially
- #173 made the metric honest (measures SUT only, not test self-coverage)
- The 85% floor was a leftover from earlier kcov-v38 days when the measurement was noisy; the new methodology is stable enough to ratchet the gate up

## Test plan

- [ ] `scanner-shell-coverage` job still passes (overall 92.36% > new 90% floor)
- [ ] Threshold message in the workflow log changes from "≥85%" to "≥90%"
- [ ] No change to which tests run

🤖 Generated with [Claude Code](https://claude.com/claude-code)