### PR TITLE
ci(kcov): tighten per-test timeout cap 120s -> 30s after root cause fixed

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -308,21 +308,23 @@ jobs:
           # with false-negative uncovered lines in test code.
           #
           # Per-test ::group:: + start/elapsed printf makes per-test runtime
-          # visible in the run log (added after the 2026-06-01 tracer found
-          # this job's wall-clock varies 35s ~ 27min depending on which test
-          # hits the kcov xtrace ptrace amplification path; per-test timing
-          # discriminates between runner stall (H1) and a single pathological
-          # test (H2)).
+          # visible in the run log. The earlier 35s~27min wall-clock variance
+          # was root-caused (#190) to un-gated GitHub API calls from
+          # dashboard-gen.py when CLAUDESEC_DASHBOARD_OFFLINE was unset on this
+          # job — NOT kcov ptrace/xtrace amplification. With the job-level
+          # offline env (above) + the per-test hermetic guard (#191), every test
+          # now completes in <=9s under kcov (observed max: test_checks_helpers
+          # 4-9s; all others <=3s across the #190/#191 runs).
           #
-          # `timeout 120` is a defensive cap — if any future test stalls under
-          # kcov instrumentation it now fails fast at 2 min with a warning
-          # annotation, instead of consuming up to 27 min of CI before the
-          # job-level timeout. The kcov exit code is preserved on normal
-          # completion; only timeout exit 124 is treated as a warning so the
-          # remaining tests still run and we still get a coverage merge.
+          # `timeout 30` is a defensive cap, tightened 120->30 after the root
+          # cause was removed (#193). 30s is ~3.3x the observed max with ample
+          # runner-variance headroom, yet catches a future network-dependent
+          # regression in 30s instead of 120s. Exit 124 (cap hit) is treated as
+          # a warning so the remaining tests still run and we still get a
+          # coverage merge; normal kcov exit codes are preserved.
           chmod +x scanner/tests/test_*.sh
           # GitHub Actions sets `bash -eo pipefail` by default, so any non-zero
-          # exit from `timeout 120 kcov ...` (e.g., 124 on cap-hit) would abort
+          # exit from `timeout 30 kcov ...` (e.g., 124 on cap-hit) would abort
           # the whole step before our rc-check runs. Use `|| rc=$?` so the
           # exit is captured into rc and the loop can decide whether to warn
           # or continue. (Prior to this fix the previous kcov loop relied on
@@ -335,20 +337,20 @@ jobs:
             # *_tty tests need stdin to be a pty slave so [[ -t 0 ]] returns
             # true inside the TTY-gated functions they exercise.
             if [[ "$name" == *_tty ]]; then
-              timeout 120 \
+              timeout 30 \
                 python3 scanner/tests/pty_run.py \
                   kcov --include-pattern=checks.sh,output.sh \
                     "kcov-out/$name" "$sh" \
                 || rc=$?
             else
-              timeout 120 \
+              timeout 30 \
                 kcov --include-pattern=checks.sh,output.sh \
                   "kcov-out/$name" "$sh" \
                 || rc=$?
             fi
             elapsed=$(( $(date +%s) - start ))
             if [ "$rc" -eq 124 ]; then
-              echo "::warning::kcov $name TIMED OUT after ${elapsed}s (>=120s cap)"
+              echo "::warning::kcov $name TIMED OUT after ${elapsed}s (>=30s cap)"
             elif [ "$rc" -ne 0 ]; then
               echo "WARN: $sh exited non-zero under kcov (rc=$rc, ${elapsed}s)"
             fi


### PR DESCRIPTION
## Summary

Now that the kcov stall root cause is fixed (#190 job-level offline env, #191 per-test hermetic guard), the per-test `timeout` cap can be tightened from 120s to 30s. A tighter cap catches a future network-dependent regression in 30s instead of 120s, while leaving generous headroom over the real runtimes.

## Evidence — observed per-test kcov runtimes (#190 + #191 runs)

| Test | Max observed |
|------|-------------|
| test_checks_helpers | 9s |
| test_check_access_control | 3s |
| test_output_coverage | 2s |
| all other 24 tests | <=1s |

30s = ~3.3x the observed max (test_checks_helpers 9s), absorbing runner variance while still failing fast on a real stall.

## Changes

- `timeout 120` -> `timeout 30` in both the `*_tty` and normal kcov branches
- warning message `>=120s cap` -> `>=30s cap`
- refreshed the stale comment block that described the cap in terms of the refuted xtrace/ptrace (H2) hypothesis

Exit 124 (cap hit) remains a **non-fatal warning** — the loop still completes and the coverage merge still runs, so a single tripped test cannot hard-fail the job.

## Test plan

This PR edits `lint.yml`, which self-triggers `scanner-shell-coverage` (path-gating self-edit rule). CI empirically validates:

- [ ] All 27 kcov tests complete under the new 30s cap (no `TIMED OUT` warnings)
- [ ] Merged bash coverage stays >= 90% (unchanged)
- [ ] `shell-lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)