### PR TITLE
docs(rules): fill [CUSTOMIZE] sections with ClaudeSec-specific rules

### DIFF
--- a/.claude/rules/coding-style.md
+++ b/.claude/rules/coding-style.md
@@ -66,9 +66,36 @@ Before marking work complete:
 - [ ] No hardcoded values
 - [ ] Immutable patterns used
 
-## [CUSTOMIZE] Project-Specific Style
+## ClaudeSec-Specific Style
 
-Add your project-specific coding style rules here:
-- Naming conventions
-- File structure requirements
-- Framework-specific patterns
+ClaudeSec is a DevSecOps toolkit: Markdown docs + a Bash scanner (`scanner/`),
+Python dashboard generator (`scanner/dashboard-gen.py`), Claude Code hooks
+(`hooks/`), and GitHub Actions. The immutability/TypeScript examples above are
+generic illustrations — apply the intent, not the literal language.
+
+### Naming & layout
+
+- File names are kebab-case (e.g. `github-actions-security.md`).
+- Place new content in the documented directory (`docs/devsecops/`, `docs/ai/`,
+  `scanner/`, `hooks/`, ...); do not add ad-hoc top-level folders.
+- Keep files small and focused; extract shared scanner logic into `scanner/lib/`.
+
+### Markdown
+
+- Every doc under `docs/` needs YAML frontmatter: `title`, `description`, `tags`.
+- All fenced code blocks must declare a language (` ```bash `, ` ```yaml `).
+- Code examples must be tested and runnable, not pseudocode.
+- Security claims must cite an authoritative source (OWASP / NIST / CIS).
+
+### Bash (scanner & scripts)
+
+- Start scripts with `set -euo pipefail`; quote all expansions.
+- Must pass `shellcheck` clean (enforced by the `shell-lint` CI job).
+- Guard any code path that makes network calls so tests can run offline
+  (see `CLAUDESEC_DASHBOARD_OFFLINE` in [Testing](./testing.md)).
+
+### No sensitive data
+
+- Never commit real paths, hostnames, IPs, account IDs, emails, or secrets.
+- Use placeholders: `~/.kube/config`, `/path/to/kubeconfig`, `your-api-key-here`.
+- `.claudesec.yml` is gitignored — users copy from `templates/*.example.yml`.

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -33,9 +33,35 @@ When creating PRs:
 - `refactor/` - Code refactoring
 - `docs/` - Documentation changes
 
-## [CUSTOMIZE] Project-Specific Git Rules
+## ClaudeSec-Specific Git Rules
 
-Add your project-specific git workflow here:
-- Branch protection rules
-- Required reviewers
-- CI/CD requirements
+### Branch protection
+
+- **Never push to `main`.** A pre-push hook blocks `git push origin main`.
+  Always branch (`docs/`, `fix/`, `feat/`, ...) → open a PR → squash-merge.
+- Use `--delete-branch` on merge to keep the remote clean.
+
+### Pre-PR validation (docs changes)
+
+Run locally before opening a docs PR:
+
+```bash
+markdownlint "**/*.md"
+lychee "**/*.md"
+```
+
+### CI / required checks
+
+- Heavy jobs (scanner, docker, lighthouse) are path-gated by the `Detect changed
+  paths` job; unrelated changes show them as `skipping` — that is not a failure.
+- Use job-level gating with an `always()` aggregator, never workflow-level
+  `paths-ignore`, for any check that is a required status (it would block merges).
+- Single CodeQL model: repository default setup only — do not add a duplicate
+  repo-level CodeQL workflow file.
+- Treat an external action download `401` as transient: rerun the failed
+  workflow up to 2 times before manual triage.
+
+### Dependabot action PRs
+
+For action-version conflicts, apply the required update directly to `main`
+(via PR), then close the duplicate/conflicting Dependabot PR with a rationale.

--- a/.claude/rules/performance.md
+++ b/.claude/rules/performance.md
@@ -32,9 +32,28 @@ Before implementing:
 - [ ] Use appropriate data structures
 - [ ] Cache expensive computations
 
-## [CUSTOMIZE] Project-Specific Performance
+## ClaudeSec-Specific Performance
 
-Add your project-specific performance requirements here:
-- Response time targets
-- Bundle size limits
-- Database query limits
+There is no production runtime to tune — performance here means fast, reliable
+CI and a scanner that does not hang.
+
+### Tests must not hang
+
+- Set `CLAUDESEC_DASHBOARD_OFFLINE=1` for any test touching the dashboard
+  generator. Un-gated GitHub API calls were the root cause of multi-minute test
+  hangs (#190): with the guard, a kcov dashboard test dropped from 120s → ~3.7s.
+- Per-test timeout cap in the kcov job is 30s — a test exceeding it is a bug,
+  not a budget to raise.
+
+### Scanner efficiency
+
+- Prefer a single pass over the file tree; avoid re-walking per check.
+- Cache expensive lookups (API responses, parsed configs) within a run.
+- Network calls belong behind an offline guard so coverage runs stay hermetic.
+
+### CI cost control
+
+- Path-gate heavy jobs (scanner, docker, lighthouse) so unrelated docs PRs skip
+  them — see [Git Workflow](./git-workflow.md).
+- For agent work, route read-only exploration to `haiku`; reserve `opus` for
+  architecture and security review.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -32,10 +32,34 @@ If security issue found:
 4. Rotate any exposed secrets
 5. Review entire codebase for similar issues
 
-## [CUSTOMIZE] Project-Specific Security
+## ClaudeSec-Specific Security
 
-Add your project-specific security requirements here:
-- Authentication method
-- Authorization rules
-- Data encryption requirements
-- Compliance requirements (GDPR, HIPAA, etc.)
+ClaudeSec ships no authenticated runtime service — it is a toolkit (scanner,
+hooks, docs). "Security" here means keeping the repo and its outputs clean and
+keeping security advice authoritative.
+
+### Secrets & sensitive data in the repo
+
+- CI enforces secret hygiene with **gitleaks** and **GitGuardian**; a
+  **pii-check** job blocks personal data. Keep them green.
+- Never commit real paths, hostnames, IPs, account IDs, emails, or secrets.
+  Use placeholders (`~/.kube/config`, `your-api-key-here`).
+- `.claudesec.yml` is gitignored; users copy from `templates/*.example.yml` and
+  fill local paths locally only.
+- When user input contains a secret, mask it — never echo it back verbatim.
+
+### Authoritative sourcing
+
+- Every security claim in docs must cite OWASP, NIST, or CIS.
+- LLM/AI security guidance should reference MITRE ATLAS where relevant.
+
+### Compliance scope
+
+- Compliance guides target **NIST, ISO 27001, and ISMS-P** (see
+  `docs/compliance/`). Run the `compliance-check` skill for gap analysis.
+
+### Scanner & hooks
+
+- Claude Code security hooks live in `hooks/`; least-privilege tool access only.
+- The scanner runs against fixture projects offline — never point CI at a real
+  external target without explicit authorization.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -40,8 +40,9 @@ keeping security advice authoritative.
 
 ### Secrets & sensitive data in the repo
 
-- CI enforces secret hygiene with **gitleaks** and **GitGuardian**; a
-  **pii-check** job blocks personal data. Keep them green.
+- CI enforces secret hygiene with the **gitleaks** job and the **pii-check** job
+  in `lint.yml`; **GitGuardian** runs as a separate GitHub App PR check (not a
+  `lint.yml` job). Keep all of them green.
 - Never commit real paths, hostnames, IPs, account IDs, emails, or secrets.
   Use placeholders (`~/.kube/config`, `your-api-key-here`).
 - `.claudesec.yml` is gitignored; users copy from `templates/*.example.yml` and

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -34,9 +34,37 @@ Every function must be tested with:
 - [ ] Both happy path and error paths tested
 - [ ] No flaky tests
 
-## [CUSTOMIZE] Project-Specific Testing
+## ClaudeSec-Specific Testing
 
-Add your project-specific testing requirements here:
-- Test framework configuration
-- Mock setup patterns
-- E2E test scenarios
+### Test suites & commands
+
+- **Scanner shell tests**: `bash scanner/tests/test_<name>.sh` (one file per case).
+- **Scanner unit tests (Python)**: `pytest scanner/` — `scanner/lib/` has a 99%
+  coverage floor (live ~99.12%) enforced in CI.
+- **Shell coverage**: `kcov` aggregates coverage at
+  `kcov-out/merged/kcov-merged/coverage.json`; floor is 85% (baseline ~89%).
+- **Docs**: `markdownlint "**/*.md"` and `lychee "**/*.md"` before any docs PR.
+
+### Offline guard (REQUIRED)
+
+Any test that calls `generate_html_dashboard` MUST export
+`CLAUDESEC_DASHBOARD_OFFLINE=1`. Without it, `dashboard-gen.py` makes live GitHub
+API calls and the test can hang for minutes (root cause of the kcov slowdown
+fixed in #190). The kcov job sets this at the job level; new dashboard tests
+should also self-export it.
+
+```bash
+CLAUDESEC_DASHBOARD_OFFLINE=1 bash scanner/tests/test_generate_html_dashboard.sh
+```
+
+### Mocking external dependencies
+
+- Stub the GitHub API via the offline guard rather than hitting the network.
+- Tests must be hermetic: no live API, no real repo paths, no machine-specific
+  state. Use fixtures and placeholders, never real PII or company paths.
+
+### What "E2E" means here
+
+There is no web app to drive. End-to-end coverage = run the scanner against an
+`examples/` fixture project and assert on the generated `scan-report.json` and
+dashboard output, all offline.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -41,8 +41,10 @@ Every function must be tested with:
 - **Scanner shell tests**: `bash scanner/tests/test_<name>.sh` (one file per case).
 - **Scanner unit tests (Python)**: `pytest scanner/` — `scanner/lib/` has a 99%
   coverage floor (live ~99.12%) enforced in CI.
-- **Shell coverage**: `kcov` aggregates coverage at
-  `kcov-out/merged/kcov-merged/coverage.json`; floor is 85% (baseline ~89%).
+- **Shell coverage**: `kcov` aggregates coverage; the merged `coverage.json`
+  lives in a nested subdir under `kcov-out/merged/` (locate via `find`, not a
+  fixed path). Floor is **90%** (baseline ~92%), raised from 85 in #171/#173/#174.
+  See the `kcov-debug` skill for the full playbook.
 - **Docs**: `markdownlint "**/*.md"` and `lychee "**/*.md"` before any docs PR.
 
 ### Offline guard (REQUIRED)


### PR DESCRIPTION
## Summary

Replaces the 5 generic `[CUSTOMIZE]` placeholders under `.claude/rules/` with project-grounded guidance. Content is derived from `CLAUDE.md`, `.cursor/rules/*.mdc`, project memory, and the actual CI configuration — no speculation.

| File | What was filled |
|------|-----------------|
| `coding-style.md` | kebab-case naming, doc frontmatter, fenced-block languages, bash `set -euo pipefail`/shellcheck, offline guard, no-sensitive-data |
| `testing.md` | scanner shell/pytest/kcov suites & floors, **`CLAUDESEC_DASHBOARD_OFFLINE=1`** requirement, hermetic mocking, what "E2E" means here |
| `git-workflow.md` | no-push-to-`main` + pre-push hook, pre-PR `markdownlint`/`lychee`, path-gated checks, single CodeQL model, Dependabot conflict policy |
| `security.md` | gitleaks/GitGuardian/pii-check, secret hygiene, OWASP/NIST/CIS citations, NIST/ISO/ISMS-P compliance scope, hooks least-privilege |
| `performance.md` | offline-guard to prevent test hangs (#190), 30s kcov per-test cap, scanner single-pass efficiency, CI path-gating |

`karpathy-guidelines.md` had no placeholder and is untouched.

## Notes

- `.claude/**` is excluded from the CI `markdown-lint` glob (`lint.yml:629-631`), so these instruction files are not linted; pre-existing MD032/MD031 in untouched original lines were left as-is (out of scope).
- All cross-references between rules files use relative links.

## Verification

- `grep -rn "\[CUSTOMIZE\]" .claude/rules/` → none remaining.
- `markdownlint-cli2 .claude/rules/*.md` → 0 errors in newly-added content (18 pre-existing errors in untouched lines, not CI-linted).
- gitleaks pre-commit hook → CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)