### PR TITLE
fix(scanner): repair ERE-lookahead and IFS pipe-split detection bugs

### DIFF
--- a/scanner/checks/access-control/secrets-scan.sh
+++ b/scanner/checks/access-control/secrets-scan.sh
@@ -155,7 +155,16 @@ _secret_details=""
 
 # Scan source code files for secret patterns
 for entry in "${SECRET_PATTERNS[@]}"; do
-  IFS='|' read -r secret_name secret_pattern _secret_severity <<< "$entry"
+  # Entries are "name|pattern|severity". Split on the FIRST and LAST '|' only,
+  # via parameter expansion, so a pattern that itself contains '|' alternation
+  # (GitHub App Token, Private Key Header, Vault, Generic*) survives intact. A
+  # plain `IFS='|' read` truncates the pattern at its first alternation '|',
+  # leaving an unbalanced-paren fragment that makes grep -E error out and
+  # silently detect nothing.
+  secret_name="${entry%%|*}"
+  _secret_severity="${entry##*|}"
+  secret_pattern="${entry#*|}"
+  secret_pattern="${secret_pattern%|*}"
 
   # Skip base64/generic patterns for source scan (too noisy)
   [[ "$secret_name" == "Base64"* ]] && continue
@@ -328,7 +337,10 @@ _cred_patterns=(
 )
 
 for cp in "${_cred_patterns[@]}"; do
-  IFS='|' read -r cred_pattern cred_desc <<< "$cp"
+  # Entries are "pattern|description". Split on the LAST '|' only so a pattern
+  # containing '|' alternation survives (descriptions never contain '|').
+  cred_pattern="${cp%|*}"
+  cred_desc="${cp##*|}"
 
   cred_hits=$(find "$SCAN_DIR" \
     \( -name "*.py" -o -name "*.js" -o -name "*.ts" -o -name "*.yaml" -o -name "*.yml" \

--- a/scanner/checks/code/security-flaws.sh
+++ b/scanner/checks/code/security-flaws.sh
@@ -62,7 +62,12 @@ _deser_hits=""
 
 # Python: pickle, yaml.load (unsafe), marshal
 [[ "${_has_python:-}" == "true" ]] && {
-  _deser_hits=$(_code_grep '(pickle\.(loads?|Unpickler)|yaml\.load\s*\([^)]*(?!Loader)|yaml\.unsafe_load|marshal\.loads?|shelve\.open)\s*\(' "*.py")
+  # NOTE: _code_grep uses grep -E (ERE), which has no lookahead. The "yaml.load
+  # without a Loader=" case is handled separately and reliably below (lines that
+  # diff yaml.load vs yaml.load(...Loader=)). Keeping a PCRE-style (?!Loader) in
+  # this ERE alternation made grep error out, silently disabling pickle/marshal/
+  # shelve/unsafe_load detection entirely — so it is dropped here.
+  _deser_hits=$(_code_grep '(pickle\.(loads?|Unpickler)|yaml\.unsafe_load|marshal\.loads?|shelve\.open)\s*\(' "*.py")
   # yaml.load without SafeLoader
   _yaml_unsafe=$(_code_grep 'yaml\.load\s*\(' "*.py")
   _yaml_safe=$(_code_grep 'yaml\.load\s*\(.*Loader\s*=' "*.py")

--- a/scanner/tests/test_check_code_security_flaws.sh
+++ b/scanner/tests/test_check_code_security_flaws.sh
@@ -133,10 +133,7 @@ assert_has_result "SHA-256 usage passes CODE-SEC-001" "PASS" "CODE-SEC-001"
 
 echo "=== CODE-SEC-002: Unsafe Deserialization ==="
 
-# yaml.load without SafeLoader -> FAIL (reliable path: separate yaml check in the check)
-# NOTE: pickle.loads goes through a combined ERE regex with a (?!Loader) lookahead that
-# macOS grep (BSD ERE) rejects, so that sub-path silently returns no hits.
-# yaml.load detection uses a separate, lookahead-free grep call on lines 68-71 and works.
+# yaml.load without SafeLoader -> FAIL (handled by a separate, lookahead-free grep)
 mkdir -p "$tmpdir/yaml_unsafe"
 cat > "$tmpdir/yaml_unsafe/loader.py" <<'PY'
 import yaml
@@ -166,6 +163,29 @@ function load_session($data) {
 PHP
 SCAN_DIR="$tmpdir/php_deser" run_check
 assert_has_result "PHP unserialize detected as unsafe deserialization" "FAIL" "CODE-SEC-002"
+
+# REGRESSION (ERE-lookahead bug): pickle.loads -> FAIL. The pickle/marshal/shelve
+# alternation previously shared a grep -E pattern with a PCRE (?!Loader) lookahead,
+# which made grep error out and silently miss ALL of them. The lookahead is gone,
+# so pickle.loads is detected again. (OWASP A08: Software & Data Integrity Failures)
+mkdir -p "$tmpdir/pickle_deser"
+cat > "$tmpdir/pickle_deser/loader.py" <<'PY'
+import pickle
+def load_obj(data):
+    return pickle.loads(data)
+PY
+SCAN_DIR="$tmpdir/pickle_deser" run_check
+assert_has_result "pickle.loads detected as unsafe deserialization (ERE-lookahead regression)" "FAIL" "CODE-SEC-002"
+
+# REGRESSION: marshal.loads also rides the same alternation -> FAIL
+mkdir -p "$tmpdir/marshal_deser"
+cat > "$tmpdir/marshal_deser/loader.py" <<'PY'
+import marshal
+def load_code(data):
+    return marshal.loads(data)
+PY
+SCAN_DIR="$tmpdir/marshal_deser" run_check
+assert_has_result "marshal.loads detected as unsafe deserialization (ERE-lookahead regression)" "FAIL" "CODE-SEC-002"
 
 # ── CODE-SEC-003: Hardcoded Credentials ──────────────────────────────────────
 

--- a/scanner/tests/test_check_secrets_scan.sh
+++ b/scanner/tests/test_check_secrets_scan.sh
@@ -126,6 +126,22 @@ printf '#!/usr/bin/env bash\nNPM_AUTH_TOKEN="%s%s"\n' "$_npm_prefix" 'ABCDEFGHIJ
 SCAN_DIR="$tmpdir/npm_leak" run_check
 assert_has_result "npm token in .sh -> FAIL SECRETS-001" "FAIL" "SECRETS-001"
 
+echo "=== SECRETS-001: GitHub App Token (|-alternation pattern) ==="
+
+# REGRESSION (IFS pipe-split bug): the "GitHub App Token" pattern is
+# (ghp|gho|ghu|ghs|ghr)_[a-zA-Z0-9]{36,} — it contains '|' alternation. The old
+# `IFS='|' read` truncated it to the unbalanced "(ghp", so grep -E errored and the
+# detector silently matched nothing. A ghu_-prefixed token is matched ONLY by this
+# pattern (the gh[ps]_/gho_ patterns exclude ghu_), so it isolates the fix.
+# Build it from prefix + 36 fake chars at runtime so no contiguous token literal
+# sits in the committed source.
+mkdir -p "$tmpdir/ghapp_leak"
+_gh_prefix='ghu_'
+printf 'GH_APP_TOKEN="%s%s"\n' "$_gh_prefix" 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789ab' \
+  > "$tmpdir/ghapp_leak/deploy.sh"
+SCAN_DIR="$tmpdir/ghapp_leak" run_check
+assert_has_result "GitHub App Token (ghu_) in source -> FAIL SECRETS-001 (IFS pipe-split regression)" "FAIL" "SECRETS-001"
+
 echo "=== SECRETS-001: Allowlisted path (scanner/tests/) not flagged ==="
 
 # PASS: A file under scanner/tests/ is in the allowlisted path, so SECRETS-001


### PR DESCRIPTION
## Summary

Two **silent** scanner-detection failures, each with an isolating regression test (RED on unfixed code, GREEN on fixed).

### Bug 1 — `CODE-SEC-002` unsafe deserialization (`scanner/checks/code/security-flaws.sh`)
The pickle / marshal / shelve / `yaml.unsafe_load` detectors shared a single `grep -E` (ERE) alternation that embedded a **PCRE negative lookahead** `(?!Loader)`. ERE has no lookahead, so `grep -E` errored out and **silently disabled all of those detections** (OWASP A08: Software & Data Integrity Failures). `_code_grep` uses `grep -nE`.
**Fix:** dropped the broken `yaml.load…(?!Loader)` alternative. The "yaml.load without `Loader=`" case is already handled separately and reliably (diffing `yaml.load` vs `yaml.load(…Loader=)`).

### Bug 2 — `SECRETS-001` + credential-path scan (`scanner/checks/access-control/secrets-scan.sh`)
Pattern-table entries (`name|pattern|severity`) were parsed with `IFS='|' read`, which **truncated any pattern containing `|` alternation** at its first `|`, leaving an unbalanced-paren fragment that made `grep -E` error and detect nothing. This broke **five** detectors:
- GitHub App Token `(ghp|gho|ghu|ghs|ghr)_…` (critical)
- Private Key Header `-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----` (critical)
- Hashicorp Vault Token `(VAULT_TOKEN|vault_token)…hvs\.` (critical)
- Generic Secret / Generic Token (medium catch-alls)

**Fix:** parameter-expansion split on the first + last `|` only, so a pattern containing `|` survives intact. Applied to both the `SECRET_PATTERNS` loop and the `_cred_patterns` loop.

## Regression tests
- `test_check_code_security_flaws.sh`: `pickle.loads` and `marshal.loads` → **FAIL CODE-SEC-002**.
- `test_check_secrets_scan.sh`: a `ghu_`-prefixed GitHub App Token (matched **only** by the `|`-alternation pattern; `gh[ps]_`/`gho_` exclude `ghu_`) → **FAIL SECRETS-001**. The token fixture is assembled at runtime so no contiguous credential literal is committed.

## Test plan
- [x] `pytest scanner/` — 1171 passed (≥99% lib coverage gate intact)
- [x] `test_check_code_security_flaws.sh` 35/35, `test_check_secrets_scan.sh` 15/15
- [x] `test_check_code_injection.sh` 10/10, `test_check_access_control.sh` 10/10 (no regression in shared check dirs)
- [x] RED/GREEN proof: regression assertions fail on unfixed checks (pickle/marshal → `PASS:CODE-SEC-002`; `ghu_` → `PASS:SECRETS-001`), pass on fixed
- [x] shellcheck clean (only pre-existing CI-tolerated SC1091)
- [x] independent `sec-reviewer` pass: all fixes correct, parsing robust across all 60 + 10 entries
- [x] both test files already registered in `.github/workflows/lint.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
