### PR TITLE
docs: note CLAUDESEC_DASHBOARD_OFFLINE=1 for dashboard tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,12 @@ bash scanner/tests/test_check_cicd_pipeline.sh
 - All new scanner checks require a corresponding test in `scanner/tests/`.
 - All Markdown must pass `markdownlint`.
 - Links validated with `lychee "**/*.md"`.
+- **Dashboard tests run offline.** Any test that calls `generate_html_dashboard`
+  must run with `CLAUDESEC_DASHBOARD_OFFLINE=1`, otherwise `dashboard-gen.py`
+  makes live GitHub API calls and the test can hang for minutes (root cause of
+  the kcov 27-min stalls; see PR #190/#191). The three current dashboard tests
+  (`test_output_coverage.sh`, `test_generate_html_dashboard.sh`,
+  `test_output_functions.sh`) self-export it; set the same in any new one.
 
 ### Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,11 @@ Token budget: prefer haiku subagents for read-only exploration. Use `run_in_back
 - Autocompact at 70%: run `/compact` manually at logical milestones for better quality
 - When compacting, always preserve the full list of modified files and test commands
 
+## Local Testing
+
+- Run scanner shell tests directly: `bash scanner/tests/test_<name>.sh`.
+- **Set `CLAUDESEC_DASHBOARD_OFFLINE=1`** for any test that calls `generate_html_dashboard`. Without it, `dashboard-gen.py` makes live GitHub API calls and the test can hang for minutes. The kcov coverage job sets this at the job level and the three current dashboard tests also self-export it (PR #190/#191).
+
 ## Quality Gates
 
 - All Markdown must pass markdownlint


### PR DESCRIPTION
## Summary

Documents the offline requirement for dashboard tests so contributors don't rediscover the kcov 27-min stall the hard way.

Tests that call `generate_html_dashboard` spawn `dashboard-gen.py`, which makes **live GitHub API calls** unless `CLAUDESEC_DASHBOARD_OFFLINE=1` is set — the root cause fixed in #190/#191. The three current dashboard tests self-export it, but anyone running them locally or adding a new one needs to know.

## Changes

- **AGENTS.md** — new bullet in the "Testing" section
- **CLAUDE.md** — new "Local Testing" section

## Validation

- `markdownlint-cli2 CLAUDE.md AGENTS.md`: 0 errors
- No new external links (PR numbers are plain text)
- Docs-only change → heavy CI jobs gated off by path-gating (#180)

🤖 Generated with [Claude Code](https://claude.com/claude-code)