### PR TITLE
chore(ci): kcov per-test ::group:: + timing + timeout 120 cap

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -292,21 +292,47 @@ jobs:
           # substitution subshells that some tests rely on for stub
           # scoping, which would otherwise pollute the overall percentage
           # with false-negative uncovered lines in test code.
+          #
+          # Per-test ::group:: + start/elapsed printf makes per-test runtime
+          # visible in the run log (added after the 2026-06-01 tracer found
+          # this job's wall-clock varies 35s ~ 27min depending on which test
+          # hits the kcov xtrace ptrace amplification path; per-test timing
+          # discriminates between runner stall (H1) and a single pathological
+          # test (H2)).
+          #
+          # `timeout 120` is a defensive cap — if any future test stalls under
+          # kcov instrumentation it now fails fast at 2 min with a warning
+          # annotation, instead of consuming up to 27 min of CI before the
+          # job-level timeout. The kcov exit code is preserved on normal
+          # completion; only timeout exit 124 is treated as a warning so the
+          # remaining tests still run and we still get a coverage merge.
           chmod +x scanner/tests/test_*.sh
           for sh in scanner/tests/test_*.sh; do
             name=$(basename "$sh" .sh)
+            echo "::group::kcov $name"
+            start=$(date +%s)
             # *_tty tests need stdin to be a pty slave so [[ -t 0 ]] returns
             # true inside the TTY-gated functions they exercise.
             if [[ "$name" == *_tty ]]; then
-              python3 scanner/tests/pty_run.py \
-                kcov --include-pattern=checks.sh,output.sh \
-                  "kcov-out/$name" "$sh" \
-                || echo "WARN: $sh exited non-zero under kcov (pty)"
+              timeout 120 \
+                python3 scanner/tests/pty_run.py \
+                  kcov --include-pattern=checks.sh,output.sh \
+                    "kcov-out/$name" "$sh"
+              rc=$?
             else
-              kcov --include-pattern=checks.sh,output.sh \
-                "kcov-out/$name" "$sh" \
-                || echo "WARN: $sh exited non-zero under kcov"
+              timeout 120 \
+                kcov --include-pattern=checks.sh,output.sh \
+                  "kcov-out/$name" "$sh"
+              rc=$?
             fi
+            elapsed=$(( $(date +%s) - start ))
+            if [ "$rc" -eq 124 ]; then
+              echo "::warning::kcov $name TIMED OUT after ${elapsed}s (>=120s cap)"
+            elif [ "$rc" -ne 0 ]; then
+              echo "WARN: $sh exited non-zero under kcov (rc=$rc, ${elapsed}s)"
+            fi
+            echo "kcov $name elapsed=${elapsed}s rc=${rc}"
+            echo "::endgroup::"
           done
           kcov --merge kcov-out/merged kcov-out/*/
       - name: Print bash coverage summary

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -307,23 +307,30 @@ jobs:
           # completion; only timeout exit 124 is treated as a warning so the
           # remaining tests still run and we still get a coverage merge.
           chmod +x scanner/tests/test_*.sh
+          # GitHub Actions sets `bash -eo pipefail` by default, so any non-zero
+          # exit from `timeout 120 kcov ...` (e.g., 124 on cap-hit) would abort
+          # the whole step before our rc-check runs. Use `|| rc=$?` so the
+          # exit is captured into rc and the loop can decide whether to warn
+          # or continue. (Prior to this fix the previous kcov loop relied on
+          # `|| echo WARN` for the same reason.)
           for sh in scanner/tests/test_*.sh; do
             name=$(basename "$sh" .sh)
             echo "::group::kcov $name"
             start=$(date +%s)
+            rc=0
             # *_tty tests need stdin to be a pty slave so [[ -t 0 ]] returns
             # true inside the TTY-gated functions they exercise.
             if [[ "$name" == *_tty ]]; then
               timeout 120 \
                 python3 scanner/tests/pty_run.py \
                   kcov --include-pattern=checks.sh,output.sh \
-                    "kcov-out/$name" "$sh"
-              rc=$?
+                    "kcov-out/$name" "$sh" \
+                || rc=$?
             else
               timeout 120 \
                 kcov --include-pattern=checks.sh,output.sh \
-                  "kcov-out/$name" "$sh"
-              rc=$?
+                  "kcov-out/$name" "$sh" \
+                || rc=$?
             fi
             elapsed=$(( $(date +%s) - start ))
             if [ "$rc" -eq 124 ]; then


### PR DESCRIPTION
## Summary

Tracer follow-up for scanner-shell-coverage runtime variance (35s ~ 27min across same-code runs, pinned to `test_output_coverage.sh:93` by the 2026-06-01 trace).

Adds two changes to the kcov for-loop:

1. **Per-test ::group:: + start/elapsed logging** — every test gets a collapsible group in the GitHub Actions log and a single `kcov $name elapsed=Ns rc=X` summary line. Makes future variance attributable to a specific test instead of the aggregate step.
2. **`timeout 120` defensive cap** — on cap-hit, `timeout` exits 124, we emit a `::warning::`, log elapsed, and continue to the next test. The merge step still runs and the ≥90% coverage floor still gates.

## Why both, why now

The trace concluded with two compounding hypotheses (H1 = runner-side stall; H2 = test-specific kcov ptrace amplification). The discriminating probe was *visibility* — the same instrumentation lets future runs answer "which test was slow?" in a single grep. The `timeout` cap is the defensive payoff: even if H1 or H2 reproduces, the worst case is now ~2 min/test wall-clock instead of 27 min/job.

## Why `timeout` and not `--preserve-status`

I initially used `timeout --preserve-status 120` and then reverted it: `--preserve-status` propagates the command's exit code on cap-hit, which makes cap detection impossible. Plain `timeout 120` returns 124 on cap, which is what the new `if [ "$rc" -eq 124 ]` branch checks for.

## Test plan

- [ ] actionlint clean (verified locally)
- [ ] `scanner-shell-coverage` job still passes (workflow self-edit → heavy jobs revalidate per #180 gating)
- [ ] Each per-test line appears in the log under its own `::group::` (manually inspect)
- [ ] If any test exceeds 120s, the workflow does NOT fail on that test (the `if rc==124` branch emits warning, kcov merge proceeds)
- [ ] Coverage floor gate still passes (90%)

## Related

- #180 — added the path-gating that makes lint.yml self-edits run heavy jobs to revalidate
- #186 — same pattern in security-scan.yml
- Tracer report from this session: H1+H2 combined model for the 35s ~ 27min variance

🤖 Generated with [Claude Code](https://claude.com/claude-code)