### PR TITLE
test(scanner/lib): cover checks.sh L374 + L403 via direct-call pattern (toward 95%)

### DIFF
--- a/scanner/tests/test_checks_lib_direct.sh
+++ b/scanner/tests/test_checks_lib_direct.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# Direct-call coverage tests for scanner/lib/checks.sh.
+#
+# The existing test_checks_coverage.sh relies on var=$( source ...; cmd )
+# command-substitution blocks for stub scoping. kcov v42 cannot reliably
+# trace lines inside `$(...)` forked subshells, which leaves
+# `return 0`/branch-success lines uncovered even when the path executes.
+#
+# This file uses the alternative pattern: define stubs, call the SUT in
+# the *current* shell, then restore the stubs via stored declare -f
+# output. kcov DEBUG-trap fires on each in-shell line, so lib branches
+# get coverage.
+#
+# Targets (from kcov main artifact 26552645502):
+#   L374  has_gcp_credentials   gcloud-auth success branch
+#   L403  has_github_credentials  gh-auth-status success branch
+#
+# Run: bash scanner/tests/test_checks_lib_direct.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $expected"
+    echo "    actual:   $actual"
+    ((TEST_FAILED++))
+  fi
+}
+
+# Stub color codes referenced by checks.sh
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+
+source "$LIB_DIR/checks.sh"
+
+# Snapshot the original definitions we'll override so each test can
+# restore them. Bash's `declare -f` returns the function body as a
+# multi-line string we can `eval` back later.
+_orig_has_command=$(declare -f has_command)
+_orig_run_with_timeout=$(declare -f run_with_timeout)
+
+_restore_originals() {
+  unset -f has_command 2>/dev/null || true
+  unset -f run_with_timeout 2>/dev/null || true
+  unset -f gcloud 2>/dev/null || true
+  unset -f gh 2>/dev/null || true
+  unset -f grep_stub 2>/dev/null || true
+  eval "$_orig_has_command"
+  eval "$_orig_run_with_timeout"
+}
+
+# ============================================================================
+# L374: has_gcp_credentials -> gcloud auth list success path
+#
+# Override has_command to recognize 'gcloud' as present, run_with_timeout
+# to passthrough, gcloud to emit an account name on stdout. The pipeline
+# `... | grep -q .` then succeeds and the inline `return 0` runs.
+# ============================================================================
+echo ""
+echo "=== L374: has_gcp_credentials gcloud-success branch ==="
+
+has_command() { [[ "$1" == "gcloud" ]]; }
+run_with_timeout() {
+  shift          # consume timeout
+  "$@"           # passthrough — the real impl uses `timeout/gtimeout/python3 fallback`
+}
+gcloud() {
+  # Mimic `gcloud auth list --filter=status:ACTIVE --format=value(account)`
+  # producing a single active-account line so the downstream `grep -q .`
+  # matches.
+  echo "tester@example.com"
+}
+
+has_gcp_credentials
+rc=$?
+assert_eq "L374: has_gcp_credentials returns 0 with active gcloud account" "0" "$rc"
+
+_restore_originals
+
+# ============================================================================
+# L403: has_github_credentials -> gh auth status success path
+#
+# Two preconditions on the function: GH_TOKEN and GITHUB_TOKEN must both
+# be empty (so the env-var branch is skipped), and gh auth status must
+# succeed under run_with_timeout.
+# ============================================================================
+echo ""
+echo "=== L403: has_github_credentials gh-auth-status success branch ==="
+
+OLD_GH_TOKEN="${GH_TOKEN:-}"
+OLD_GITHUB_TOKEN="${GITHUB_TOKEN:-}"
+unset GH_TOKEN GITHUB_TOKEN
+
+has_command() { [[ "$1" == "gh" ]]; }
+run_with_timeout() {
+  shift          # consume timeout
+  "$@"
+}
+gh() {
+  # `gh auth status` exits 0 when authenticated.
+  [[ "$1" == "auth" && "$2" == "status" ]] && return 0
+  return 1
+}
+
+has_github_credentials
+rc=$?
+assert_eq "L403: has_github_credentials returns 0 with gh-auth-status success" "0" "$rc"
+
+# Restore env
+[[ -n "$OLD_GH_TOKEN" ]] && export GH_TOKEN="$OLD_GH_TOKEN"
+[[ -n "$OLD_GITHUB_TOKEN" ]] && export GITHUB_TOKEN="$OLD_GITHUB_TOKEN"
+_restore_originals
+
+# ============================================================================
+# Additional pass: drive has_gcp_credentials through its OTHER branches
+# (L376-377 ADC file path) and has_github_credentials through its env-var
+# path (L400) to ensure no regression in already-covered code.
+# ============================================================================
+echo ""
+echo "=== Regression: existing branches still pass ==="
+
+# has_gcp_credentials L376-377: GOOGLE_APPLICATION_CREDENTIALS set + file present
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+touch "$tmpdir/adc.json"
+has_command() { return 1; }   # gcloud absent
+OLD_GAC="${GOOGLE_APPLICATION_CREDENTIALS:-}"
+export GOOGLE_APPLICATION_CREDENTIALS="$tmpdir/adc.json"
+has_gcp_credentials
+rc=$?
+assert_eq "regression: has_gcp_credentials ADC-file branch returns 0" "0" "$rc"
+[[ -n "$OLD_GAC" ]] && export GOOGLE_APPLICATION_CREDENTIALS="$OLD_GAC" || unset GOOGLE_APPLICATION_CREDENTIALS
+_restore_originals
+
+# has_github_credentials L399-400: GH_TOKEN env var set
+export GH_TOKEN="ghp_test_token"
+has_github_credentials
+rc=$?
+assert_eq "regression: has_github_credentials GH_TOKEN-env branch returns 0" "0" "$rc"
+unset GH_TOKEN
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "=========================================="
+echo "Results: PASSED=$TEST_PASSED FAILED=$TEST_FAILED"
+echo "=========================================="
+[[ "$TEST_FAILED" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Add `scanner/tests/test_checks_lib_direct.sh` exercising two previously-uncovered branch-success `return 0` lines in `scanner/lib/checks.sh`:

- **L374** — `has_gcp_credentials` gcloud-auth success branch
- **L403** — `has_github_credentials` gh-auth-status success branch

## Why a separate test file

The existing `test_checks_coverage.sh` (from #171) reaches these branches but does so inside `var=\$( source ...; cmd )` blocks. kcov v42 does not reliably trace into `\$(...)` forked subshells, so the internal `return 0` lines stayed uncovered despite the path executing.

This file uses a **direct-call pattern** instead: define stubs in the current shell, call the SUT in-shell, restore via stored `declare -f` snapshots. kcov DEBUG-trap fires on each in-shell command so the inline `return 0` gets the hit.

## Honest scoping

This is a partial push toward the 95% target, **not** the full delta. Expected gain: `checks.sh` 91.48% → **~91.89%** (+~2 lines). The remaining ~40 uncovered lines are structurally hard to cover under kcov v42:

| Pattern | Lines | Why uncoverable |
|---|---|---|
| `python3 -c 'multi-line'` heredoc | L21-28 | String literal lines aren't separately-executable bash |
| `awk 'multi-line'` heredoc | L114-138 | Same — awk script body is one string arg |
| Multi-line array `local x=(\n a\n b\n )` | L483-488 | One bash assignment spanning text lines |
| `done < <(find ...)` process substitution | L498, L522 | kcov can't trace process substitutions |
| Function calls inside `\$(...)` | L64, L73, L281-320 | Subshell trace gap |

A lib-side refactor (collapse multi-line strings, replace process substitutions with intermediate variables) would be needed to push checks.sh much beyond ~92.5%.

## Test plan

- [x] Local: `bash scanner/tests/test_checks_lib_direct.sh` → 4 PASS / 0 FAIL
- [ ] `scanner-shell-coverage` picks up the new test via existing `for sh in scanner/tests/test_*.sh` glob
- [ ] Expected new baseline: `checks.sh` 91.89%, overall (lib-only) ~92.56%

🤖 Generated with [Claude Code](https://claude.com/claude-code)