### PR TITLE
chore(ci): drop fetch-depth: 0 from gitleaks job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -452,9 +452,12 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
+      # Shallow checkout (default fetch-depth: 1) is sufficient because the
+      # `gitleaks dir` invocation below scans the filesystem only — `gitleaks
+      # dir --help` confirms it takes "[path]" and walks files. The history-
+      # scanning subcommand `gitleaks git` is intentionally not used here;
+      # full history checkout was a leftover from the gitleaks-action era.
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-        with:
-          fetch-depth: 0
       # gitleaks/gitleaks-action v2.3.9 (latest) still runs on node20, and the
       # upstream node24 migration (gitleaks/gitleaks-action#215) was still open
       # as of 2026-05-19. To stay clear of the 2026-06-02 node20 deprecation we


### PR DESCRIPTION
## Summary

The gitleaks job runs `gitleaks dir .` which walks the filesystem — it does not need git history. `gitleaks dir --help` confirms the command only accepts a path argument; the history-scanning subcommand is `gitleaks git`, intentionally not used in this workflow.

`fetch-depth: 0` was a leftover from the gitleaks-action era (the previous action scanned commits). Removing it lets `actions/checkout` use its default shallow depth (1).

## Wins

- **Faster checkout** on every Lint run. Negligible on the current repo size; grows with history.
- **Lower false-positive surface in .git/**: a shallow clone writes less metadata into `.git/logs/`. The `.gitleaks.toml` allowlist does not exclude `.git/`, so reducing what ends up there narrows the FP window. (CI has been incidentally safe because runner git config does not match the PII rules.)

## Verification

Local repro on a shallow clone, identical command and config to CI:

```bash
git clone --depth=1 https://github.com/Twodragon0/claudesec
cd claudesec
gitleaks dir . --config .gitleaks.toml --redact --no-banner --exit-code 1 --verbose
```

→ scanned 44 MB in 10s, behaviour identical to `fetch-depth: 0`. `actionlint` clean.

## Risk

If anyone later switches to `gitleaks git` (history scanning), they will need to add `fetch-depth: 0` back. The expanded comment block in the diff makes that explicit.

## Test plan

- [ ] gitleaks job runs on this PR and PASSes (proves shallow clone is sufficient)
- [ ] Lint workflow's `Detect changed paths` marks scanner=true (PR edits lint.yml), so the heavy jobs revalidate
- [ ] All checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)