### PR TITLE
fix(docker,scanner): correct quickstart healthcheck and remove shellcheck noise

### DIFF
--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -41,7 +41,9 @@ services:
       - ./claudesec-dashboard.html:/usr/share/nginx/html/scan.html:ro
       - ./.claudesec-assets/dashboard-data.json:/usr/share/nginx/html/.claudesec-assets/dashboard-data.json:ro
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/"]
+      # Use wget (busybox) — the nginx:alpine base image does not ship curl,
+      # so a curl-based healthcheck always reports unhealthy. Matches docker-compose.yml.
+      test: ["CMD-SHELL", "wget -qO /dev/null http://127.0.0.1:8080/ || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/scanner/checks/infra/kubernetes.sh
+++ b/scanner/checks/infra/kubernetes.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # ClaudeSec — Infrastructure: Kubernetes Security Checks
 
-k8s_files=$(count_files "*.yaml" 2>/dev/null)
 has_k8s=false
 
 # Detect Kubernetes manifests

--- a/scanner/checks/prowler/integration.sh
+++ b/scanner/checks/prowler/integration.sh
@@ -57,7 +57,6 @@ _prowler_scan() {
   local provider="$1"
   shift
   local extra_args=("$@")
-  local output_file="${PROWLER_OUTPUT_DIR}/prowler-${provider}.json"
 
   # Compliance framework: pass through to Prowler when set (--compliance / .claudesec.yml)
   local compliance_args=()
@@ -80,13 +79,19 @@ _prowler_scan() {
     ci_flags+=(--quiet --unix-timestamp)
   fi
 
+  # PROWLER_SEVERITY is a space-separated list (default "medium high critical").
+  # prowler --severity accepts multiple values, so split into an array rather
+  # than relying on unquoted word-splitting.
+  local severity_args=()
+  read -ra severity_args <<< "$PROWLER_SEVERITY"
+
   # Run prowler with JSON-OCSF output, severity filter, FAIL only
   if has_command timeout; then
     timeout "$PROWLER_TIMEOUT" prowler "$provider" \
       -M json-ocsf \
       -F "prowler-${provider}" \
       -o "$PROWLER_OUTPUT_DIR" \
-      --severity $PROWLER_SEVERITY \
+      --severity "${severity_args[@]}" \
       --status FAIL \
       -b \
       --no-color \
@@ -98,7 +103,7 @@ _prowler_scan() {
       -M json-ocsf \
       -F "prowler-${provider}" \
       -o "$PROWLER_OUTPUT_DIR" \
-      --severity $PROWLER_SEVERITY \
+      --severity "${severity_args[@]}" \
       --status FAIL \
       -b \
       --no-color \
@@ -110,7 +115,7 @@ _prowler_scan() {
       -M json-ocsf \
       -F "prowler-${provider}" \
       -o "$PROWLER_OUTPUT_DIR" \
-      --severity $PROWLER_SEVERITY \
+      --severity "${severity_args[@]}" \
       --status FAIL \
       -b \
       --no-color \


### PR DESCRIPTION
## Summary

Audit follow-up across `docker/`, `scanner/`. Three surgical, verified fixes — one real correctness bug plus two shellcheck-hygiene cleanups (no behavior change).

| File | Change | Why |
|------|--------|-----|
| `docker-compose.quickstart.yml` | healthcheck `curl` → `wget` | **Real bug**: the `nginx:1.27-alpine` base (`Dockerfile.nginx`) ships no `curl`, so the curl healthcheck always reported `unhealthy`. `docker-compose.yml` already uses `wget`; this aligns quickstart with it. |
| `scanner/checks/prowler/integration.sh` | drop unused `output_file`; build `severity_args` array from `PROWLER_SEVERITY` | Removes SC2034 (dead var) and SC2086 ×3. `PROWLER_SEVERITY` is an intentional space-separated multi-value list (`medium high critical`) — converted to a `read -ra` array so the split is explicit and lint-clean. **Behavior identical.** |
| `scanner/checks/infra/kubernetes.sh` | drop unused `k8s_files` | Removes SC2034 (dead var). |

Intentional command-building splits (`$_ns_flag`, `$_kcmd`) and the SC2317 info finding were left untouched — they are correct as-is and non-blocking (CI shell-lint runs at `severity: error`).

## Test plan

- [x] `bash -n` on both edited scripts — clean
- [x] `shellcheck -x -S error` (CI gate severity) — 0 errors
- [x] SC2086/SC2034 removed from edited files (confirmed via shellcheck diff)
- [x] `bash scanner/tests/test_checks_coverage.sh` — 37 passed / 0 failed
- [x] `docker-compose.quickstart.yml` parses as valid YAML; healthcheck now `wget -qO /dev/null ...`
- [ ] CI: path-gated `docker-*` and `scanner-*` jobs validate on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)