### PR TITLE
ci(lint-gate): make workflow-fork-guard merge-blocking

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -695,6 +695,7 @@ jobs:
       - docker-dashboard-smoke
       - markdown-lint
       - link-check
+      - workflow-fork-guard
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate lint workflow results

--- a/scanner/tests/test_ci_gate_topology.py
+++ b/scanner/tests/test_ci_gate_topology.py
@@ -36,12 +36,11 @@ LINT_YML = WORKFLOW_DIR / "lint.yml"
 # exists to police.
 #
 # - lint-gate: the aggregator itself (cannot depend on itself).
-# - workflow-fork-guard: a standalone pull_request_target fork-guard audit. NOTE:
-#   it is currently neither in lint-gate.needs nor a required status check, so a
-#   red result does not block merges. This is flagged for review (see the PR that
-#   added this test); if it should gate merges, add it to lint-gate.needs and
-#   delete it from this allowlist.
-UNGATED_JOBS_ALLOWLIST = {"lint-gate", "workflow-fork-guard"}
+#
+# (workflow-fork-guard was previously allowlisted, but is now wired into
+# lint-gate.needs so its OWASP A08 fork-guard audit is merge-blocking — it is
+# therefore correctly NO LONGER allowlisted.)
+UNGATED_JOBS_ALLOWLIST = {"lint-gate"}
 
 
 def _strip_comment(line: str) -> str:


### PR DESCRIPTION
## Summary

Resolves the gating gap surfaced by the topology guard in #201: the **`workflow-fork-guard`** job — which audits `pull_request_target` workflows (`dependabot-auto-merge.yml`) for the head-repo fork-guard that prevents OWASP A08 fork-PR privilege escalation — ran on every PR but was **not** in `lint-gate.needs` and is not a standalone required check. A red audit therefore did **not** block merges.

## Change

- `lint.yml`: add `workflow-fork-guard` to `lint-gate.needs` (now 15 jobs). It runs unconditionally (no `if:`/path-gating), so the `skipped`-as-success aggregator semantics are unaffected.
- `scanner/tests/test_ci_gate_topology.py`: remove `workflow-fork-guard` from `UNGATED_JOBS_ALLOWLIST` (now `{lint-gate}` only). The guard's `test_allowlist_has_no_stale_entries` check enforces this consistency.

## Decision rationale (task #2)

Investigated whether the exclusion was intentional: the job is a security audit, runs unconditionally, and protects a real `pull_request_target` workflow. Making it merge-blocking is a clear, low-risk security improvement (reversible). Verdict: **gate it.**

## Verification

- `pytest scanner/tests/test_ci_gate_topology.py -v` → **4 passed**.
- PyYAML parse: `lint-gate.needs` = 15 jobs, includes `workflow-fork-guard`.
- gitleaks → CLEAN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)