### PR TITLE
ci(lint): upgrade lycheeVersion v0.23.0 → v0.24.2

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -671,11 +671,14 @@ jobs:
             --timeout 20
             '**/*.md'
           fail: true
-          # Pin to v0.23.0 — lychee-v0.24.0 (2026-04-24) changed release asset
-          # naming from `lychee-<triple>.tar.gz` to `lychee-lychee-v0.24.0-<triple>.tar.gz`,
-          # which the pinned lychee-action SHA can't resolve (404). Revisit
-          # once a newer lychee-action understands the new naming scheme.
-          lycheeVersion: v0.23.0
+          # lychee-v0.24.0 (2026-04-24) had a one-off release-asset naming
+          # regression (`lychee-lychee-v0.24.0-<triple>.tar.gz`) that the pinned
+          # lychee-action SHA could not resolve (404). It was reverted the same
+          # day in v0.24.1, and v0.24.2 (2026-05-01) uses the original flat
+          # `lychee-<triple>.tar.gz` naming, which the pinned action resolves
+          # correctly — so no action-SHA change is required. (Was pinned to
+          # v0.23.0 for the v0.24.0-only break.)
+          lycheeVersion: v0.24.2
 
   lint-gate:
     name: Lint


### PR DESCRIPTION
## Summary

Upgrades the link-check binary pin from `v0.23.0` to **`v0.24.2`** and refreshes the now-stale rationale comment. Resolves the deferred follow-up from the lychee guard investigation.

## Why it's safe (research-backed)

The `v0.23.0` pin worked around a release-asset naming regression that existed in **lychee-v0.24.0 only** (2026-04-24). It was reverted the same day in v0.24.1; v0.24.2 (2026-05-01, current Latest) uses the original flat `lychee-<triple>.tar.gz` naming, which the currently pinned `lychee-action@8646ba3` (v2.8.0) resolves **without an action-SHA change**.

## Verification

Local (the action fetches the same release assets):
- `lychee-v0.24.2/lychee-aarch64-apple-darwin.tar.gz` **downloads** — flat naming resolves, no 404 (CI uses the analogous `linux-gnu` asset, also flat-named).
- binary reports `lychee 0.24.2`; parses repo markdown with the workflow's `--accept '100..=599'` args → **0 errors** offline on `README.md`.

⚠️ **Note:** `link-check` is path-gated on `markdown` changes (`lint.yml` `changes` job — `markdown` matches `\.md$`, not workflow files), so it **skips on this workflow-only PR**. v0.24.2 will first be exercised in CI on the next markdown-touching PR or the scheduled run. Local verification above stands in for in-PR CI coverage.

## Memory

`reference_lychee_pin` was updated to reflect the v0.24.1 revert / v0.24.2 safety in a prior session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)