### PR TITLE
ci(lint): revert lycheeVersion to v0.23.0 (fix link-check regression from #204)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -671,14 +671,17 @@ jobs:
             --timeout 20
             '**/*.md'
           fail: true
-          # lychee-v0.24.0 (2026-04-24) had a one-off release-asset naming
-          # regression (`lychee-lychee-v0.24.0-<triple>.tar.gz`) that the pinned
-          # lychee-action SHA could not resolve (404). It was reverted the same
-          # day in v0.24.1, and v0.24.2 (2026-05-01) uses the original flat
-          # `lychee-<triple>.tar.gz` naming, which the pinned action resolves
-          # correctly — so no action-SHA change is required. (Was pinned to
-          # v0.23.0 for the v0.24.0-only break.)
-          lycheeVersion: v0.24.2
+          # PIN TO v0.23.0 — do not bump without verifying the lychee-action
+          # install path end-to-end (not just the asset filename). The v0.24.x
+          # tarballs nest the binary inside a `lychee-<triple>/` subdirectory
+          # (alongside complete/ and docs/), but the pinned lychee-action SHA's
+          # installer expects the binary at the archive root and runs
+          # `install ... /tmp/lychee-download/lychee` → `install: cannot stat`
+          # (PR #204 regressed this; reverted in #209). Upstream lychee-action
+          # itself still defaults lycheeVersion to v0.23.0 for the same reason.
+          # (v0.24.0 additionally had a one-off asset-filename break, fixed in
+          # v0.24.1 — but the nested-binary layout still breaks the installer.)
+          lycheeVersion: v0.23.0
 
   lint-gate:
     name: Lint


### PR DESCRIPTION
## Urgent: fixes a link-check regression on `main`

PR #204 bumped `lycheeVersion` to v0.24.2; this **broke `link-check` on every markdown PR** (first surfaced on #207). Reverting to the known-good **v0.23.0**.

## Root cause (verified against the release tarballs)

| Version | Linux tarball layout | Pinned action install |
|---------|----------------------|------------------------|
| **v0.23.0** | `lychee` at **archive root** | ✅ `install .../lychee-download/lychee` works |
| v0.24.x | binary nested at `lychee-<triple>/lychee` (+ `complete/`, `docs/`) | ❌ `install: cannot stat '.../lychee-download/lychee'` |

The pinned `lychee-action` installer expects the binary at the archive root. #204's verification checked only the asset **filename** (which v0.24.1+ did revert to flat) but **not the action's end-to-end install path** — the internal tarball **layout** also changed in v0.24.x. Upstream `lychee-action` itself still defaults `lycheeVersion` to v0.23.0 for this exact reason.

Failing job log (#207): `install: cannot stat '/home/runner/work/_temp/lychee-download/lychee': No such file or directory`.

## Verification

- Downloaded both linux tarballs and confirmed the layout difference above (binary at root in v0.23.0, nested in v0.24.2).
- v0.23.0 is the value that ran green on `main` for months prior to #204 (restores known-good).
- This PR is `lint.yml`-only, so `link-check` is path-gated to skip here; the fix is confirmed in-CI by rebasing #207 (which has markdown) onto the reverted `main`.

## Lesson

The `kcov-debug`-style verification discipline applies to version bumps too: verify the **consumer's end-to-end path**, not just the artifact's existence/name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)