### PR TITLE
chore(agents): add name/description/tools frontmatter for auto-delegation

### DIFF
--- a/.claude/agents/ci-pipeline.md
+++ b/.claude/agents/ci-pipeline.md
@@ -1,4 +1,7 @@
 ---
+name: ci-pipeline
+description: Manages ClaudeSec CI/CD — GitHub Actions workflows, security-scan integration, quality gates, and automation scripts. Use for changes under .github/workflows/ or scripts/, or when debugging CI failures, kcov/coverage gates, and Dependabot / action-version conflicts.
+tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---
 

--- a/.claude/agents/sec-implementer.md
+++ b/.claude/agents/sec-implementer.md
@@ -1,4 +1,7 @@
 ---
+name: sec-implementer
+description: Implements ClaudeSec changes — scanner checks, Claude Code security hooks, CI/config templates, and vulnerability remediation. Use when building or editing code/docs under scanner/, hooks/, templates/, or docs/guides/. Writes tested, shellcheck-clean bash and verifies before handoff.
+tools: Read, Write, Edit, Bash, Grep, Glob
 model: sonnet
 ---
 

--- a/.claude/agents/sec-orchestrator.md
+++ b/.claude/agents/sec-orchestrator.md
@@ -1,4 +1,6 @@
 ---
+name: sec-orchestrator
+description: Coordinates multi-agent ClaudeSec security workflows — triages scan findings by severity, assigns work to sec-researcher / sec-implementer / sec-reviewer, tracks progress, and accepts completion. Use when a security task spans multiple steps or agents (full scan + remediation, security-guide authoring, scanner-feature delivery, hotfix). Delegates rather than implementing directly.
 model: opus
 ---
 

--- a/.claude/agents/sec-researcher.md
+++ b/.claude/agents/sec-researcher.md
@@ -1,4 +1,7 @@
 ---
+name: sec-researcher
+description: Read-only security research for ClaudeSec — threats, CVEs, attack vectors, and compliance frameworks (NIST, ISO 27001, ISMS-P). Use when a task needs authoritative evidence (OWASP / NIST / CIS / MITRE ATLAS) before any code or docs change. Gathers and cites; does not modify files.
+tools: Read, Grep, Glob, WebSearch, WebFetch
 model: sonnet
 ---
 

--- a/.claude/agents/sec-reviewer.md
+++ b/.claude/agents/sec-reviewer.md
@@ -1,4 +1,7 @@
 ---
+name: sec-reviewer
+description: Read-only security review for ClaudeSec — verifies correctness, security risk, regressions, and that scanner checks detect what they claim. Use after code/docs changes and before commit or merge. Reports issues with severity ratings and cites sources; never edits files. The omitted Write/Edit tools enforce the read-only contract.
+tools: Read, Grep, Glob, Bash
 model: sonnet
 ---
 


### PR DESCRIPTION
## Summary

The 5 ClaudeSec subagents in `.claude/agents/` declared only `model:`. Without a `description`, Claude Code cannot match a task to the agent, so auto-delegation never fired — they were effectively manual-only. This adds the canonical subagent frontmatter so the existing agent roster actually participates in delegation.

## Per-agent frontmatter

| Agent | model | tools | role contract |
|-------|-------|-------|---------------|
| `sec-orchestrator` | opus | *(inherit all)* | must delegate to other agents |
| `sec-researcher` | sonnet | Read, Grep, Glob, WebSearch, WebFetch | read-only research |
| `sec-implementer` | sonnet | Read, Write, Edit, Bash, Grep, Glob | code/docs changes |
| `sec-reviewer` | sonnet | Read, Grep, Glob, Bash | **read-only** — Write/Edit omitted so "report, don't fix" is enforced |
| `ci-pipeline` | sonnet | Read, Write, Edit, Bash, Grep, Glob | CI/scripts |

Each `description` uses action-oriented "use when ..." phrasing so Claude Code can auto-select the right agent.

## Why this is safe

- **Bodies unchanged**: 14 insertions, 0 deletions. Only frontmatter added; `model:` preserved.
- **Validated**: all 5 frontmatter blocks parse as YAML; `name` matches filename.
- **CI-safe**: `markdownlint` config ignores `.claude/agents/**`; `frontmatter-check` scans only `docs/`. Models/names stay consistent with the role table in `AGENTS.md`.

## Test plan

- [ ] CI green (docs-only-style change; heavy jobs gated off by path-gating)
- [ ] `markdown-lint`, `frontmatter-check` pass (both exclude `.claude/agents/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)