### PR TITLE
docs: kcov-debug follow-ups (baseline + hourly-ops link)

### DIFF
--- a/.claude/skills/kcov-debug/SKILL.md
+++ b/.claude/skills/kcov-debug/SKILL.md
@@ -96,6 +96,8 @@ Also: Ubuntu's apt kcov (v38 on Jammy) is broken for sourced files. The job buil
 
 The floor is a **one-way ratchet** — it only moves up, and only with observed headroom.
 Lineage: 50%(#123) → 65%(#124) → 85% → **90%** (#171/#173/#174 lifted SUT 91.19%→92.36%).
+Observed baseline drifts: as of 2026-06 a green `main` run measured **91.74%**, i.e.
+~1.7pp headroom over the 90% floor — re-read the run log, don't assume the peak.
 
 - **Real regression**: a change removed exercised lib lines or added unexercised ones.
   Add/extend a `scanner/tests/test_*.sh` fixture that drives the new `lib/` code, then

--- a/docs/guides/hourly-operations.md
+++ b/docs/guides/hourly-operations.md
@@ -54,8 +54,19 @@ tail -n 50 ~/.twodragon0-runtime/logs/hourly-opencode-git-pull.log
 - Keep pull mode as `--ff-only` to avoid accidental merge commits.
 - Keep logs and scan artifacts for audit and trend analysis.
 
+## Troubleshooting
+
+When an hourly run's scanner or coverage step fails, hangs, or reports missing/zero
+coverage, use the `kcov-debug` skill (`.claude/skills/kcov-debug/SKILL.md`) — a
+symptom → diagnosis → fix decision tree for the `scanner-shell-coverage` (kcov) and
+`scanner-unit-tests` (pytest) gates. Most common cause of a hung run is a missing
+`CLAUDESEC_DASHBOARD_OFFLINE=1` guard (un-gated GitHub API calls); set it for any test
+that calls `generate_html_dashboard`.
+
 ## References
 
+- `kcov-debug` skill: `.claude/skills/kcov-debug/SKILL.md` (coverage-gate debugging playbook)
+- CI coverage history: [`docs/guides/ci-coverage-journey.md`](./ci-coverage-journey.md)
 - OWASP SAMM: [https://owaspsamm.org/](https://owaspsamm.org/)
 - NIST SP 800-92 (Guide to Computer Security Log Management): [https://csrc.nist.gov/publications/detail/sp/800-92/final](https://csrc.nist.gov/publications/detail/sp/800-92/final)
 - CIS Controls v8: [https://www.cisecurity.org/controls/v8](https://www.cisecurity.org/controls/v8)


### PR DESCRIPTION
## Summary

Two small follow-ups to the `kcov-debug` skill (#198):

1. **`kcov-debug` SKILL.md §4** — add the observed 2026-06 `main` bash-coverage baseline (**91.74%**, ~1.7pp over the 90% floor) next to the historical 92.36% peak. The regression check surfaced this drift; the historical figure is left intact (it's what #171/#173/#174 achieved).
2. **`docs/guides/hourly-operations.md`** — add a **Troubleshooting** section pointing operators to the `kcov-debug` playbook when an hourly run's scanner/coverage step fails or hangs, plus skill + `ci-coverage-journey.md` references.

## Verification

- `markdownlint-cli2 docs/guides/hourly-operations.md` → **0 errors**.
- Frontmatter present (`title`/`description`/`tags`).
- New relative link `./ci-coverage-journey.md` resolves to an existing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)