### PR TITLE
chore(ci): auto-merge minor dependabot updates for github_actions only

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -59,7 +59,32 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Minor updates require manual merge for supply chain security
-      # - name: Auto-merge minor update
-      #   if: steps.metadata.outputs.update-type == 'version-update:semver-minor'
-      #   run: gh pr merge "$PR_URL" --squash --auto
+      # Auto-merge minor updates ONLY for the github_actions ecosystem.
+      # Rationale:
+      #   - github_actions deps are SHA-pinned in workflows, and dependabot
+      #     verifies that the SHA corresponds to the released version. A
+      #     compromised-maintainer scenario would still require the attacker
+      #     to push a tag at a SHA that dependabot then advertises — a much
+      #     higher bar than npm/pip typosquats.
+      #   - npm/pip minor updates pull arbitrary runtime code and remain
+      #     manual-merge for supply chain security.
+      # The fork-guard above (head.repo.full_name == github.repository) plus
+      # branch-protection-required CI together gate this auto-merge.
+      - name: Auto-merge minor update (github_actions only)
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          && steps.metadata.outputs.package-ecosystem == 'github_actions'
+        run: gh pr merge "$PR_URL" --squash --auto
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Comment on minor update (npm/pip — manual review)
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          && steps.metadata.outputs.package-ecosystem != 'github_actions'
+        run: |
+          gh pr comment "$PR_URL" --body "ℹ️ Minor version update for \`${{ steps.metadata.outputs.package-ecosystem }}\` ecosystem auto-approved but **not** auto-merged. Supply-chain policy requires manual merge for npm / pip runtime dependencies."
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Narrow the manual-merge requirement on dependabot PRs to ecosystems where it actually pays off.

| Ecosystem | Patch | Minor (was) | Minor (now) | Major |
|-----------|-------|-------------|-------------|-------|
| github_actions | auto-merge | manual | **auto-merge** | manual |
| npm | auto-merge | manual | manual + visible comment | manual |
| pip | auto-merge | manual | manual + visible comment | manual |

## Rationale

**github_actions: safe to auto-merge minor.** Workflows pin to SHAs. Dependabot verifies the SHA corresponds to the released version. A minor bump cannot smuggle in code without a maintainer-compromise scenario, which also defeats manual review. The actions group bumps weekly (#166, #173, #182…) and these have historically been routine refreshes (Docker buildx, actions/checkout, dependency-review-action, etc.).

**npm/pip: keep manual.** Minor versions pull arbitrary runtime code from a public registry. Typosquat and compromised-maintainer attacks are realistic enough that human eyes per bump remain worthwhile.

## Defense-in-depth preserved

- Fork-guard `head.repo.full_name == github.repository` (added in #168, audit added in #170) still blocks fork PRs from auto-anything.
- Branch protection still requires the full Lint + Security Scan Gate to pass before merge.
- Auto-approval (the step before auto-merge) is unchanged for minor — only the merge gate flips.
- New `Comment on minor update (npm/pip — manual review)` step makes the intentional non-merge visible on the PR.

## Test plan

This PR can't validate its own change since it's a workflow edit, not a dependabot PR. The next dependabot actions group minor bump (typically within the week, weekly cron at `interval: weekly`) will exercise the new flow. Until then:

- [ ] `Auto-merge Dependabot PR` workflow remains green on this PR (fork-guard not triggered for own-repo branch)
- [ ] actionlint clean
- [ ] On next dependabot github_actions minor bump: PR auto-approves AND auto-merges
- [ ] On next dependabot npm/pip minor bump: PR auto-approves, posts the new comment, and does NOT auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)