### PR TITLE
chore(ci): exempt non-self workflow files from security-scan trigger

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -66,10 +66,25 @@ jobs:
           fi
           echo "Changed files:"
           echo "$FILES"
-          # Anything outside docs/markdown/cursor/claude rules triggers a real
-          # scan. Inverse of the previous paths-ignore list, plus workflow
-          # files themselves (workflow edits should re-validate the gate).
-          if printf '%s\n' "$FILES" | grep -vE '^(docs/|.*\.md$|\.cursor/|\.claude/|CODEOWNERS$|LICENSE$)' >/dev/null; then
+          # `code=true` when at least one changed file is meaningful runtime
+          # input to the scanner. The classification is:
+          #
+          #   - SAFE-SKIP (do not trigger scan):
+          #       docs/**, **/*.md, .cursor/**, .claude/**, CODEOWNERS, LICENSE,
+          #       .github/workflows/*.yml  (other workflow files cannot change
+          #       scanner/dashboard runtime — see PR #184 incident where editing
+          #       dependabot-auto-merge.yml triggered an unrelated 3m20s scan)
+          #
+          #   - ALWAYS-TRIGGER (force scan revalidation):
+          #       .github/workflows/security-scan.yml  (this workflow itself —
+          #       any change to gating logic must re-run the heavy scan)
+          #
+          #   - REAL CODE (trigger scan):
+          #       scanner/, scripts/, hooks/, Dockerfile, docker-compose*,
+          #       requirements*.txt, etc. — anything outside the safe-skip set.
+          self_edit=$(printf '%s\n' "$FILES" | grep -E '^\.github/workflows/security-scan\.yml$' || true)
+          non_safe=$(printf '%s\n' "$FILES" | grep -vE '^(docs/|.*\.md$|\.cursor/|\.claude/|CODEOWNERS$|LICENSE$|\.github/workflows/[^/]+\.ya?ml$)' || true)
+          if [ -n "$self_edit" ] || [ -n "$non_safe" ]; then
             echo "code=true" >> "$GITHUB_OUTPUT"
           else
             echo "code=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary

Fix the classification in `security-scan.yml::changes` so that **editing a workflow file other than `security-scan.yml` itself** no longer triggers a heavy 3+ minute `Run Security Scan`.

## The bug (observed on PR #184)

PR #184 only touched `.github/workflows/dependabot-auto-merge.yml` — a CI policy config that cannot affect scanner runtime. The #186 `changes` job still classified it as `code=true` (anything outside `docs/`, `*.md`, `.cursor/`, `.claude/`, `CODEOWNERS`, `LICENSE`), so the workflow burned 3m20s on `Run Security Scan` + the dependent Lighthouse audit before merging.

## Fix

Two buckets:

- **`self_edit`** matches `^\.github/workflows/security-scan\.yml$` exactly. Any change to this workflow forces `code=true` — gating logic edits must revalidate against a real scan. Same self-edit-forces-scan pattern lint.yml uses.
- **`non_safe`** is every changed file that is NOT in the safe-skip set, now extended to include `.github/workflows/*.yml` (non-self).

`code=true` iff at least one `self_edit` OR `non_safe` file exists.

## Local simulation

| Diff | Expected `code` | Result |
|------|-----------------|--------|
| `docs/reports/r.md` | `false` | ✓ |
| `scanner/lib/checks.sh` | `true` | ✓ |
| `Dockerfile` | `true` | ✓ |
| `.github/workflows/dependabot-auto-merge.yml` (← #184 case) | `false` | ✓ |
| `.github/workflows/lint.yml` | `false` | ✓ |
| `.github/workflows/security-scan.yml` (self) | `true` | ✓ |
| self + other workflow | `true` | ✓ |
| docs + non-self workflow | `false` | ✓ |
| scanner code + non-self workflow | `true` | ✓ |

9/9 cases pass locally.

## What this PR does NOT change

- lint.yml's `changes` detector still includes `^\.github/workflows/lint\.yml` in its scanner/docker buckets so lint-workflow self-edits still revalidate the heavy lint jobs.
- The workflow-level trigger is unchanged: security-scan.yml still runs on every push/PR (no paths-ignore — that was the #185 bug fixed in #186). The `Security Scan Gate` check still always emits.

## Test plan

This PR itself **edits `security-scan.yml`** (self-edit) so `code=true` and a full scan runs to validate the gating logic. Future workflow-only PRs (e.g., dependabot-auto-merge bumps) will skip the heavy scan and only see the small `Detect changed paths` + `Security Scan Gate` jobs.

- [ ] `Run Security Scan` + `Lighthouse Audit` run on this PR (self-edit path)
- [ ] All checks green
- [ ] After merge, open a workflow-only PR (e.g., touch lint.yml) and confirm `Run Security Scan` SKIPs while `Security Scan Gate` still emits SUCCESS

🤖 Generated with [Claude Code](https://claude.com/claude-code)