### PR TITLE
fix(ci): set CLAUDESEC_DASHBOARD_OFFLINE=1 for kcov shell-coverage job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -246,6 +246,20 @@ jobs:
     runs-on: ubuntu-latest
     needs: [changes, scanner-unit-tests]
     if: needs.changes.outputs.scanner == 'true' || github.event_name == 'schedule'
+    env:
+      # Run dashboard generation fully offline under kcov. Without this,
+      # generate_html_dashboard() spawns python3 dashboard-gen.py, which makes
+      # live GitHub API calls (dashboard_data_loader.py gates them on this var).
+      # test_output_coverage.sh alone calls generate_html_dashboard 24 times, so
+      # those network round-trips — amplified by kcov's ptrace tracing of every
+      # subprocess — drove the per-test runtime to the 120s cap with wall-clock
+      # variance of 35s~27min (the variance was network latency, not xtrace; this
+      # is the actual root cause behind the earlier-refuted H2 hypothesis). The
+      # network calls live in python, NOT in checks.sh/output.sh, so they
+      # contribute ZERO to the bash coverage measured here — pure waste. Offline
+      # mode keeps output.sh's python-invocation path identical (exit 0, file
+      # written) so measured bash coverage is unchanged; local: 120s+ -> 3.7s.
+      CLAUDESEC_DASHBOARD_OFFLINE: "1"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Cache kcov v42 binary


### PR DESCRIPTION
## Summary

The `scanner-shell-coverage` (kcov) job did **not** set `CLAUDESEC_DASHBOARD_OFFLINE`, unlike the pytest step in `scanner-unit-tests` (lint.yml:188). Without it, `generate_html_dashboard()` in `output.sh` spawns `python3 dashboard-gen.py`, which makes **live GitHub API calls** (gated on this var in `dashboard_data_loader.py:172,210,248`).

`test_output_coverage.sh` alone calls `generate_html_dashboard` **24 times** (1 in Group 2 + 23 in Group 3's `_id_to_category` matrix). Those network round-trips — amplified by kcov's ptrace tracing of every spawned subprocess — drove per-test runtime to the **120s timeout cap**, with the documented 35s~27min wall-clock variance.

That variance was **network latency**, not xtrace amplification — this identifies the actual root cause behind the earlier empirically-refuted **H2 hypothesis**.

## Why coverage is unaffected

The network calls live in **python** (`dashboard-gen.py`), not in `checks.sh`/`output.sh`. The kcov run measures only `--include-pattern=checks.sh,output.sh`, so the network calls contribute **zero** to the measured bash coverage. Offline mode keeps `output.sh`'s python-invocation path identical (python still runs, exits 0, writes the output file → `output.sh:745-747 return 0` path intact), so measured bash coverage is **unchanged**.

## Empirical verification (local, no kcov)

| Condition | Result |
|-----------|--------|
| OFFLINE unset (current CI state) | 80s+ hang (stuck at first `generate_html_dashboard`) |
| `CLAUDESEC_DASHBOARD_OFFLINE=1` | **3.676s, 76 passed / 0 failed** |

Confirmed `generate_html_dashboard` returns 0 and writes both dashboard HTML and `scan-report.json` under OFFLINE=1.

## Change

One job-level `env:` entry on `scanner-shell-coverage` (applies to all steps incl. the kcov loop), with an explanatory comment. Fixes all three test files that call `generate_html_dashboard` without offline (`test_output_coverage.sh`, `test_generate_html_dashboard.sh`, `test_output_functions.sh`).

## Test plan

- [ ] CI `scanner-shell-coverage` job completes well under the 120s per-test cap (no timeout warnings)
- [ ] Merged bash coverage stays >= 90% threshold (unchanged from baseline)
- [ ] No `::warning::kcov ... TIMED OUT` annotations in the kcov loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)