### PR TITLE
test(ci): guard npm publish provenance and DAST nightly schedule

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -44,9 +44,10 @@ All guards follow the same rules (see the existing files for reference):
 |-------|----------|----------------|--------|
 | `scanner/tests/test_ci_coverage_thresholds.py` | Coverage floors in `lint.yml` | pytest `--cov-fail-under >= 99`; bash kcov `threshold >= 90.0` | #200 |
 | `scanner/tests/test_ci_gate_topology.py` | Enforcement topology of `lint.yml` | every `uses:` across all `.github/workflows/*.yml` is 40-hex SHA-pinned (OWASP A08); every job is in `lint-gate.needs` or a tiny documented allowlist | #201 (allowlist tightened in #203) |
-| `scanner/tests/test_ci_security_gate.py` | `Security Scan Gate` + DAST signal | `security-scan-gate` keeps `name`, `if: always()`, `needs: ⊇ {changes, scan, lighthouse}`, pass-set `not in (success, skipped)`; `dast-baseline.yml` keeps its `pull_request` trigger | #205 |
+| `scanner/tests/test_ci_security_gate.py` | `Security Scan Gate` + DAST signals | `security-scan-gate` keeps `name`, `if: always()`, `needs: ⊇ {changes, scan, lighthouse}`, pass-set `not in (success, skipped)`; `dast-baseline.yml` keeps its `pull_request` trigger; `dast-full-scan.yml` keeps its `schedule:` trigger | #205, #216 |
 | `scanner/tests/test_ci_required_jobs_exist.py` | Existence of security/enforcement jobs in `lint.yml` | `{gitleaks, pii-check, dependency-review, workflow-fork-guard, scanner-unit-tests, scanner-shell-coverage}` are all present — deleting a whole job is a silent control loss the topology guard cannot see | #215 |
 | `scanner/tests/test_ci_codeql_single_model.py` | Single CodeQL model (default setup only) | no workflow uses `github/codeql-action/init` or `/analyze` (a repo-level analysis would duplicate the default-setup model); `upload-sarif` is allowed (DAST SARIF upload, not analysis) | #215 |
+| `scanner/tests/test_ci_npm_publish.py` | npm release supply-chain integrity (`npm-publish.yml`) | every `npm publish` carries `--provenance` (SLSA attestation); workflow-level `permissions:` stays `contents: read` (job-level `id-token: write` is not flagged) | #216 |
 
 ### Related enforcement (not a pytest guard)
 

--- a/scanner/tests/test_ci_npm_publish.py
+++ b/scanner/tests/test_ci_npm_publish.py
@@ -1,0 +1,127 @@
+"""
+Regression guards for the npm release workflow `.github/workflows/npm-publish.yml`.
+
+Two supply-chain invariants, both silently weakenable:
+
+1. **SLSA provenance** — every `npm publish` invocation must pass `--provenance`.
+   This is the whole point of the workflow (OIDC trusted-publisher + SLSA
+   attestation). Dropping `--provenance` still publishes successfully, so the
+   regression is invisible: packages ship WITHOUT attestation and nobody sees a
+   failure. Plausible incident: a "fix the failing publish" commit removes the
+   flag. (OWASP A08 Software & Data Integrity Failures; SLSA provenance.)
+
+2. **Least-privilege default token** — the workflow-level `permissions:` block
+   must stay `contents: read`. Broadening it (e.g. `write-all`) silently grants
+   the release workflow extra scope across all jobs. The `publish` job legitimately
+   ADDS `id-token: write` at the JOB level (required for OIDC provenance); this
+   guard inspects only the top-level block, so that job-level grant is not flagged.
+
+Semantics: PRESENCE for the flag; the permissions block must contain
+`contents: read` and no `write` grant. If you intentionally change either, update
+this guard in the same PR and justify it.
+
+stdlib-only (regex/line scanning, no PyYAML — absent from requirements-ci.txt).
+No network, no subprocess. Passes under pytest (the CI runner) and
+`python3 -m unittest`. Does not import scanner/lib.
+
+Scope note: action SHA-pinning for this file is already covered by
+test_ci_gate_topology.py (it globs all workflows) — NOT duplicated here.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+NPM_PUBLISH = REPO_ROOT / ".github" / "workflows" / "npm-publish.yml"
+
+
+def _strip_comment(line: str) -> str:
+    return re.sub(r"\s+#.*$", "", line)
+
+
+class TestNpmPublishProvenance(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = (
+            NPM_PUBLISH.read_text(encoding="utf-8") if NPM_PUBLISH.is_file() else ""
+        )
+
+    def test_npm_publish_yml_exists(self):
+        self.assertTrue(NPM_PUBLISH.is_file(), f"{NPM_PUBLISH} not found")
+
+    def test_every_npm_publish_has_provenance(self):
+        # Match `npm publish ...` run lines (ignore inline comments). Both the
+        # dry-run and the real publish step must carry --provenance.
+        publish_lines = [
+            line.strip()
+            for line in self.text.splitlines()
+            if re.search(r"\bnpm\s+publish\b", _strip_comment(line))
+        ]
+        self.assertTrue(
+            publish_lines,
+            "No `npm publish` invocation found in npm-publish.yml — the publish "
+            "step was removed or renamed.",
+        )
+        missing = [ln for ln in publish_lines if "--provenance" not in ln]
+        self.assertEqual(
+            missing,
+            [],
+            "`npm publish` without `--provenance` (packages would ship without "
+            "SLSA attestation, silently):\n  " + "\n  ".join(missing),
+        )
+
+
+class TestNpmPublishLeastPrivilege(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = (
+            NPM_PUBLISH.read_text(encoding="utf-8") if NPM_PUBLISH.is_file() else ""
+        )
+
+    def _top_level_permissions_block(self):
+        # Capture the WORKFLOW-level `permissions:` block: from a column-0
+        # `permissions:` header to the next column-0 top-level key (jobs:, etc.).
+        # Job-level permissions live under `jobs:` and are NOT captured here.
+        out, in_perms = [], False
+        for raw in self.text.splitlines():
+            if re.match(r"^permissions:\s*$", raw):
+                in_perms = True
+                continue
+            if in_perms:
+                if re.match(r"^\S", raw):  # dedent to next top-level key
+                    break
+                out.append(raw)
+        return "\n".join(out)
+
+    def test_top_level_permissions_is_least_privilege(self):
+        block = self._top_level_permissions_block()
+        self.assertTrue(
+            block.strip(),
+            "No workflow-level `permissions:` block found in npm-publish.yml — the "
+            "least-privilege default was removed (GITHUB_TOKEN would fall back to "
+            "broad default scopes).",
+        )
+        self.assertRegex(
+            block,
+            r"^\s*contents:\s*read\s*$",
+            "Workflow-level permissions must keep `contents: read`.",
+        )
+        write_grants = [
+            ln.strip()
+            for ln in block.splitlines()
+            if re.search(r":\s*write\b", _strip_comment(ln))
+        ]
+        self.assertEqual(
+            write_grants,
+            [],
+            "Workflow-level `permissions:` was broadened with a write grant "
+            "(least-privilege regression — keep it `contents: read`; job-level "
+            "`id-token: write` belongs under the publish job, not here):\n  "
+            + "\n  ".join(write_grants),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_ci_security_gate.py
+++ b/scanner/tests/test_ci_security_gate.py
@@ -9,9 +9,11 @@ loosening the pass-set would neuter the only security required-check without any
 visible failure. This guards that topology (cf. test_ci_gate_topology.py for the
 lint-gate analogue, and project memory paths-ignore-vs-branch-protection #186).
 
-Also guards that the PR-time DAST signal (`dast-baseline.yml`) is not silently
-downgraded to schedule/dispatch-only by asserting it still triggers on
-`pull_request`.
+Also guards both DAST triggers:
+- the PR-time signal (`dast-baseline.yml`) still triggers on `pull_request`
+  (not silently downgraded to schedule/dispatch-only); and
+- the nightly full scan (`dast-full-scan.yml`) keeps its `schedule:` trigger
+  (silently removing it would stop nightly DAST with no visible failure).
 
 Scope note: action SHA-pinning for these files is already covered by
 test_ci_gate_topology.py (it globs all workflows) — NOT duplicated here.
@@ -30,6 +32,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 SECURITY_SCAN = WORKFLOW_DIR / "security-scan.yml"
 DAST_BASELINE = WORKFLOW_DIR / "dast-baseline.yml"
+DAST_FULL_SCAN = WORKFLOW_DIR / "dast-full-scan.yml"
 
 # Dependencies the Security Scan Gate MUST aggregate. Removing any of these from
 # `needs:` would let that job fail without blocking a merge.
@@ -138,6 +141,43 @@ class TestDastBaselinePrTrigger(unittest.TestCase):
             "dast-baseline.yml must keep its `pull_request` trigger — losing it "
             "would silently demote the DAST scan to schedule/dispatch-only, "
             "removing per-PR signal.",
+        )
+
+
+class TestDastFullScanSchedule(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = (
+            DAST_FULL_SCAN.read_text(encoding="utf-8")
+            if DAST_FULL_SCAN.is_file()
+            else ""
+        )
+
+    def _on_block(self):
+        # The `on:` region: from `^on:` to the next top-level key (`jobs:` etc.).
+        out, in_on = [], False
+        for raw in self.text.splitlines():
+            if re.match(r"^on:\s*$", raw):
+                in_on = True
+                continue
+            if in_on:
+                if re.match(r"^[A-Za-z]", raw):  # next top-level key (jobs:, etc.)
+                    break
+                out.append(raw)
+        return "\n".join(out)
+
+    def test_dast_full_scan_yml_exists(self):
+        self.assertTrue(DAST_FULL_SCAN.is_file(), f"{DAST_FULL_SCAN} not found")
+
+    def test_triggers_on_schedule(self):
+        on_block = self._on_block()
+        self.assertTrue(on_block, "dast-full-scan.yml `on:` block not found")
+        self.assertRegex(
+            on_block,
+            r"^\s*schedule:",
+            "dast-full-scan.yml must keep its `schedule:` trigger — removing it "
+            "would silently stop the nightly full DAST scan with no visible "
+            "failure (parallels the dast-baseline pull_request guard).",
         )
 
 


### PR DESCRIPTION
## Summary

Follow-up audit of the release/nightly **security** workflows (`npm-publish.yml`, `dast-full-scan.yml`) found three silently-weakenable invariants with no regression guard. Adds a focused set (chosen to avoid guard sprawl).

### New / extended guards

- **`scanner/tests/test_ci_npm_publish.py`** (new)
  - every `npm publish` carries **`--provenance`** — dropping it still publishes successfully, so packages would ship **without SLSA attestation** with no visible failure (the whole point of the trusted-publisher workflow).
  - workflow-level **`permissions:` stays `contents: read`** — broadening it silently grants the release workflow extra scope. The `publish` job's legitimate **job-level** `id-token: write` (OIDC, required for provenance) is *not* flagged: the guard inspects only the top-level block.
- **`scanner/tests/test_ci_security_gate.py`** (extended) — `dast-full-scan.yml` keeps its **`schedule:`** trigger; silently removing it would stop the nightly DAST scan with no failure. Parallels the existing `dast-baseline.yml` `pull_request` trigger guard (co-located).

Conventions: stdlib-only (no PyYAML), no `scanner/lib` import (does not move the 99% coverage gate), dual-runner (pytest + `python3 -m unittest`), direction-explicit docstrings, comment-safe regexes. SHA-pinning already covered by `test_ci_gate_topology.py` (not duplicated).

## Test plan

- [x] Positive: `python3 -m pytest scanner/tests/test_ci_*.py` → 27 passed
- [x] Dual-runner: `python3 -m unittest` on changed modules → OK
- [x] **Non-vacuous** (mutation, no real files touched):
  - provenance guard FAILS when `--provenance` stripped
  - least-privilege guard FAILS when top-level perms broadened to `write`, and does **not** flag the real file's job-level `id-token: write` (precision check)
  - schedule guard FAILS when the `cron` schedule is removed
- [x] `markdownlint` clean + `lychee` 3/3 OK on the catalog doc

## Refs

OWASP CICD-SEC-1 / A08 (Software & Data Integrity Failures); NIST SSDF (SP 800-218) PO.3/PW.4; SLSA provenance. Catalog: `docs/devsecops/ci-config-regression-guards.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)