### PR TITLE
test(scanner): hermetic offline guard in generate_html_dashboard tests

### DIFF
--- a/scanner/tests/test_generate_html_dashboard.sh
+++ b/scanner/tests/test_generate_html_dashboard.sh
@@ -4,6 +4,13 @@
 # Run: bash scanner/tests/test_generate_html_dashboard.sh
 set -uo pipefail
 
+# Hermetic offline guard (PR #190): this test calls generate_html_dashboard(),
+# which spawns dashboard-gen.py. Without offline mode that makes live GitHub API
+# calls and can hang for minutes (root cause of the kcov 27min stalls). Force
+# offline here so the test never depends on the network or on the CI job's env,
+# and stays fast everywhere it runs.
+export CLAUDESEC_DASHBOARD_OFFLINE=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR_REAL="$SCRIPT_DIR/../lib"
 

--- a/scanner/tests/test_output_coverage.sh
+++ b/scanner/tests/test_output_coverage.sh
@@ -8,6 +8,13 @@
 # Run: bash scanner/tests/test_output_coverage.sh
 set -uo pipefail
 
+# Hermetic offline guard (PR #190): this test calls generate_html_dashboard(),
+# which spawns dashboard-gen.py. Without offline mode that makes live GitHub API
+# calls and can hang for minutes (root cause of the kcov 27min stalls). Force
+# offline here so the test never depends on the network or on the CI job's env,
+# and stays fast everywhere it runs.
+export CLAUDESEC_DASHBOARD_OFFLINE=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$SCRIPT_DIR/../lib"
 

--- a/scanner/tests/test_output_functions.sh
+++ b/scanner/tests/test_output_functions.sh
@@ -3,6 +3,13 @@
 # Run: bash scanner/tests/test_output_functions.sh
 set -uo pipefail
 
+# Hermetic offline guard (PR #190): this test calls generate_html_dashboard(),
+# which spawns dashboard-gen.py. Without offline mode that makes live GitHub API
+# calls and can hang for minutes (root cause of the kcov 27min stalls). Force
+# offline here so the test never depends on the network or on the CI job's env,
+# and stays fast everywhere it runs.
+export CLAUDESEC_DASHBOARD_OFFLINE=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 LIB_DIR="$SCRIPT_DIR/../lib"
 


### PR DESCRIPTION
## Summary

Follow-up regression guard for #190. That PR fixed the kcov 27min stall by setting `CLAUDESEC_DASHBOARD_OFFLINE=1` at the `scanner-shell-coverage` **job** level, but that leaves the three tests dependent on the CI job's env. If the env entry is ever removed — or these tests run in any other context — `generate_html_dashboard()` again spawns `dashboard-gen.py` making live GitHub API calls and can hang for minutes.

This adds `export CLAUDESEC_DASHBOARD_OFFLINE=1` **inside** each of the three tests that call `generate_html_dashboard`, making them **hermetic**: they can never hang on the network regardless of how they're invoked.

## Why self-set instead of a pure fail-fast guard

A bare `[[ -n $CLAUDESEC_DASHBOARD_OFFLINE ]] || exit 1` would break local `bash scanner/tests/test_*.sh` runs for anyone who forgets the env. Self-setting achieves the same regression protection (never hangs) while keeping local runs frictionless.

## Files

- `scanner/tests/test_output_coverage.sh`
- `scanner/tests/test_generate_html_dashboard.sh`
- `scanner/tests/test_output_functions.sh`

## Verification (env var EXPLICITLY UNSET via `env -u`, simulating a missing job env)

| Test | Result |
|------|--------|
| test_output_coverage | **4.3s, 76 passed / 0 failed** (was 27min hang) |
| test_generate_html_dashboard | **0.12s, 36 passed / 0 failed** |
| test_output_functions | **0.42s, 225 passed / 0 failed** |

`shellcheck -S error`: clean on all three.

## Test plan

- [ ] CI `scanner-shell-coverage` job stays fast (no timeout warnings); coverage unchanged (>=90%)
- [ ] `shell-lint` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)