### PR TITLE
docs(commands): cross-link kcov-debug from pipeline-review (Option A)

### DIFF
--- a/.claude/commands/pipeline-review.md
+++ b/.claude/commands/pipeline-review.md
@@ -11,7 +11,10 @@ Launch these agents simultaneously:
 1. **sec-researcher** — Analyze current threat landscape relevant to this project
 2. **architect** — Review pipeline design for gaps in docs/architecture/
 3. **sec-reviewer** — Audit existing documentation for accuracy and completeness
-4. **ci-pipeline** — Check .github/workflows/ for security scanning coverage gaps
+4. **ci-pipeline** — Check .github/workflows/ for security scanning coverage gaps.
+   If a CI _test-coverage_ gate is red (`scanner-shell-coverage` kcov, or
+   `scanner-unit-tests` pytest), route into the `/kcov-debug` playbook to diagnose
+   before proposing a fix.
 
 ### Sequential Fix Phase
 Based on findings:
@@ -25,3 +28,9 @@ Produce a structured report:
 - Gap analysis with priority ranking
 - Remediation actions taken
 - Remaining items for manual follow-up
+
+## See also
+
+- `/kcov-debug` — coverage-gate debugging playbook (kcov bash / pytest
+  `scanner/lib` hangs, missing `coverage.json`, floor-below-threshold). Use when
+  the `ci-pipeline` step finds a red coverage CI job.


### PR DESCRIPTION
## Summary

Implements **Option A** from the architect memo on auto-referencing `kcov-debug`:

- **`.claude/commands/pipeline-review.md`** — augment the `ci-pipeline` step with a routing note ("if a CI test-coverage gate is red → route into `/kcov-debug`") and add a `## See also` section linking the playbook.
- **`scan.md` deliberately untouched** — `scan` runs the runtime product scanner (`scan-report.json`), produces no test-coverage output, so a `/kcov-debug` link would misrepresent it (the Option B category error).

## Why Option A

The `ci-pipeline` agent (`pipeline-review.md:14`) is the only node in either flow that encounters a kcov/pytest coverage-gate failure; its own agent description already scopes "kcov/coverage gates". A name-level prose pointer (no thresholds/numbers) matches the repo's existing `## References` convention and can't rot, unlike conditional routing logic (Option C).

## Verification

- `.claude/**` is excluded from CI markdown-lint, so no lint gate applies; edits are prose-only and render correctly.
- No behavior/code change; pure documentation cross-link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)