### PR TITLE
ci(security-scan): block merge on CRITICAL findings

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -151,18 +151,20 @@ jobs:
           if-no-files-found: warn
 
       # Gate: count critical/high findings from scan output.
-      # Known findings are surfaced as warnings; only NEW criticals block.
+      # Any CRITICAL finding FAILS the build (blocks merge via the Security Scan
+      # Gate required check); HIGH findings are surfaced as warnings only.
       - name: Check for critical/high failures
         run: |
           CRITS=$(grep -ci '✗.*critical\|CRITICAL.*Fail' scan-output.txt || true)
           HIGHS=$(grep -ci '✗.*high\|HIGH.*Fail' scan-output.txt || true)
           echo "Critical: $CRITS, High: $HIGHS"
           echo "::notice::Security scan completed — Critical: $CRITS, High: $HIGHS"
-          if [ "$CRITS" -gt 0 ]; then
-            echo "::warning::$CRITS critical finding(s) detected — review scan-output.txt"
-          fi
           if [ "$HIGHS" -gt 0 ]; then
             echo "::warning::$HIGHS high finding(s) detected"
+          fi
+          if [ "$CRITS" -gt 0 ]; then
+            echo "::error::$CRITS critical finding(s) detected — failing the build (review scan-output.txt)"
+            exit 1
           fi
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Resolves the header/code contradiction in `security-scan.yml` per the maintainer decision: **enforce merge-blocking on CRITICAL findings.**

Previously `:96` ("Fails the workflow on any CRITICAL finding") and the inline comment claimed blocking, but the code only emitted `::warning::` and never exited non-zero.

## Change

- `scan` job: `CRITS>0` now emits `::error::` + `exit 1`, failing the job → the `Security Scan Gate` required check blocks the merge.
- HIGH findings stay warnings (non-blocking), matching the header.
- Corrected the inline comment (dropped the inaccurate "only NEW criticals block" — there's no baseline-diff; it counts all criticals).

## Safety / verification

- Latest scan runs report **`Critical: 0, High: 0`**, so enabling the block does not break current CI.
- This PR edits `security-scan.yml`, which sets the changes-job `code=true`, so **its own `scan` job runs** and verifies the gate passes on a clean tree (self-verifying).
- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML valid.

## Follow-up

Once #205 (Security Scan Gate topology guard) merges, a small regression guard asserting the `scan` step keeps the `exit 1`-on-critical behavior would prevent silent reversion (analyst memo's invariant E, now unblocked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)