### PR TITLE
refactor(skills): rename project guard skill to ci-config-guard-claudesec

### DIFF
--- a/.claude/skills/ci-config-guard-claudesec/SKILL.md
+++ b/.claude/skills/ci-config-guard-claudesec/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: ci-config-guard
-description: Author a CI config regression guard — a stdlib pytest that fails when a CI gate (coverage floor, action SHA pin, required-check topology, severity block, version pin) is silently weakened or removed. Use when adding/extending CI invariant protection in this repo or porting the pattern to another repo.
+name: ci-config-guard-claudesec
+description: ClaudeSec-specific CI config regression guard authoring — exact conventions (scanner/tests, stdlib-only/no-PyYAML, 99% pytest + 90% kcov floors, scanner/lib) and the existing test_ci_*.py catalog. Use in THIS repo. For the repo-agnostic pattern, use the global ci-config-guard skill.
 user-invocable: true
 ---
 


### PR DESCRIPTION
## Summary

Resolves a skill name collision: a **generic** `ci-config-guard` skill was promoted to the global `~/.claude/skills` (repo-agnostic pattern), colliding by name with this repo's **project-local** `ci-config-guard` skill — the registry surfaced only one.

Renames the project-local instance `ci-config-guard` → **`ci-config-guard-claudesec`** and sharpens its description to the ClaudeSec specifics (scanner/tests, stdlib-only/no-PyYAML, 99% pytest + 90% kcov floors, scanner/lib, the existing `test_ci_*.py` catalog).

## Result

Both skills now coexist distinctly (verified in the session skill registry):
- `ci-config-guard` (global) — repo-agnostic authoring pattern, "in any repo".
- `ci-config-guard-claudesec` (project) — "Use in THIS repo"; points to the global one for the generic pattern.

## Verification

- `git mv` preserves history; only the dir name + frontmatter `name`/`description` changed.
- No dangling references to the old name in `docs/` or `.claude/`.
- `.claude/**` is excluded from CI markdown-lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)