### PR TITLE
test(ci): guard security-job existence and single CodeQL model

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -45,6 +45,8 @@ All guards follow the same rules (see the existing files for reference):
 | `scanner/tests/test_ci_coverage_thresholds.py` | Coverage floors in `lint.yml` | pytest `--cov-fail-under >= 99`; bash kcov `threshold >= 90.0` | #200 |
 | `scanner/tests/test_ci_gate_topology.py` | Enforcement topology of `lint.yml` | every `uses:` across all `.github/workflows/*.yml` is 40-hex SHA-pinned (OWASP A08); every job is in `lint-gate.needs` or a tiny documented allowlist | #201 (allowlist tightened in #203) |
 | `scanner/tests/test_ci_security_gate.py` | `Security Scan Gate` + DAST signal | `security-scan-gate` keeps `name`, `if: always()`, `needs: ⊇ {changes, scan, lighthouse}`, pass-set `not in (success, skipped)`; `dast-baseline.yml` keeps its `pull_request` trigger | #205 |
+| `scanner/tests/test_ci_required_jobs_exist.py` | Existence of security/enforcement jobs in `lint.yml` | `{gitleaks, pii-check, dependency-review, workflow-fork-guard, scanner-unit-tests, scanner-shell-coverage}` are all present — deleting a whole job is a silent control loss the topology guard cannot see | #215 |
+| `scanner/tests/test_ci_codeql_single_model.py` | Single CodeQL model (default setup only) | no workflow uses `github/codeql-action/init` or `/analyze` (a repo-level analysis would duplicate the default-setup model); `upload-sarif` is allowed (DAST SARIF upload, not analysis) | #215 |
 
 ### Related enforcement (not a pytest guard)
 
@@ -66,6 +68,11 @@ The consequence: **any job that is not wired into one of these two aggregators'
 `needs:` is invisible to branch protection** — it can fail without blocking a
 merge. That is precisely the gap the topology guards
 (`test_ci_gate_topology.py`, `test_ci_security_gate.py`) exist to catch.
+
+The topology guards check that every *present* job is gated; they cannot see a
+job that is **deleted entirely** (a removed job simply leaves the gated set, and
+the aggregator stays green). `test_ci_required_jobs_exist.py` closes that
+complementary gap by asserting the load-bearing security jobs still exist.
 
 ## Adding a new guard
 

--- a/scanner/tests/test_ci_codeql_single_model.py
+++ b/scanner/tests/test_ci_codeql_single_model.py
@@ -1,0 +1,80 @@
+"""
+Regression guard: ClaudeSec keeps a SINGLE CodeQL model.
+
+Project policy (CLAUDE.md / git-workflow rules): "Single CodeQL model:
+repository default setup only — do not add a duplicate repo-level CodeQL
+workflow file." GitHub's default setup runs CodeQL *analysis* without any
+in-repo workflow; adding a workflow that runs CodeQL analysis creates a second,
+conflicting model (duplicate runs, divergent config, wasted minutes).
+
+A repo-level CodeQL ANALYSIS necessarily invokes the `github/codeql-action/init`
+and/or `github/codeql-action/analyze` actions. This guard asserts NO workflow
+file uses either.
+
+IMPORTANT — `upload-sarif` is intentionally ALLOWED: `dast-full-scan.yml` uses
+`github/codeql-action/upload-sarif` to publish ZAP/DAST SARIF results to the
+Security tab. That is a third-party-result upload, not a CodeQL analysis, so it
+does NOT create a duplicate model. The guard must match only `init`/`analyze`.
+
+Semantics: PRESENCE-of-violation (the analysis actions must be ABSENT). If you
+ever intentionally move from default setup to a workflow-based CodeQL model,
+delete this guard in the same PR and document the decision.
+
+stdlib-only (regex/line scanning, no PyYAML — absent from requirements-ci.txt).
+No network, no subprocess. Passes under pytest (the CI runner) and
+`python3 -m unittest`. Does not import scanner/lib.
+"""
+
+import re
+import unittest
+from glob import glob
+from pathlib import Path
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+# CodeQL *analysis* sub-actions that constitute a repo-level model. `upload-sarif`
+# is deliberately excluded — it only publishes third-party SARIF.
+ANALYSIS_ACTION_RE = re.compile(
+    r"uses:\s*github/codeql-action/(init|analyze)(?:[/@]|\s|$)"
+)
+
+
+def _strip_comment(line: str) -> str:
+    return re.sub(r"\s+#.*$", "", line)
+
+
+class TestCodeqlSingleModel(unittest.TestCase):
+    def test_workflow_dir_exists(self):
+        self.assertTrue(
+            WORKFLOW_DIR.is_dir(),
+            f"Workflow dir not found at {WORKFLOW_DIR} — path assumption broke",
+        )
+
+    def test_no_repo_level_codeql_analysis(self):
+        workflow_files = sorted(glob(str(WORKFLOW_DIR / "*.yml")))
+        self.assertTrue(
+            workflow_files,
+            f"No workflow files found under {WORKFLOW_DIR} — path assumption broke",
+        )
+        violations = []
+        for path in workflow_files:
+            for lineno, raw in enumerate(
+                Path(path).read_text(encoding="utf-8").splitlines(), start=1
+            ):
+                if ANALYSIS_ACTION_RE.search(_strip_comment(raw)):
+                    violations.append(f"{Path(path).name}:{lineno}: {raw.strip()}")
+        self.assertEqual(
+            violations,
+            [],
+            "Repo-level CodeQL analysis (init/analyze) found — this duplicates "
+            "the repository default-setup CodeQL model (CLAUDE.md: single CodeQL "
+            "model only). Remove the workflow, or if intentionally switching to a "
+            "workflow-based model, delete this guard in the same PR:\n  "
+            + "\n  ".join(violations),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_ci_required_jobs_exist.py
+++ b/scanner/tests/test_ci_required_jobs_exist.py
@@ -1,0 +1,112 @@
+"""
+Regression guard: security/enforcement jobs in `.github/workflows/lint.yml`
+must keep EXISTING.
+
+`test_ci_gate_topology.py` proves that every job that *exists* in lint.yml is
+wired into the `lint-gate` aggregator (so it blocks merges). But that check is
+satisfied by the set of jobs that happen to be present: deleting a job entirely
+shrinks `jobs` and the topology assertion stays green. So a refactor or a botched
+merge-conflict resolution that DROPS a whole security job would silently disable
+that control while CI stays green — exactly the silent-weakening class these
+guards exist to catch (cf. project memory: "CI enforces secret hygiene with the
+gitleaks job and the pii-check job"; workflow-fork-guard was made merge-blocking
+in #203).
+
+This guard asserts a documented set of load-bearing jobs is still PRESENT:
+
+- `gitleaks`             — secret scanning (OWASP A07/secret hygiene)
+- `pii-check`            — PII leakage scan
+- `dependency-review`   — supply-chain gate (OWASP A08)
+- `workflow-fork-guard` — `pull_request_target` fork guard (OWASP A08), #203
+- `scanner-unit-tests`  — runs the entire `test_ci_*.py` guard suite; if this job
+                          is dropped, NONE of the CI config guards execute
+- `scanner-shell-coverage` — kcov bash coverage floor enforcement
+
+Semantics are PRESENCE: removing any of these trips the guard. If a job is
+intentionally renamed/retired, update REQUIRED_LINT_JOBS here in the same PR and
+justify it. (Whether each present job is merge-blocking is the separate concern
+of test_ci_gate_topology.py — NOT duplicated here.)
+
+stdlib-only (regex/line scanning, no PyYAML — absent from requirements-ci.txt).
+No network, no subprocess. Passes under pytest (the CI runner) and
+`python3 -m unittest`. Does not import scanner/lib, so it never moves the
+measured coverage gate.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LINT_YML = REPO_ROOT / ".github" / "workflows" / "lint.yml"
+
+# Load-bearing security/enforcement jobs whose silent deletion would disable a
+# control without any visible CI failure. Keep each entry justified (see module
+# docstring). Edit ONLY in the same PR that intentionally renames/retires a job.
+REQUIRED_LINT_JOBS = frozenset(
+    {
+        "gitleaks",
+        "pii-check",
+        "dependency-review",
+        "workflow-fork-guard",
+        "scanner-unit-tests",
+        "scanner-shell-coverage",
+    }
+)
+
+
+def _strip_comment(line: str) -> str:
+    return re.sub(r"\s+#.*$", "", line)
+
+
+class TestRequiredLintJobsExist(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = LINT_YML.read_text(encoding="utf-8") if LINT_YML.is_file() else ""
+
+    def _top_level_jobs(self):
+        """Return the set of 2-space-indented job keys under `jobs:`."""
+        jobs, in_jobs = [], False
+        for raw in self.text.splitlines():
+            if re.match(r"^jobs:\s*$", raw):
+                in_jobs = True
+                continue
+            if in_jobs:
+                if re.match(r"^\S", raw):  # dedent back to a top-level key
+                    break
+                m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", _strip_comment(raw))
+                if m:
+                    jobs.append(m.group(1))
+        return set(jobs)
+
+    def test_lint_yml_exists(self):
+        self.assertTrue(
+            LINT_YML.is_file(),
+            f"CI workflow not found at {LINT_YML} — path assumption broke",
+        )
+
+    def test_parser_canary(self):
+        # If the job parser breaks, fail loudly here rather than vacuously
+        # "finding" the required jobs missing (or present).
+        jobs = self._top_level_jobs()
+        self.assertIn(
+            "lint-gate", jobs, "job parsing broke — 'lint-gate' aggregator not found"
+        )
+
+    def test_required_security_jobs_present(self):
+        jobs = self._top_level_jobs()
+        missing = REQUIRED_LINT_JOBS - jobs
+        self.assertEqual(
+            missing,
+            set(),
+            "Required security/enforcement job(s) missing from lint.yml — a "
+            "control was deleted and CI would stay green:\n  "
+            + ", ".join(sorted(missing))
+            + "\nRestore the job(s), or (if intentionally retired) update "
+            "REQUIRED_LINT_JOBS in this test with a justification.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds two stdlib-only CI config regression guards that close coverage gaps found in an audit of the existing `test_ci_*.py` guards.

The current topology guards (`test_ci_gate_topology.py`, `test_ci_security_gate.py`) prove every **present** job is wired into a required-check aggregator — but they cannot see a job that is **deleted entirely** (a removed job just leaves the gated set and the aggregator stays green). So dropping a whole security job would silently disable that control while CI stays green.

### New guards

- **`scanner/tests/test_ci_required_jobs_exist.py`** — asserts the load-bearing security/enforcement jobs still EXIST in `lint.yml`: `gitleaks`, `pii-check`, `dependency-review`, `workflow-fork-guard`, `scanner-unit-tests` (runs the guard suite itself), `scanner-shell-coverage`. Semantics: presence (deletion trips it).
- **`scanner/tests/test_ci_codeql_single_model.py`** — asserts no workflow runs repo-level CodeQL **analysis** (`github/codeql-action/init`|`analyze`), which would duplicate the repository default-setup model (CLAUDE.md: single CodeQL model only). `upload-sarif` is intentionally **allowed** — `dast-full-scan.yml` uses it to publish ZAP/DAST SARIF, which is not an analysis.

Both follow the ClaudeSec guard conventions: stdlib-only (no PyYAML), no `scanner/lib` import (does not move the 99% coverage gate), dual-runner (pytest + `python3 -m unittest`), direction-explicit docstrings.

## Test plan

- [x] Positive: `python3 -m pytest scanner/tests/test_ci_*.py` → 22 passed
- [x] Dual-runner: `python3 -m unittest` on both new modules → OK
- [x] **Non-vacuous** (mutation, no real files touched):
  - Guard #1 FAILS when the `gitleaks:` job header is removed from a temp copy
  - Guard #2 FAILS on injected `codeql-action/init`+`analyze`; stays green on an `upload-sarif`-only workflow (no false positive)
- [x] `markdownlint` clean + `lychee` 3/3 OK on the updated catalog doc

## Refs

OWASP CICD-SEC-1 (Insufficient Flow Control) / A08 (Software & Data Integrity Failures); NIST SSDF (SP 800-218) PO.3/PW.4. Catalog: `docs/devsecops/ci-config-regression-guards.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)