### PR TITLE
chore(ci): drop duplicate Lighthouse, gate lychee, fix SC2044

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,7 @@ jobs:
       python_deps: ${{ steps.detect.outputs.python_deps }}
       npm_deps: ${{ steps.detect.outputs.npm_deps }}
       shell: ${{ steps.detect.outputs.shell }}
+      markdown: ${{ steps.detect.outputs.markdown }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
@@ -77,6 +78,7 @@ jobs:
             echo "python_deps=$(match '^(requirements.*\.txt|pyproject\.toml|setup\.py)')"
             echo "npm_deps=$(match '^(package(-lock)?\.json|\.nvmrc)')"
             echo "shell=$(match '\.(sh|bash)$')"
+            echo "markdown=$(match '\.md$')"
           } >> "$GITHUB_OUTPUT"
 
   dependency-review:
@@ -413,33 +415,13 @@ jobs:
         run: test -f "$RUNNER_TEMP/claudesec-scan/claudesec-dashboard.html"
       - name: Validate dashboard content
         run: grep -qi "ClaudeSec.*Security" "$RUNNER_TEMP/claudesec-scan/claudesec-dashboard.html"
-      - name: Install Lighthouse CI
-        run: npm install -g @lhci/cli@0.14.x
-      - name: Run Lighthouse accessibility audit
-        run: |
-          cd "$RUNNER_TEMP/claudesec-scan"
-          lhci autorun --collect.staticDistDir=. \
-            --collect.url=claudesec-dashboard.html \
-            --assert.preset=lighthouse:no-pwa \
-            --assert.assertions.categories:accessibility=off \
-            --upload.target=temporary-public-storage || true
-      - name: Check Lighthouse accessibility score
-        run: |
-          cd "$RUNNER_TEMP/claudesec-scan"
-          if [ -d ".lighthouseci" ]; then
-            score=$(node -e "
-              const fs = require('fs');
-              const files = fs.readdirSync('.lighthouseci').filter(f => f.endsWith('.json') && f.startsWith('lhr-'));
-              if (files.length) {
-                const lhr = JSON.parse(fs.readFileSync('.lighthouseci/' + files[0]));
-                console.log(Math.round(lhr.categories.accessibility.score * 100));
-              } else { console.log(0); }
-            ")
-            echo "Accessibility score: $score"
-            if [ "$score" -lt 90 ]; then
-              echo "::warning::Lighthouse accessibility score $score is below 90"
-            fi
-          fi
+      # Lighthouse audit removed: security-scan.yml::lighthouse already runs
+      # the same audit against the same generated dashboard, and
+      # lighthouse.yml audits the live deployed Pages. The previous lhci run
+      # here was informational only (`--assert.assertions.categories:accessibility=off`
+      # disabled the gate, and the trailing score check emitted ::warning::
+      # rather than failing), so dropping it removes ~30s of npm install +
+      # headless Chrome boot per Lint run without losing signal.
 
   pii-check:
     runs-on: ubuntu-latest
@@ -509,14 +491,19 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Check YAML frontmatter in docs
+        # Uses find -print0 + while-read with process substitution to avoid
+        # the shellcheck SC2044 fragile-for-loop pattern. Process substitution
+        # keeps the while loop in the parent shell so `failed=1` propagates
+        # (a pipeline `find | while read` would put the loop in a subshell
+        # and lose the flag).
         run: |
           failed=0
-          for f in $(find docs -name '*.md' -not -path '*/node_modules/*'); do
+          while IFS= read -r -d '' f; do
             if ! head -1 "$f" | grep -q '^---$'; then
               echo "::error file=$f::Missing YAML frontmatter"
               failed=1
             fi
-          done
+          done < <(find docs -name '*.md' -not -path '*/node_modules/*' -print0)
           if [ "$failed" -eq 1 ]; then
             echo "::error::Some docs files are missing YAML frontmatter (title, description, tags)"
             exit 1
@@ -592,7 +579,13 @@ jobs:
             !.claude/**
 
   link-check:
+    # lychee scans *.md link validity. If no markdown changed, nothing new
+    # to verify — gate on the `markdown` bucket so docs-untouched PRs skip
+    # the external HTTP fetches entirely. Scheduled runs always execute so
+    # link rot from external URLs is still caught on a cadence.
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.markdown == 'true' || github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Check links


### PR DESCRIPTION
## Summary

Round 2 of CI optimizations following #180. Three independent lint.yml tweaks in one PR (all touch lint.yml, so bundling saves a CI cycle).

| Change | Where | Win |
|--------|-------|-----|
| Remove duplicate Lighthouse audit | `lint.yml::dashboard-regression-check` | ~30s/Lint run; signal already covered by `security-scan.yml::lighthouse` |
| Gate lychee on markdown changes | `lint.yml::link-check` + new `markdown` output on `changes` job | Skips external-URL HTTP fetches on non-docs PRs; weekly cadence preserved via schedule trigger |
| Fix SC2044 in frontmatter-check | `lint.yml::frontmatter-check` | Clears the only actionlint warning in this file; safer against filenames with whitespace |

## Why the Lighthouse drop is safe

`lint.yml::dashboard-regression-check`'s Lighthouse block was already non-gating:
- `--assert.assertions.categories:accessibility=off` disabled the assertion
- The trailing score check used `echo "::warning::"` (never fails the job)

`security-scan.yml::lighthouse` runs against the same generated dashboard and gates on Performance + Accessibility, so the audit is preserved — just not duplicated.

## SC2044 fix details

```diff
-for f in $(find docs -name '*.md' -not -path '*/node_modules/*'); do
+while IFS= read -r -d '' f; do
   if ! head -1 "$f" | grep -q '^---$'; then
     ...
     failed=1
   fi
-done
+done < <(find docs -name '*.md' -not -path '*/node_modules/*' -print0)
```

Process substitution `< <(...)` keeps the while loop in the parent shell so `failed=1` propagates (a pipeline would put the loop in a subshell and lose the flag). Verified locally:

- Missing frontmatter: emits `::error file=...` and exits 1
- All have frontmatter: prints `All docs files have YAML frontmatter` and exits 0

## Test plan

- [ ] `changes` job emits `markdown=false` for this PR (no *.md touched)
- [ ] `link-check` is **skipped** on this PR (proves the new gate works for non-docs PRs)
- [ ] `frontmatter-check` runs and passes on this PR (proves the rewrite still works against all current docs/*.md)
- [ ] `scanner-shell-coverage` cache **hits** on this PR (built and cached during #180's CI; should now take seconds instead of ~5 min)
- [ ] `dashboard-regression-check` runs but no longer installs `@lhci/cli` (verify in step list)
- [ ] All checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)