### PR TITLE
chore(docker): pin base images by digest and track via Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,3 +26,13 @@ updates:
       pip-deps:
         patterns:
           - "*"
+
+  # Keeps the digest-pinned base images in Dockerfile / Dockerfile.nginx current.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@
 # - Optimized: removes unused cloud provider SDKs (~700MB savings)
 
 # ── Stage 1: build prowler wheels ────────────────────────────────────────────
-FROM alpine:3.20 AS builder
+# Base image pinned by digest for reproducible, supply-chain-safe builds.
+# Dependabot (docker ecosystem) bumps the digest when alpine:3.20 is rebuilt.
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc AS builder
 
 RUN apk add --no-cache \
     gcc \
@@ -59,7 +61,8 @@ RUN pip install --no-cache-dir --no-compile --break-system-packages --prefix=/in
        done
 
 # ── Stage 2: runtime image ──────────────────────────────────────────────────
-FROM alpine:3.20
+# Pinned by digest (same alpine:3.20 release as the builder stage).
+FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc
 
 RUN apk add --no-cache \
     bash \

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,4 +1,6 @@
-FROM nginx:1.27-alpine
+# Base image pinned by digest for reproducible, supply-chain-safe builds.
+# Dependabot (docker ecosystem) bumps the digest when nginx:1.27-alpine is rebuilt.
+FROM nginx:1.27-alpine@sha256:65645c7bb6a0661892a8b03b89d0743208a18dd2f3f17a54ef4b76fb8e2f2a10
 COPY nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY nginx/favicon.svg /usr/share/nginx/html/favicon.svg
 RUN echo '<!DOCTYPE html><html><body>Dashboard not mounted.</body></html>' > /usr/share/nginx/html/index.html \


### PR DESCRIPTION
## Summary

A DevSecOps scanner shipping with floating base-image tags is an ironic supply-chain gap. This pins all base images by `sha256` digest and adds an auto-update path so the pins don't go stale.

| File | Change |
|------|--------|
| `Dockerfile` | `FROM alpine:3.20` → `…@sha256:d9e853e8…a4b6bc` (builder **and** runtime stage) |
| `Dockerfile.nginx` | `FROM nginx:1.27-alpine` → `…@sha256:65645c7b…2f2a10` |
| `.github/dependabot.yml` | add `package-ecosystem: "docker"` (weekly) so Dependabot bumps the digests |

The human-readable tag is retained alongside the digest (`tag@sha256:…`) so the version stays legible while the pull is immutable.

### Why Dependabot, not Renovate
The repo already standardizes on Dependabot (actions/npm/pip) with a CI-gated auto-merge workflow and no Renovate config. Extending the existing tool keeps a single update path and reuses `dependabot-auto-merge.yml` as-is. Digest bumps flow through its current policy (patch auto-merge after required CI, incl. the Docker Smoke Test).

## Test plan

- [x] Digests captured via `docker buildx imagetools inspect <img>` (not hand-written)
- [x] `docker pull <img>@<digest>` succeeds for both images
- [x] `docker build --check` clean on `Dockerfile` and `Dockerfile.nginx`
- [x] `Dockerfile.nginx` builds end-to-end with the pinned digest
- [x] `.github/dependabot.yml` valid YAML; ecosystems = [github-actions, npm, pip, docker]
- [ ] CI: `Docker Dashboard Smoke Test` builds the full image on this PR

## Out of scope (separate backlog)
`prowler` and `apk` package version pinning (`Dockerfile:18,64`) — different concern (pip/apk, not base image); apk pins in Alpine are brittle. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)