### PR TITLE
test(scanner): cover untested checks + extend token-expiry-gate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -181,6 +181,14 @@ jobs:
         run: bash scanner/tests/test_check_network_tls.sh
       - name: Run bash unit tests (cicd/pipeline checks)
         run: bash scanner/tests/test_check_cicd_pipeline.sh
+      - name: Run bash unit tests (code/security-flaws checks)
+        run: bash scanner/tests/test_check_code_security_flaws.sh
+      - name: Run bash unit tests (code/sast-tools checks)
+        run: bash scanner/tests/test_check_code_sast_tools.sh
+      - name: Run bash unit tests (infra/iac checks)
+        run: bash scanner/tests/test_check_infra_iac.sh
+      - name: Run bash unit tests (access-control/secrets-scan checks)
+        run: bash scanner/tests/test_check_secrets_scan.sh
       - name: Run scanner pytest + coverage gate (>=99%)
         id: scanner_tests
         env:

--- a/scanner/tests/test_check_code_sast_tools.sh
+++ b/scanner/tests/test_check_code_sast_tools.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Unit tests for scanner/checks/code/sast-tools.sh
+#
+# WHY THIS TEST IS NARROW:
+# sast-tools.sh (CODE-SAST-001..006) wraps live external CLIs:
+#   semgrep, bandit, gosec, brakeman, npm-audit, pip-audit, cargo-audit, govulncheck.
+# It executes those tools against SCAN_DIR at runtime and parses their JSON output.
+# There are no file-pattern heuristics to exercise with fixtures — the check produces
+# SKIP when a CLI is absent, and PASS/FAIL only when the CLI is installed and run.
+# Making these tests non-flaky would require either stubbing every CLI binary or
+# having them installed in CI, neither of which is hermetic.
+#
+# WHAT IS TESTABLE OFFLINE (no live CLIs needed):
+#   CODE-SAST-001..005  skip when CLAUDESEC_NONINTERACTIVE=1 (dashboard mode gate)
+#   CODE-SAST-006       WARN when 0 tools are installed (tool-coverage summary)
+#
+# Run: bash scanner/tests/test_check_code_sast_tools.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+CHECKS_DIR="$SCRIPT_DIR/../checks"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+
+RESULTS=()
+pass()  { RESULTS+=("PASS:$1"); }
+fail()  { RESULTS+=("FAIL:$1:${4:-}"); }
+warn()  { RESULTS+=("WARN:$1"); }
+skip()  { RESULTS+=("SKIP:$1"); }
+info()  { true; }  # suppress info output in test context
+
+source "$LIB_DIR/checks.sh"
+
+assert_has_result() {
+  local desc="$1" expected_type="$2" check_id="$3"
+  local found=false
+  for r in "${RESULTS[@]}"; do
+    if [[ "$r" == "${expected_type}:${check_id}"* ]]; then
+      found=true
+      break
+    fi
+  done
+  if $found; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (expected $expected_type:$check_id, got: ${RESULTS[*]:-none})"
+    ((TEST_FAILED++))
+  fi
+}
+
+run_check_noninteractive() {
+  RESULTS=()
+  # Inject language detection vars expected by sast-tools.sh
+  _has_python=false; _has_js=false; _has_ts=false
+  _has_go=false; _has_java=false; _has_ruby=false; _has_php=false
+  CLAUDESEC_NONINTERACTIVE=1 source "$CHECKS_DIR/code/sast-tools.sh"
+}
+
+run_check_interactive() {
+  RESULTS=()
+  _has_python=false; _has_js=false; _has_ts=false
+  _has_go=false; _has_java=false; _has_ruby=false; _has_php=false
+  SCAN_DIR="$1"
+  # Run without CLAUDESEC_NONINTERACTIVE so the tool-presence path executes
+  unset CLAUDESEC_NONINTERACTIVE 2>/dev/null || true
+  source "$CHECKS_DIR/code/sast-tools.sh" 2>/dev/null || true
+}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ── CLAUDESEC_NONINTERACTIVE=1 short-circuits all checks to SKIP ─────────────
+
+echo "=== CODE-SAST: NONINTERACTIVE mode skips all checks ==="
+
+mkdir -p "$tmpdir/empty"
+echo "# readme" > "$tmpdir/empty/README.md"
+SCAN_DIR="$tmpdir/empty" run_check_noninteractive
+assert_has_result "NONINTERACTIVE skips CODE-SAST-001 (Semgrep)" "SKIP" "CODE-SAST-001"
+assert_has_result "NONINTERACTIVE skips CODE-SAST-002 (Bandit)" "SKIP" "CODE-SAST-002"
+assert_has_result "NONINTERACTIVE skips CODE-SAST-003 (gosec)" "SKIP" "CODE-SAST-003"
+assert_has_result "NONINTERACTIVE skips CODE-SAST-004 (dep audit)" "SKIP" "CODE-SAST-004"
+
+# ── Interactive mode: no lockfile -> CODE-SAST-004 skips ─────────────────────
+
+echo "=== CODE-SAST-004: no lockfile -> skip ==="
+
+mkdir -p "$tmpdir/nolockfile"
+cat > "$tmpdir/nolockfile/app.py" <<'PY'
+print("hello")
+PY
+run_check_interactive "$tmpdir/nolockfile"
+assert_has_result "No lockfile -> skip CODE-SAST-004" "SKIP" "CODE-SAST-004"
+
+# ── Interactive mode: lockfile present -> CODE-SAST-004 passes or skips ──────
+
+echo "=== CODE-SAST-004: requirements.txt present -> pass or skip ==="
+
+mkdir -p "$tmpdir/withlockfile"
+cat > "$tmpdir/withlockfile/requirements.txt" <<'REQ'
+flask==3.0.0
+requests==2.31.0
+REQ
+run_check_interactive "$tmpdir/withlockfile"
+# pip-audit/safety may or may not be installed; result is PASS or SKIP, never FAIL on a clean fixture
+for r in "${RESULTS[@]}"; do
+  if [[ "$r" == "PASS:CODE-SAST-004"* || "$r" == "SKIP:CODE-SAST-004"* ]]; then
+    echo "  PASS: requirements.txt -> CODE-SAST-004 is PASS or SKIP (not FAIL)"
+    ((TEST_PASSED++))
+    break
+  fi
+done
+
+# ── Interactive mode: no SAST tools -> CODE-SAST-006 warns ──────────────────
+
+echo "=== CODE-SAST-006: no installed SAST tools -> WARN ==="
+
+# Override has_command to simulate no tools installed
+has_command() { return 1; }
+mkdir -p "$tmpdir/notool"
+cat > "$tmpdir/notool/app.py" <<'PY'
+print("hello")
+PY
+run_check_interactive "$tmpdir/notool"
+unset -f has_command 2>/dev/null || true
+# Restore real has_command from checks.sh
+source "$LIB_DIR/checks.sh"
+assert_has_result "No SAST tools installed -> WARN CODE-SAST-006" "WARN" "CODE-SAST-006"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1

--- a/scanner/tests/test_check_code_security_flaws.sh
+++ b/scanner/tests/test_check_code_security_flaws.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Unit tests for scanner/checks/code/security-flaws.sh
+# Run: bash scanner/tests/test_check_code_security_flaws.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+CHECKS_DIR="$SCRIPT_DIR/../checks"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+
+RESULTS=()
+pass()  { RESULTS+=("PASS:$1"); }
+fail()  { RESULTS+=("FAIL:$1:${4:-}"); }
+warn()  { RESULTS+=("WARN:$1"); }
+skip()  { RESULTS+=("SKIP:$1"); }
+
+source "$LIB_DIR/checks.sh"
+
+assert_has_result() {
+  local desc="$1" expected_type="$2" check_id="$3"
+  local found=false
+  for r in "${RESULTS[@]}"; do
+    if [[ "$r" == "${expected_type}:${check_id}"* ]]; then
+      found=true
+      break
+    fi
+  done
+  if $found; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (expected $expected_type:$check_id, got: ${RESULTS[*]:-none})"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_no_result() {
+  local desc="$1" unexpected_type="$2" check_id="$3"
+  local found=false
+  for r in "${RESULTS[@]}"; do
+    if [[ "$r" == "${unexpected_type}:${check_id}"* ]]; then
+      found=true
+      break
+    fi
+  done
+  if ! $found; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (unexpected $unexpected_type:$check_id found)"
+    ((TEST_FAILED++))
+  fi
+}
+
+# Source injection.sh first — security-flaws.sh reuses the language detection
+# vars and helpers (_code_grep, _format_hits) defined there.
+run_check() {
+  RESULTS=()
+  # injection.sh sets language flags and defines _code_grep / _format_hits
+  source "$CHECKS_DIR/code/injection.sh"
+  source "$CHECKS_DIR/code/security-flaws.sh"
+}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ── No source code -> all skip ──────────────────────────────────────────────
+
+echo "=== CODE-SEC: No source code ==="
+
+mkdir -p "$tmpdir/empty"
+echo "# readme" > "$tmpdir/empty/README.md"
+SCAN_DIR="$tmpdir/empty" run_check
+assert_has_result "No code files -> skip CODE-SEC-001" "SKIP" "CODE-SEC-001"
+assert_has_result "No code files -> skip CODE-SEC-002" "SKIP" "CODE-SEC-002"
+assert_has_result "No code files -> skip CODE-SEC-003" "SKIP" "CODE-SEC-003"
+assert_has_result "No code files -> skip CODE-SEC-004" "SKIP" "CODE-SEC-004"
+assert_has_result "No code files -> skip CODE-SEC-005" "SKIP" "CODE-SEC-005"
+
+# ── CODE-SEC-001: Insecure Cryptography ─────────────────────────────────────
+
+echo "=== CODE-SEC-001: Insecure Cryptography ==="
+
+# MD5 usage -> FAIL
+mkdir -p "$tmpdir/md5"
+cat > "$tmpdir/md5/hash.py" <<'PY'
+import hashlib
+def checksum(data):
+    return hashlib.md5(data).hexdigest()
+PY
+SCAN_DIR="$tmpdir/md5" run_check
+assert_has_result "hashlib.md5 detected as insecure crypto" "FAIL" "CODE-SEC-001"
+
+# SHA1 usage -> FAIL
+mkdir -p "$tmpdir/sha1"
+cat > "$tmpdir/sha1/hash.py" <<'PY'
+import hashlib
+def legacy_hash(data):
+    return hashlib.sha1(data).hexdigest()
+PY
+SCAN_DIR="$tmpdir/sha1" run_check
+assert_has_result "hashlib.sha1 detected as insecure crypto" "FAIL" "CODE-SEC-001"
+
+# DES usage in Java -> FAIL
+mkdir -p "$tmpdir/des"
+cat > "$tmpdir/des/Cipher.java" <<'JAVA'
+import javax.crypto.Cipher;
+public class Cipher {
+    public void encrypt() throws Exception {
+        Cipher c = Cipher.getInstance("DES");
+    }
+}
+JAVA
+SCAN_DIR="$tmpdir/des" run_check
+assert_has_result "DES cipher usage detected as insecure crypto" "FAIL" "CODE-SEC-001"
+
+# Safe: SHA-256 -> PASS
+mkdir -p "$tmpdir/safe_crypto"
+cat > "$tmpdir/safe_crypto/hash.py" <<'PY'
+import hashlib
+def secure_hash(data):
+    return hashlib.sha256(data).hexdigest()
+PY
+SCAN_DIR="$tmpdir/safe_crypto" run_check
+assert_has_result "SHA-256 usage passes CODE-SEC-001" "PASS" "CODE-SEC-001"
+
+# ── CODE-SEC-002: Unsafe Deserialization ─────────────────────────────────────
+
+echo "=== CODE-SEC-002: Unsafe Deserialization ==="
+
+# yaml.load without SafeLoader -> FAIL (reliable path: separate yaml check in the check)
+# NOTE: pickle.loads goes through a combined ERE regex with a (?!Loader) lookahead that
+# macOS grep (BSD ERE) rejects, so that sub-path silently returns no hits.
+# yaml.load detection uses a separate, lookahead-free grep call on lines 68-71 and works.
+mkdir -p "$tmpdir/yaml_unsafe"
+cat > "$tmpdir/yaml_unsafe/loader.py" <<'PY'
+import yaml
+def load_config(data):
+    return yaml.load(data)
+PY
+SCAN_DIR="$tmpdir/yaml_unsafe" run_check
+assert_has_result "yaml.load without Loader detected as unsafe deserialization" "FAIL" "CODE-SEC-002"
+
+# yaml.load WITH SafeLoader -> PASS
+mkdir -p "$tmpdir/yaml_safe"
+cat > "$tmpdir/yaml_safe/loader.py" <<'PY'
+import yaml
+def load_config(data):
+    return yaml.load(data, Loader=yaml.SafeLoader)
+PY
+SCAN_DIR="$tmpdir/yaml_safe" run_check
+assert_has_result "yaml.load with SafeLoader passes CODE-SEC-002" "PASS" "CODE-SEC-002"
+
+# PHP unserialize -> FAIL
+mkdir -p "$tmpdir/php_deser"
+cat > "$tmpdir/php_deser/handler.php" <<'PHP'
+<?php
+function load_session($data) {
+    return unserialize($data);
+}
+PHP
+SCAN_DIR="$tmpdir/php_deser" run_check
+assert_has_result "PHP unserialize detected as unsafe deserialization" "FAIL" "CODE-SEC-002"
+
+# ── CODE-SEC-003: Hardcoded Credentials ──────────────────────────────────────
+
+echo "=== CODE-SEC-003: Hardcoded Credentials ==="
+
+# Hardcoded password -> FAIL
+# NOTE: filename must NOT contain "config" or "settings" — the check's filter skips
+# any line whose output path matches "config\." (see security-flaws.sh lines 119-126).
+mkdir -p "$tmpdir/hardcred"
+# Assemble the dummy password from two fragments at runtime so the committed test
+# source contains no `password = "<value>"` literal for GitGuardian to flag. The
+# fixture written to disk still holds the full assignment the check detects.
+printf 'def get_db():\n    password = "%s%s"\n    return connect(password=password)\n' \
+  'supersecret' '123' > "$tmpdir/hardcred/database.py"
+SCAN_DIR="$tmpdir/hardcred" run_check
+assert_has_result "Hardcoded password in non-config file detected" "FAIL" "CODE-SEC-003"
+
+# Safe: env var lookup -> PASS
+mkdir -p "$tmpdir/env_cred"
+cat > "$tmpdir/env_cred/database.py" <<'PY'
+import os
+def get_db():
+    password = os.getenv("DB_PASSWORD")
+    return connect(password=password)
+PY
+SCAN_DIR="$tmpdir/env_cred" run_check
+assert_has_result "os.getenv credential lookup passes CODE-SEC-003" "PASS" "CODE-SEC-003"
+
+# ── CODE-SEC-004: Insecure Random ────────────────────────────────────────────
+
+echo "=== CODE-SEC-004: Insecure Random ==="
+
+# Python random.randint -> FAIL
+mkdir -p "$tmpdir/rand"
+cat > "$tmpdir/rand/token.py" <<'PY'
+import random
+def generate_token():
+    return random.randint(0, 999999)
+PY
+SCAN_DIR="$tmpdir/rand" run_check
+assert_has_result "random.randint detected as insecure PRNG" "FAIL" "CODE-SEC-004"
+
+# JavaScript Math.random -> FAIL
+mkdir -p "$tmpdir/js_rand"
+cat > "$tmpdir/js_rand/token.js" <<'JS'
+function generateToken() {
+    return Math.random().toString(36).slice(2);
+}
+JS
+SCAN_DIR="$tmpdir/js_rand" run_check
+assert_has_result "Math.random detected as insecure PRNG" "FAIL" "CODE-SEC-004"
+
+# Safe: secrets module -> PASS
+mkdir -p "$tmpdir/safe_rand"
+cat > "$tmpdir/safe_rand/token.py" <<'PY'
+import secrets
+def generate_token():
+    return secrets.token_hex(32)
+PY
+SCAN_DIR="$tmpdir/safe_rand" run_check
+assert_has_result "secrets.token_hex passes CODE-SEC-004" "PASS" "CODE-SEC-004"
+
+# ── CODE-SEC-005: Debug Mode ──────────────────────────────────────────────────
+
+echo "=== CODE-SEC-005: Debug Mode ==="
+
+# Python DEBUG=True -> FAIL
+mkdir -p "$tmpdir/debug"
+cat > "$tmpdir/debug/settings.py" <<'PY'
+DEBUG = True
+SECRET_KEY = "dev-key"
+PY
+SCAN_DIR="$tmpdir/debug" run_check
+assert_has_result "DEBUG=True detected as debug mode enabled" "FAIL" "CODE-SEC-005"
+
+# Flask app.run with debug=True -> FAIL
+mkdir -p "$tmpdir/flask_debug"
+cat > "$tmpdir/flask_debug/app.py" <<'PY'
+from flask import Flask
+app = Flask(__name__)
+
+if __name__ == "__main__":
+    app.run(debug=True, port=5000)
+PY
+SCAN_DIR="$tmpdir/flask_debug" run_check
+assert_has_result "app.run(debug=True) detected as debug mode" "FAIL" "CODE-SEC-005"
+
+# Safe: no debug config -> PASS
+mkdir -p "$tmpdir/nodebug"
+cat > "$tmpdir/nodebug/settings.py" <<'PY'
+import os
+DEBUG = os.getenv("DEBUG", "false").lower() == "true"
+SECRET_KEY = os.getenv("SECRET_KEY")
+PY
+SCAN_DIR="$tmpdir/nodebug" run_check
+assert_has_result "No static debug mode passes CODE-SEC-005" "PASS" "CODE-SEC-005"
+
+# ── CODE-SEC-006: Error Information Leakage ───────────────────────────────────
+
+echo "=== CODE-SEC-006: Error Information Leakage ==="
+
+# Python traceback.format_exc -> WARN
+mkdir -p "$tmpdir/traceback"
+cat > "$tmpdir/traceback/handler.py" <<'PY'
+import traceback
+from flask import jsonify
+
+def handle_error(e):
+    return jsonify({"error": traceback.format_exc()}), 500
+PY
+SCAN_DIR="$tmpdir/traceback" run_check
+assert_has_result "traceback.format_exc detected as info leakage" "WARN" "CODE-SEC-006"
+
+# JavaScript res.send with error stack -> WARN
+mkdir -p "$tmpdir/js_err"
+cat > "$tmpdir/js_err/app.js" <<'JS'
+app.use((err, req, res, next) => {
+    res.send(err.message);
+});
+JS
+SCAN_DIR="$tmpdir/js_err" run_check
+assert_has_result "res.send(err.message) detected as info leakage" "WARN" "CODE-SEC-006"
+
+# Safe: no error exposure -> PASS
+mkdir -p "$tmpdir/safe_err"
+cat > "$tmpdir/safe_err/handler.py" <<'PY'
+import logging
+logger = logging.getLogger(__name__)
+
+def handle_error(e):
+    logger.error("Internal error", exc_info=True)
+    return {"error": "Internal server error"}, 500
+PY
+SCAN_DIR="$tmpdir/safe_err" run_check
+assert_has_result "No error leakage passes CODE-SEC-006" "PASS" "CODE-SEC-006"
+
+# ── CODE-SEC-007: Insecure File Upload ───────────────────────────────────────
+
+echo "=== CODE-SEC-007: Insecure File Upload ==="
+
+# Python request.files without validation -> FAIL
+mkdir -p "$tmpdir/upload"
+cat > "$tmpdir/upload/views.py" <<'PY'
+from flask import request
+
+def upload():
+    f = request.files["file"]
+    f.save("/uploads/" + f.filename)
+PY
+SCAN_DIR="$tmpdir/upload" run_check
+assert_has_result "request.files without validation detected as insecure upload" "FAIL" "CODE-SEC-007"
+
+# Python request.files WITH validation -> PASS
+mkdir -p "$tmpdir/safe_upload"
+cat > "$tmpdir/safe_upload/views.py" <<'PY'
+from flask import request
+
+ALLOWED_EXTENSIONS = {"png", "jpg", "gif"}
+
+def upload():
+    f = request.files["file"]
+    ext = f.filename.rsplit(".", 1)[-1].lower()
+    if ext not in ALLOWED_EXTENSIONS:
+        return "Not allowed", 400
+    f.save("/uploads/" + f.filename)
+PY
+SCAN_DIR="$tmpdir/safe_upload" run_check
+assert_has_result "File upload with ALLOWED_EXTENSIONS passes CODE-SEC-007" "PASS" "CODE-SEC-007"
+
+# No upload patterns -> SKIP
+mkdir -p "$tmpdir/no_upload"
+cat > "$tmpdir/no_upload/app.py" <<'PY'
+def hello():
+    return "Hello, World!"
+PY
+SCAN_DIR="$tmpdir/no_upload" run_check
+assert_has_result "No upload patterns -> skip CODE-SEC-007" "SKIP" "CODE-SEC-007"
+
+# ── CODE-SEC-008: Race Conditions ─────────────────────────────────────────────
+
+echo "=== CODE-SEC-008: Race Conditions ==="
+
+# Python threading -> WARN
+mkdir -p "$tmpdir/threading"
+cat > "$tmpdir/threading/worker.py" <<'PY'
+import threading
+
+def run_task(func, args):
+    t = threading.Thread(target=func, args=args)
+    t.start()
+    return t
+PY
+SCAN_DIR="$tmpdir/threading" run_check
+assert_has_result "threading.Thread usage detected for concurrency review" "WARN" "CODE-SEC-008"
+
+# Safe: no concurrency -> PASS
+mkdir -p "$tmpdir/no_concurrency"
+cat > "$tmpdir/no_concurrency/app.py" <<'PY'
+def process(data):
+    return data.upper()
+PY
+SCAN_DIR="$tmpdir/no_concurrency" run_check
+assert_has_result "No concurrency patterns passes CODE-SEC-008" "PASS" "CODE-SEC-008"
+
+# ── CODE-SEC-009: Prototype Pollution ─────────────────────────────────────────
+
+echo "=== CODE-SEC-009: Prototype Pollution ==="
+
+# JavaScript __proto__ manipulation -> FAIL
+mkdir -p "$tmpdir/proto"
+cat > "$tmpdir/proto/merge.js" <<'JS'
+function merge(target, source) {
+    for (const key in source) {
+        if (key === "__proto__") continue;
+        target[key] = source[key];
+    }
+}
+const obj = {};
+obj["__proto__"]["admin"] = true;
+JS
+SCAN_DIR="$tmpdir/proto" run_check
+assert_has_result "__proto__ usage detected as prototype pollution risk" "FAIL" "CODE-SEC-009"
+
+# Safe: no JS code -> SKIP
+mkdir -p "$tmpdir/no_js"
+cat > "$tmpdir/no_js/app.py" <<'PY'
+def hello():
+    return "Hello"
+PY
+SCAN_DIR="$tmpdir/no_js" run_check
+assert_has_result "No JS/TS files -> skip CODE-SEC-009" "SKIP" "CODE-SEC-009"
+
+# ── CODE-SEC-010: Open Redirect ───────────────────────────────────────────────
+
+echo "=== CODE-SEC-010: Open Redirect ==="
+
+# Python redirect with request.GET -> FAIL
+# NOTE: the grep pattern matches single lines only — request.GET must appear on the
+# same line as redirect() for the check to fire (see security-flaws.sh line 336).
+mkdir -p "$tmpdir/redirect"
+cat > "$tmpdir/redirect/views.py" <<'PY'
+from django.shortcuts import redirect
+
+def login_view(request):
+    return redirect(request.GET.get("next", "/"))
+PY
+SCAN_DIR="$tmpdir/redirect" run_check
+assert_has_result "redirect(request.GET...) on same line detected as open redirect" "FAIL" "CODE-SEC-010"
+
+# JavaScript res.redirect with req.query -> FAIL
+# NOTE: same single-line constraint — req.query must appear on the same line as res.redirect().
+mkdir -p "$tmpdir/js_redirect"
+cat > "$tmpdir/js_redirect/app.js" <<'JS'
+app.get("/login", (req, res) => { res.redirect(req.query.next || "/"); });
+JS
+SCAN_DIR="$tmpdir/js_redirect" run_check
+assert_has_result "res.redirect(req.query...) on same line detected as open redirect" "FAIL" "CODE-SEC-010"
+
+# Safe: no redirect patterns -> PASS
+mkdir -p "$tmpdir/no_redirect"
+cat > "$tmpdir/no_redirect/app.py" <<'PY'
+def home():
+    return "Welcome"
+PY
+SCAN_DIR="$tmpdir/no_redirect" run_check
+assert_has_result "No redirect patterns passes CODE-SEC-010" "PASS" "CODE-SEC-010"
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1

--- a/scanner/tests/test_check_infra_iac.sh
+++ b/scanner/tests/test_check_infra_iac.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Unit tests for scanner/checks/infra/iac.sh
+# Run: bash scanner/tests/test_check_infra_iac.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+CHECKS_DIR="$SCRIPT_DIR/../checks"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+# Stub color codes (checks.sh uses these variables for output formatting)
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+
+# Capture pass/fail/warn/skip calls instead of printing
+RESULTS=()
+pass()  { RESULTS+=("PASS:$1"); }
+fail()  { RESULTS+=("FAIL:$1:${4:-}"); }
+warn()  { RESULTS+=("WARN:$1"); }
+skip()  { RESULTS+=("SKIP:$1"); }
+
+source "$LIB_DIR/checks.sh"
+
+assert_has_result() {
+  local desc="$1" expected_type="$2" check_id="$3"
+  local found=false
+  for r in "${RESULTS[@]+"${RESULTS[@]}"}"; do
+    if [[ "$r" == "${expected_type}:${check_id}"* ]]; then
+      found=true
+      break
+    fi
+  done
+  if $found; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (expected $expected_type:$check_id, got: ${RESULTS[*]:-none})"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_no_result() {
+  local desc="$1" unexpected_type="$2" check_id="$3"
+  local found=false
+  for r in "${RESULTS[@]+"${RESULTS[@]}"}"; do
+    if [[ "$r" == "${unexpected_type}:${check_id}"* ]]; then
+      found=true
+      break
+    fi
+  done
+  if ! $found; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (unexpected $unexpected_type:$check_id found)"
+    ((TEST_FAILED++))
+  fi
+}
+
+run_check() {
+  RESULTS=()
+  source "$CHECKS_DIR/infra/iac.sh"
+}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ── No Terraform / No Helm -> all skip ──────────────────────────────────────
+
+echo "=== INFRA-020/021/022: No Terraform files -> skip ==="
+
+mkdir -p "$tmpdir/empty"
+printf '# readme\n' > "$tmpdir/empty/README.md"
+SCAN_DIR="$tmpdir/empty" run_check
+assert_has_result "No .tf files -> skip INFRA-020" "SKIP" "INFRA-020"
+assert_has_result "No .tf files -> skip INFRA-021" "SKIP" "INFRA-021"
+assert_has_result "No .tf files -> skip INFRA-022" "SKIP" "INFRA-022"
+
+echo "=== INFRA-023: No Helm chart -> skip ==="
+
+SCAN_DIR="$tmpdir/empty" run_check
+assert_has_result "No Chart.yaml -> skip INFRA-023" "SKIP" "INFRA-023"
+
+# ── INFRA-020: Hardcoded secrets in Terraform ────────────────────────────────
+
+echo "=== INFRA-020: Hardcoded secrets in Terraform ==="
+
+# FAIL: password hardcoded in .tf file
+# Runtime-assemble the dummy password from two fragments so the committed test
+# source carries no `password = "<value>"` literal for GitGuardian to flag; the
+# fixture written to disk still holds the full assignment the check detects.
+mkdir -p "$tmpdir/tf_secret"
+printf 'resource "aws_db_instance" "db" {\n  password = "%s%s"\n}\n' \
+  'hunter2' 'supersecret' > "$tmpdir/tf_secret/main.tf"
+SCAN_DIR="$tmpdir/tf_secret" run_check
+assert_has_result "Hardcoded password in .tf -> FAIL INFRA-020" "FAIL" "INFRA-020"
+
+# FAIL: api_key hardcoded in .tf file
+mkdir -p "$tmpdir/tf_apikey"
+cat > "$tmpdir/tf_apikey/vars.tf" <<'TF'
+variable "config" {
+  default = ""
+}
+resource "example" "r" {
+  api_key = "some-hardcoded-key-value"
+}
+TF
+SCAN_DIR="$tmpdir/tf_apikey" run_check
+assert_has_result "Hardcoded api_key in .tf -> FAIL INFRA-020" "FAIL" "INFRA-020"
+
+# FAIL: token hardcoded in .tf file
+mkdir -p "$tmpdir/tf_token"
+cat > "$tmpdir/tf_token/main.tf" <<'TF'
+resource "service_account" "sa" {
+  token = "my-static-token-value"
+}
+TF
+SCAN_DIR="$tmpdir/tf_token" run_check
+assert_has_result "Hardcoded token in .tf -> FAIL INFRA-020" "FAIL" "INFRA-020"
+
+# PASS: .tf file present but no hardcoded secrets (uses var reference)
+mkdir -p "$tmpdir/tf_clean"
+cat > "$tmpdir/tf_clean/main.tf" <<'TF'
+resource "aws_db_instance" "db" {
+  engine   = "postgres"
+  password = var.db_password
+}
+TF
+SCAN_DIR="$tmpdir/tf_clean" run_check
+assert_has_result "Terraform using var reference -> PASS INFRA-020" "PASS" "INFRA-020"
+
+# ── INFRA-021: Terraform state file in repository ───────────────────────────
+
+echo "=== INFRA-021: Terraform state file in repo ==="
+
+# FAIL: terraform.tfstate present
+mkdir -p "$tmpdir/tf_state"
+cat > "$tmpdir/tf_state/main.tf" <<'TF'
+resource "null_resource" "example" {}
+TF
+printf '{"version":4,"terraform_version":"1.5.0","resources":[]}\n' \
+  > "$tmpdir/tf_state/terraform.tfstate"
+SCAN_DIR="$tmpdir/tf_state" run_check
+assert_has_result "terraform.tfstate present -> FAIL INFRA-021" "FAIL" "INFRA-021"
+
+# PASS: .tf present but no .tfstate
+mkdir -p "$tmpdir/tf_no_state"
+cat > "$tmpdir/tf_no_state/main.tf" <<'TF'
+resource "null_resource" "example" {}
+TF
+SCAN_DIR="$tmpdir/tf_no_state" run_check
+assert_has_result "No terraform.tfstate -> PASS INFRA-021" "PASS" "INFRA-021"
+
+# ── INFRA-022: Terraform lock file ───────────────────────────────────────────
+
+echo "=== INFRA-022: Terraform dependency lock file ==="
+
+# WARN: .tf present but no .terraform.lock.hcl
+mkdir -p "$tmpdir/tf_no_lock"
+cat > "$tmpdir/tf_no_lock/main.tf" <<'TF'
+resource "null_resource" "example" {}
+TF
+SCAN_DIR="$tmpdir/tf_no_lock" run_check
+assert_has_result "Missing .terraform.lock.hcl -> WARN INFRA-022" "WARN" "INFRA-022"
+
+# PASS: both .tf and .terraform.lock.hcl present
+mkdir -p "$tmpdir/tf_with_lock"
+cat > "$tmpdir/tf_with_lock/main.tf" <<'TF'
+resource "null_resource" "example" {}
+TF
+cat > "$tmpdir/tf_with_lock/.terraform.lock.hcl" <<'HCL'
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.2.1"
+}
+HCL
+SCAN_DIR="$tmpdir/tf_with_lock" run_check
+assert_has_result "Lock file present -> PASS INFRA-022" "PASS" "INFRA-022"
+
+# ── INFRA-023: Helm chart default passwords ──────────────────────────────────
+
+echo "=== INFRA-023: Helm default passwords in values.yaml ==="
+
+# FAIL: default password in values.yaml
+mkdir -p "$tmpdir/helm_bad/charts"
+cat > "$tmpdir/helm_bad/Chart.yaml" <<'YAML'
+apiVersion: v2
+name: myapp
+version: 0.1.0
+YAML
+cat > "$tmpdir/helm_bad/values.yaml" <<'YAML'
+database:
+  password: "admin"
+YAML
+SCAN_DIR="$tmpdir/helm_bad" run_check
+assert_has_result "Default password in Helm values.yaml -> FAIL INFRA-023" "FAIL" "INFRA-023"
+
+# FAIL: 'changeme' value in values.yaml
+mkdir -p "$tmpdir/helm_changeme/charts"
+cat > "$tmpdir/helm_changeme/Chart.yaml" <<'YAML'
+apiVersion: v2
+name: myapp
+version: 0.1.0
+YAML
+cat > "$tmpdir/helm_changeme/values.yaml" <<'YAML'
+auth:
+  secret: "changeme"
+YAML
+SCAN_DIR="$tmpdir/helm_changeme" run_check
+assert_has_result "'changeme' in Helm values.yaml -> FAIL INFRA-023" "FAIL" "INFRA-023"
+
+# PASS: Chart.yaml present but values.yaml uses non-default value
+mkdir -p "$tmpdir/helm_clean/charts"
+cat > "$tmpdir/helm_clean/Chart.yaml" <<'YAML'
+apiVersion: v2
+name: myapp
+version: 0.1.0
+YAML
+cat > "$tmpdir/helm_clean/values.yaml" <<'YAML'
+database:
+  password: ""
+auth:
+  existingSecret: my-app-secret
+YAML
+SCAN_DIR="$tmpdir/helm_clean" run_check
+assert_has_result "No default passwords in Helm values -> PASS INFRA-023" "PASS" "INFRA-023"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1

--- a/scanner/tests/test_check_secrets_scan.sh
+++ b/scanner/tests/test_check_secrets_scan.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+# Unit tests for scanner/checks/access-control/secrets-scan.sh
+# Covers patterns and edge cases not in test_check_access_control.sh, plus
+# SECRETS-003 (git history scan) which requires a real git repo fixture.
+# Run: bash scanner/tests/test_check_secrets_scan.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+CHECKS_DIR="$SCRIPT_DIR/../checks"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+# Stub color codes
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+FORMAT="text"
+QUIET=1
+SEVERITY="low"
+
+# Capture pass/fail/warn/skip calls instead of printing
+RESULTS=()
+pass()  { RESULTS+=("PASS:$1"); }
+fail()  { RESULTS+=("FAIL:$1:${4:-}"); }
+warn()  { RESULTS+=("WARN:$1"); }
+skip()  { RESULTS+=("SKIP:$1"); }
+
+# Stub JSON output helpers used by the check
+append_json() { :; }
+_emit_finding_json() { :; }
+JSON_RESULTS=""
+TOTAL_CHECKS=0
+PASSED_COUNT=0
+FAILED_COUNT=0
+WARNINGS=0
+SKIPPED=0
+
+source "$LIB_DIR/checks.sh"
+
+assert_has_result() {
+  local desc="$1" expected_type="$2" check_id="$3"
+  local found=false
+  for r in "${RESULTS[@]+"${RESULTS[@]}"}"; do
+    if [[ "$r" == "${expected_type}:${check_id}"* ]]; then
+      found=true
+      break
+    fi
+  done
+  if $found; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (expected $expected_type:$check_id, got: ${RESULTS[*]:-none})"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_no_result() {
+  local desc="$1" unexpected_type="$2" check_id="$3"
+  local found=false
+  for r in "${RESULTS[@]+"${RESULTS[@]}"}"; do
+    if [[ "$r" == "${unexpected_type}:${check_id}"* ]]; then
+      found=true
+      break
+    fi
+  done
+  if ! $found; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (unexpected $unexpected_type:$check_id found)"
+    ((TEST_FAILED++))
+  fi
+}
+
+run_check() {
+  RESULTS=()
+  ENV_SCAN_FILES=()
+  source "$CHECKS_DIR/access-control/secrets-scan.sh"
+}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ── SECRETS-001: Additional source-code secret pattern coverage ──────────────
+
+echo "=== SECRETS-001: Stripe secret key in source ==="
+
+# FAIL: Stripe secret key pattern in Python file.
+# Build the dummy key from prefix + suffix at runtime so the committed test
+# source holds no contiguous secret literal (GitHub push protection scans source
+# files, not the temp fixture). The check still sees the full value on disk.
+mkdir -p "$tmpdir/stripe_leak/src"
+_sk_prefix='sk_live_'
+printf 'STRIPE_KEY = "%s%s"\n' "$_sk_prefix" 'abcdefghijklmnopqrstuvwx' \
+  > "$tmpdir/stripe_leak/src/payments.py"
+SCAN_DIR="$tmpdir/stripe_leak" run_check
+assert_has_result "Stripe secret key in source -> FAIL SECRETS-001" "FAIL" "SECRETS-001"
+
+echo "=== SECRETS-001: Slack token in source ==="
+
+# FAIL: Slack xoxb token in YAML config. Same runtime-assembly trick as above so
+# the source contains only the bare "xoxb-" prefix (too short to match GitHub's
+# Slack detector), while the fixture on disk holds the full dummy token.
+mkdir -p "$tmpdir/slack_leak"
+_slack_prefix='xoxb-'
+printf 'slack:\n  token: "%s%s"\n' "$_slack_prefix" '000000000-000000000000-FakeSlackTokenForTestOnly' \
+  > "$tmpdir/slack_leak/config.yaml"
+SCAN_DIR="$tmpdir/slack_leak" run_check
+assert_has_result "Slack token in YAML -> FAIL SECRETS-001" "FAIL" "SECRETS-001"
+
+echo "=== SECRETS-001: npm token in source ==="
+
+# FAIL: npm token pattern in a .sh file.
+# The npm Token pattern is "npm_[a-zA-Z0-9]{36}" — no | inside the regex,
+# so IFS='|' splitting in the check loop produces a valid grep pattern.
+# Dummy value: npm_ prefix + 36 obviously-fake alphanumeric chars. Build it from
+# prefix + suffix at runtime (same trick as the Stripe/Slack fixtures above) so the
+# committed test source holds no contiguous npm-token literal — GitGuardian scans
+# every commit in the PR, not just the temp fixture written to disk.
+mkdir -p "$tmpdir/npm_leak"
+_npm_prefix='npm_'
+printf '#!/usr/bin/env bash\nNPM_AUTH_TOKEN="%s%s"\n' "$_npm_prefix" 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij' \
+  > "$tmpdir/npm_leak/publish.sh"
+SCAN_DIR="$tmpdir/npm_leak" run_check
+assert_has_result "npm token in .sh -> FAIL SECRETS-001" "FAIL" "SECRETS-001"
+
+echo "=== SECRETS-001: Allowlisted path (scanner/tests/) not flagged ==="
+
+# PASS: A file under scanner/tests/ is in the allowlisted path, so SECRETS-001
+# scans source code via find -exec grep, but the check itself excludes */scanner/*
+# Verify that a clean source dir with no patterns passes
+mkdir -p "$tmpdir/clean_src"
+cat > "$tmpdir/clean_src/app.py" <<'PY'
+import os
+db_password = os.environ.get("DB_PASSWORD", "")
+PY
+SCAN_DIR="$tmpdir/clean_src" run_check
+assert_has_result "No secrets in source -> PASS SECRETS-001" "PASS" "SECRETS-001"
+
+# ── SECRETS-001: GCP service account pattern ─────────────────────────────────
+
+echo "=== SECRETS-001: GCP service account JSON pattern ==="
+
+# FAIL: GCP service account type field in JSON file
+mkdir -p "$tmpdir/gcp_sa_leak"
+cat > "$tmpdir/gcp_sa_leak/credentials.json" <<'JSON'
+{
+  "type": "service_account",
+  "project_id": "fake-project-id-example",
+  "private_key_id": "fakekeyid00000000000000000000000000000000"
+}
+JSON
+SCAN_DIR="$tmpdir/gcp_sa_leak" run_check
+assert_has_result "GCP service_account type field -> FAIL SECRETS-001" "FAIL" "SECRETS-001"
+
+# ── SECRETS-002: Additional .env edge cases ───────────────────────────────────
+
+echo "=== SECRETS-002: VAULT_TOKEN in non-allowlisted .env ==="
+
+# FAIL: Vault token key in a non-allowlisted .env. Assemble from the bare "s."
+# prefix + suffix at runtime (as with the source-secret fixtures above) so no
+# contiguous Vault-style token literal sits in the committed source.
+mkdir -p "$tmpdir/vault_env"
+_vault_prefix='s.'
+printf 'VAULT_TOKEN=%s%s\n' "$_vault_prefix" 'fake-vault-token-value-for-testing' \
+  > "$tmpdir/vault_env/.env"
+cat > "$tmpdir/vault_env/app.py" <<'PY'
+pass
+PY
+SCAN_DIR="$tmpdir/vault_env" run_check
+assert_has_result "VAULT_TOKEN in .env -> FAIL SECRETS-002" "FAIL" "SECRETS-002"
+
+echo "=== SECRETS-002: Empty .env values skipped ==="
+
+# PASS: .env with empty values for sensitive keys — no real secret
+mkdir -p "$tmpdir/empty_env"
+cat > "$tmpdir/empty_env/.env" <<'ENV'
+API_KEY=
+SECRET=
+TOKEN=""
+PASSWORD=''
+ENV
+cat > "$tmpdir/empty_env/app.py" <<'PY'
+pass
+PY
+SCAN_DIR="$tmpdir/empty_env" run_check
+assert_has_result "Empty .env values -> PASS SECRETS-002" "PASS" "SECRETS-002"
+
+echo "=== SECRETS-002: .env in examples/ allowlisted path -> WARN ==="
+
+# WARN: .env with a non-placeholder value inside examples/ (allowlisted path).
+# The value must NOT contain: YOUR_, CHANGE_ME, xxx, placeholder, example, TODO
+# (those are treated as placeholders by the check and skipped).
+# Use a value that looks real but is obviously a dummy (all-caps FAKE prefix).
+# Assemble from prefix + suffix at runtime (as above) so no contiguous OpenAI-style
+# literal sits in the committed source for GitGuardian to flag.
+mkdir -p "$tmpdir/examples_env/examples"
+_openai_prefix='sk-'
+printf 'OPENAI_API_KEY=FAKE-%s%s\n' "$_openai_prefix" 'abcdefghijklmnopqrstuvwxyz0123456789' \
+  > "$tmpdir/examples_env/examples/.env"
+cat > "$tmpdir/examples_env/app.py" <<'PY'
+pass
+PY
+SCAN_DIR="$tmpdir/examples_env" run_check
+assert_has_result ".env with non-placeholder value in examples/ -> WARN SECRETS-002" "WARN" "SECRETS-002"
+
+# ── SECRETS-003: Git history scan ────────────────────────────────────────────
+
+echo "=== SECRETS-003: Not a git repo -> skip ==="
+
+# SKIP: SCAN_DIR is not a git repository
+mkdir -p "$tmpdir/not_a_repo"
+cat > "$tmpdir/not_a_repo/app.py" <<'PY'
+pass
+PY
+SCAN_DIR="$tmpdir/not_a_repo" run_check
+assert_has_result "Non-git dir -> skip SECRETS-003" "SKIP" "SECRETS-003"
+
+echo "=== SECRETS-003: Clean git repo -> pass ==="
+
+# PASS: git repo with no secrets in history
+gitrepo="$tmpdir/clean_git_repo"
+mkdir -p "$gitrepo"
+git -C "$gitrepo" init -q
+git -C "$gitrepo" config user.email "test@example.com"
+git -C "$gitrepo" config user.name "Test"
+cat > "$gitrepo/app.py" <<'PY'
+import os
+api_key = os.environ.get("API_KEY", "")
+PY
+git -C "$gitrepo" add app.py
+git -C "$gitrepo" commit -q -m "initial commit"
+SCAN_DIR="$gitrepo" run_check
+assert_has_result "Clean git repo -> PASS SECRETS-003" "PASS" "SECRETS-003"
+
+echo "=== SECRETS-003: Git repo with AWS key pattern in history -> fail ==="
+
+# FAIL: git repo where a recent commit added a file containing an AWS key pattern.
+# The dummy value is the canonical AWS documentation example access-key id. It is
+# assembled from prefix + suffix at runtime (like the source-secret fixtures above)
+# so the committed test source holds no contiguous AKIA-literal — the AWS Keys
+# detector flags even the documentation example, so we keep it out of the diff. The
+# throwaway git repo built below still contains the full value the check detects.
+awsrepo="$tmpdir/aws_history_repo"
+mkdir -p "$awsrepo"
+git -C "$awsrepo" init -q
+git -C "$awsrepo" config user.email "test@example.com"
+git -C "$awsrepo" config user.name "Test"
+# First commit: clean file
+cat > "$awsrepo/app.py" <<'PY'
+pass
+PY
+git -C "$awsrepo" add app.py
+git -C "$awsrepo" commit -q -m "initial"
+# Second commit: accidentally add a file with AWS key pattern (fake/example key)
+_aws_prefix='AKIA'
+printf '# FAKE test fixture — AWS documentation example key, not a real credential\nAWS_ACCESS_KEY_ID = "%s%s"\n' \
+  "$_aws_prefix" 'IOSFODNN7EXAMPLE' > "$awsrepo/oops.py"
+git -C "$awsrepo" add oops.py
+git -C "$awsrepo" commit -q -m "oops added fake key"
+SCAN_DIR="$awsrepo" run_check
+assert_has_result "AWS key pattern in git history -> FAIL SECRETS-003" "FAIL" "SECRETS-003"
+
+# ── SECRETS-004: Credential file path references ──────────────────────────────
+
+echo "=== SECRETS-004: SSH key path in Dockerfile ==="
+
+# FAIL: reference to id_rsa in Dockerfile (non-allowlisted)
+mkdir -p "$tmpdir/dockerfile_ssh"
+cat > "$tmpdir/dockerfile_ssh/Dockerfile" <<'DOCKER'
+FROM ubuntu:22.04
+COPY id_rsa /root/.ssh/id_rsa
+RUN chmod 600 /root/.ssh/id_rsa
+DOCKER
+SCAN_DIR="$tmpdir/dockerfile_ssh" run_check
+assert_has_result "id_rsa path in Dockerfile -> FAIL SECRETS-004" "FAIL" "SECRETS-004"
+
+echo "=== SECRETS-004: kube config path in allowlisted template ==="
+
+# WARN: kubeconfig reference in templates/ (allowlisted path)
+mkdir -p "$tmpdir/kube_template/templates"
+cat > "$tmpdir/kube_template/templates/setup.sh" <<'SH'
+#!/usr/bin/env bash
+# Example setup — replace with your actual path
+KUBECONFIG=~/.kube/config
+SH
+SCAN_DIR="$tmpdir/kube_template" run_check
+assert_has_result "kubeconfig path in templates/ -> WARN SECRETS-004" "WARN" "SECRETS-004"
+
+echo "=== SECRETS-004: No credential path refs -> pass ==="
+
+# PASS: source files with no credential path references
+mkdir -p "$tmpdir/cred_clean"
+cat > "$tmpdir/cred_clean/main.py" <<'PY'
+print("hello world")
+PY
+SCAN_DIR="$tmpdir/cred_clean" run_check
+assert_has_result "No credential path refs -> PASS SECRETS-004" "PASS" "SECRETS-004"
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1

--- a/scanner/tests/test_token_expiry_gate.py
+++ b/scanner/tests/test_token_expiry_gate.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 
@@ -143,6 +144,177 @@ class TokenExpiryGateTests(unittest.TestCase):
         )
         self.assertEqual(res.returncode, 0)
         self.assertIn("Token expiry gate passed", res.stdout)
+
+
+class TokenExpiryGateModeTests(unittest.TestCase):
+    """New cases covering previously untested branches."""
+
+    def _run_gate(self, args, extra_env=None):
+        env = os.environ.copy()
+        for key in (
+            "GH_TOKEN_EXPIRES_AT",
+            "GITHUB_TOKEN_EXPIRES_AT",
+            "OKTA_OAUTH_TOKEN_EXPIRES_AT",
+            "DATADOG_TOKEN_EXPIRES_AT",
+            "DD_TOKEN_EXPIRES_AT",
+            "DD_API_KEY_EXPIRES_AT",
+            "SLACK_TOKEN_EXPIRES_AT",
+            "SLACK_BOT_TOKEN_EXPIRES_AT",
+            "CLAUDESEC_TOKEN_EXPIRY_PROVIDERS",
+            "CLAUDESEC_TOKEN_EXPIRY_GATE_MODE",
+            "CLAUDESEC_TOKEN_EXPIRY_STRICT_PROVIDERS",
+        ):
+            env.pop(key, None)
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(
+            [sys.executable, str(SCRIPT_PATH), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def _iso(self, dt: datetime) -> str:
+        """Format a timezone-aware datetime as ISO 8601 with Z suffix."""
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # ── (a) MODE=off short-circuits to pass ──────────────────────────────────
+
+    def test_mode_off_exits_zero_without_checking_tokens(self):
+        """MODE=off must exit 0 and print 'disabled' even when no token env is set."""
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "true"],
+            {"CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "off"},
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("disabled", res.stdout)
+
+    def test_mode_none_alias_also_exits_zero(self):
+        """'none' is an accepted alias for MODE=off."""
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "true"],
+            {"CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "none"},
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("disabled", res.stdout)
+
+    def test_mode_false_alias_exits_zero(self):
+        """'false' is an accepted alias for MODE=off."""
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "false"],
+            {"CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "false"},
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("disabled", res.stdout)
+
+    # ── (b) MODE=7d window behavior ──────────────────────────────────────────
+
+    def test_mode_7d_fails_token_expiring_within_7_days(self):
+        """In 7d mode a token expiring in 100 hours (< 168h) must fail."""
+        expiry = datetime.now(timezone.utc) + timedelta(hours=100)
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "false"],
+            {
+                "CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "7d",
+                "GH_TOKEN_EXPIRES_AT": self._iso(expiry),
+            },
+        )
+        self.assertEqual(res.returncode, 1)
+        self.assertIn("expires within gate window (168h)", res.stdout)
+
+    def test_mode_7d_passes_token_expiring_beyond_7_days(self):
+        """In 7d mode a token expiring in 200 hours (> 168h) must pass."""
+        expiry = datetime.now(timezone.utc) + timedelta(hours=200)
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "false"],
+            {
+                "CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "7d",
+                "GH_TOKEN_EXPIRES_AT": self._iso(expiry),
+            },
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("Token expiry gate passed", res.stdout)
+        self.assertIn("window=168h", res.stdout)
+
+    def test_mode_24h_passes_token_expiring_in_100h_but_7d_would_fail(self):
+        """In default 24h mode a token expiring in 100h must pass (only 7d mode would fail it)."""
+        expiry = datetime.now(timezone.utc) + timedelta(hours=100)
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "false"],
+            {
+                "CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "24h",
+                "GH_TOKEN_EXPIRES_AT": self._iso(expiry),
+            },
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("Token expiry gate passed", res.stdout)
+        self.assertIn("window=24h", res.stdout)
+
+    # ── (c) Valid token expiring far in the future passes ────────────────────
+
+    def test_token_expiring_far_in_future_passes_in_24h_mode(self):
+        """A token expiring 30 days from now must pass in 24h mode (non-strict)."""
+        expiry = datetime.now(timezone.utc) + timedelta(days=30)
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "false"],
+            {
+                "CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "24h",
+                "GH_TOKEN_EXPIRES_AT": self._iso(expiry),
+            },
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("Token expiry gate passed", res.stdout)
+
+    def test_token_expiring_far_in_future_passes_strict_mode(self):
+        """A token expiring 30 days from now must pass even in strict mode."""
+        expiry = datetime.now(timezone.utc) + timedelta(days=30)
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "true"],
+            {
+                "CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "24h",
+                "GH_TOKEN_EXPIRES_AT": self._iso(expiry),
+            },
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("Token expiry gate passed", res.stdout)
+
+    # ── (d) Missing metadata warns but does not fail when not strict ─────────
+
+    def test_missing_metadata_non_strict_warns_and_passes(self):
+        """Missing expiry metadata with strict=false must exit 0 and print a warning."""
+        res = self._run_gate(
+            ["--providers", "okta", "--strict-providers", "false"],
+            {"CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "7d"},
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("expiry metadata not set", res.stdout)
+        self.assertIn("Token expiry gate passed", res.stdout)
+
+    def test_token_expiring_just_outside_24h_window_passes(self):
+        """Token expiring in 25 hours must pass the 24h gate (just outside the window)."""
+        expiry = datetime.now(timezone.utc) + timedelta(hours=25)
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "false"],
+            {
+                "CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "24h",
+                "GH_TOKEN_EXPIRES_AT": self._iso(expiry),
+            },
+        )
+        self.assertEqual(res.returncode, 0)
+        self.assertIn("Token expiry gate passed", res.stdout)
+
+    def test_token_expiring_just_inside_24h_window_fails(self):
+        """Token expiring in 23 hours must fail the 24h gate (inside the window)."""
+        expiry = datetime.now(timezone.utc) + timedelta(hours=23)
+        res = self._run_gate(
+            ["--providers", "github", "--strict-providers", "false"],
+            {
+                "CLAUDESEC_TOKEN_EXPIRY_GATE_MODE": "24h",
+                "GH_TOKEN_EXPIRES_AT": self._iso(expiry),
+            },
+        )
+        self.assertEqual(res.returncode, 1)
+        self.assertIn("expires within gate window (24h)", res.stdout)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes real scanner-test gaps found during an audit. **Correction:** the audit's "token-expiry-gate is untested" claim was wrong — `test_token_expiry_gate.py` already had 11 passing tests; this PR *strengthens* it and spends the rest of the effort on checks that genuinely had no coverage.

### New hermetic offline shell tests
Built on the canonical `test_check_code_injection.sh` harness (stub pass/fail/warn/skip → RESULTS array, temp fixtures, assert by check ID). No network, no real paths.

| File | Check IDs | Cases |
|------|-----------|-------|
| `test_check_code_security_flaws.sh` | CODE-SEC-001..010 | 33 |
| `test_check_code_sast_tools.sh` | NONINTERACTIVE gate, no-tools WARN | 7 |
| `test_check_infra_iac.sh` | INFRA-020..023 | 15 |
| `test_check_secrets_scan.sh` | SECRETS-001..004 (incl. git-history) | 14 |

### Extended `test_token_expiry_gate.py` (+11 → 22)
MODE=off short-circuit, MODE=7d window, valid-future-token pass, just-inside / just-outside warning-window boundaries, non-strict missing-metadata warn. Timestamps computed relative to now.

### CI wiring
Registered the 4 new shell tests in the `scanner-unit-tests` job (explicit list). The `scanner-shell-coverage` (kcov) job already globs `scanner/tests/test_*.sh`, so they also feed bash coverage **and get validated on Linux/GNU-grep** (local runs were macOS/BSD-grep).

### Secret-fixture handling
GitHub push protection (correctly) flagged the Stripe/Slack dummy tokens. Rather than allow-listing a secret into the repo, the fixtures are now **assembled at runtime from prefix + suffix fragments** — the committed source holds no contiguous token, while the on-disk fixture still exercises the check's regex. Other fixtures use allow-listed canonical dummies (`AKIAIOSFODNN7EXAMPLE`).

## Pre-existing check bugs found (NOT fixed here — separate backlog)
Tests route around two latent bugs (documented in comments):
1. `code/security-flaws.sh` CODE-SEC-002 uses a `(?!Loader)` lookahead in `grep -E` — unsupported by BSD *and* GNU grep, so pickle/marshal/shelve never match.
2. `access-control/secrets-scan.sh` splits `SECRET_PATTERNS` with `IFS='|'`, truncating the "Private Key Header" regex (inner `|`) into an invalid pattern.

## Test plan
- [x] `bash` each new test → 33 / 7 / 15 / 14 pass, exit 0
- [x] `pytest test_token_expiry_gate.py` → 22 passed
- [x] `shellcheck -x -S error` on all 4 new files → clean
- [x] `lint.yml` YAML valid; CI config-guard tests (`test_ci_*`) green
- [x] gitleaks + GitHub push protection clean
- [ ] CI: `scanner-unit-tests` + `scanner-shell-coverage` validate on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)