### PR TITLE
fix(scanner): repair broken \|-alternation (grep -E ERE) in saas/ai checks

### DIFF
--- a/scanner/checks/ai/llm-security.sh
+++ b/scanner/checks/ai/llm-security.sh
@@ -77,8 +77,8 @@ if [[ "$has_ai" == "true" ]]; then
   fi
 
   # AI-007: No eval() of LLM output
-  if files_contain "*.py" "eval\(.*completion\|eval\(.*response\|exec\(.*completion" 2>/dev/null || \
-     files_contain "*.js" "eval\(.*completion\|eval\(.*response" 2>/dev/null; then
+  if files_contain "*.py" "eval\(.*completion|eval\(.*response|exec\(.*completion" 2>/dev/null || \
+     files_contain "*.js" "eval\(.*completion|eval\(.*response" 2>/dev/null; then
     fail "AI-007" "eval()/exec() used on LLM output" "critical" \
       "Executing LLM output as code enables arbitrary code execution" \
       "Never eval() LLM responses. Parse and validate structured output instead"

--- a/scanner/checks/saas/solutions.sh
+++ b/scanner/checks/saas/solutions.sh
@@ -71,7 +71,7 @@ if has_dir ".github/workflows"; then
   # Check for environment protection rules reference
   if files_contain ".github/workflows/*.yml" "environment:" 2>/dev/null; then
     :  # Good — uses environment protection
-  elif files_contain ".github/workflows/*.yml" "deploy\|release\|production" 2>/dev/null; then
+  elif files_contain ".github/workflows/*.yml" "deploy|release|production" 2>/dev/null; then
     _gha_problems=$((_gha_problems + 1))
     _gha_issues="${_gha_issues}\n    Deploy workflows without environment protection rules"
   fi
@@ -100,13 +100,13 @@ if has_file "vercel.json" || has_file ".vercel/project.json"; then
 
   # Check for security headers in vercel.json
   if has_file "vercel.json"; then
-    if ! file_contains "vercel.json" "X-Frame-Options\|Content-Security-Policy\|x-frame-options\|content-security-policy" 2>/dev/null; then
+    if ! file_contains "vercel.json" "X-Frame-Options|Content-Security-Policy|x-frame-options|content-security-policy" 2>/dev/null; then
       _vercel_issues=$((_vercel_issues + 1))
       _vercel_details="${_vercel_details}\n    Missing security headers (CSP, X-Frame-Options)"
     fi
 
     # Check for exposed source maps
-    if file_contains "vercel.json" "sourceMap.*true\|source-map" 2>/dev/null; then
+    if file_contains "vercel.json" "sourceMap.*true|source-map" 2>/dev/null; then
       _vercel_issues=$((_vercel_issues + 1))
       _vercel_details="${_vercel_details}\n    Source maps may be exposed in production"
     fi
@@ -150,7 +150,7 @@ if files_contain "*.yaml" "kind:[[:space:]]*Application" 2>/dev/null && \
 
   # Check for plaintext secrets in ArgoCD manifests
   if files_contain "*.yaml" "kind:[[:space:]]*Secret" 2>/dev/null && \
-     ! files_contain "*.yaml" "sealed-secrets\|external-secrets\|vault" 2>/dev/null; then
+     ! files_contain "*.yaml" "sealed-secrets|external-secrets|vault" 2>/dev/null; then
     _argo_issues=$((_argo_issues + 1))
     _argo_details="${_argo_details}\n    Plaintext Secrets in manifests (use SealedSecrets/ExternalSecrets)"
   fi
@@ -176,9 +176,9 @@ fi
 # ── SAAS-005: Sentry Configuration Security ──────────────────────────────────
 
 _sentry_detected=false
-if files_contain "*.js" "Sentry.init\|@sentry/node\|@sentry/browser\|@sentry/react" 2>/dev/null || \
-   files_contain "*.ts" "Sentry.init\|@sentry/node\|@sentry/browser\|@sentry/nextjs" 2>/dev/null || \
-   files_contain "*.py" "sentry_sdk\|sentry-sdk" 2>/dev/null; then
+if files_contain "*.js" "Sentry.init|@sentry/node|@sentry/browser|@sentry/react" 2>/dev/null || \
+   files_contain "*.ts" "Sentry.init|@sentry/node|@sentry/browser|@sentry/nextjs" 2>/dev/null || \
+   files_contain "*.py" "sentry_sdk|sentry-sdk" 2>/dev/null; then
   _sentry_detected=true
 fi
 
@@ -195,7 +195,7 @@ if [[ "$_sentry_detected" == "true" ]]; then
   fi
 
   # Check for PII scrubbing
-  if files_contain "*.js" "sendDefaultPii.*true\|send_default_pii.*true" 2>/dev/null || \
+  if files_contain "*.js" "sendDefaultPii.*true|send_default_pii.*true" 2>/dev/null || \
      files_contain "*.ts" "sendDefaultPii.*true" 2>/dev/null || \
      files_contain "*.py" "send_default_pii.*True" 2>/dev/null; then
     _sentry_issues=$((_sentry_issues + 1))
@@ -223,9 +223,9 @@ fi
 # ── SAAS-006: Datadog Integration Security ───────────────────────────────────
 
 _dd_detected=false
-if files_contain "*.yaml" "datadog\|dd-agent" 2>/dev/null || \
-   files_contain "*.js" "dd-trace\|datadog" 2>/dev/null || \
-   files_contain "*.py" "ddtrace\|datadog" 2>/dev/null || \
+if files_contain "*.yaml" "datadog|dd-agent" 2>/dev/null || \
+   files_contain "*.js" "dd-trace|datadog" 2>/dev/null || \
+   files_contain "*.py" "ddtrace|datadog" 2>/dev/null || \
    files_contain "*.tf" "datadog" 2>/dev/null; then
   _dd_detected=true
 fi
@@ -242,15 +242,15 @@ if [[ "$_dd_detected" == "true" ]]; then
   fi
 
   # Check for DD agent security in K8s
-  if files_contain "*.yaml" "dd-agent\|datadog-agent" 2>/dev/null; then
-    if ! files_contain "*.yaml" "DD_DOGSTATSD_NON_LOCAL_TRAFFIC\|DD_APM_NON_LOCAL_TRAFFIC" 2>/dev/null; then
+  if files_contain "*.yaml" "dd-agent|datadog-agent" 2>/dev/null; then
+    if ! files_contain "*.yaml" "DD_DOGSTATSD_NON_LOCAL_TRAFFIC|DD_APM_NON_LOCAL_TRAFFIC" 2>/dev/null; then
       :  # Agent traffic defaults are usually fine
     fi
   fi
 
   # Check for Datadog secrets in Terraform
-  if files_contain "*.tf" "datadog_api_key\|datadog_app_key" 2>/dev/null && \
-     ! files_contain "*.tf" "var\\.datadog\|data\\..*vault" 2>/dev/null; then
+  if files_contain "*.tf" "datadog_api_key|datadog_app_key" 2>/dev/null && \
+     ! files_contain "*.tf" "var\\.datadog|data\\..*vault" 2>/dev/null; then
     _dd_issues=$((_dd_issues + 1))
     _dd_details="${_dd_details}\n    Datadog keys may be hardcoded in Terraform (use variables/vault)"
   fi
@@ -270,7 +270,7 @@ fi
 _cf_detected=false
 if files_contain "*.tf" "cloudflare" 2>/dev/null || \
    has_file "wrangler.toml" || has_file "wrangler.jsonc" || \
-   files_contain "*.js" "cloudflare\|@cloudflare/workers" 2>/dev/null; then
+   files_contain "*.js" "cloudflare|@cloudflare/workers" 2>/dev/null; then
   _cf_detected=true
 fi
 
@@ -281,13 +281,13 @@ if [[ "$_cf_detected" == "true" ]]; then
   # Check Cloudflare Workers security
   if has_file "wrangler.toml"; then
     # Check for hardcoded secrets in wrangler.toml
-    if file_contains "wrangler.toml" "[Aa][Pp][Ii]_[Tt][Oo][Kk][Ee][Nn]\|[Aa][Pp][Ii]_[Kk][Ee][Yy]" 2>/dev/null; then
+    if file_contains "wrangler.toml" "[Aa][Pp][Ii]_[Tt][Oo][Kk][Ee][Nn]|[Aa][Pp][Ii]_[Kk][Ee][Yy]" 2>/dev/null; then
       _cf_issues=$((_cf_issues + 1))
       _cf_details="${_cf_details}\n    API credentials found in wrangler.toml"
     fi
 
     # Check for secrets binding (good practice)
-    if ! file_contains "wrangler.toml" "\\[vars\\]\|secrets" 2>/dev/null && \
+    if ! file_contains "wrangler.toml" "\\[vars\\]|secrets" 2>/dev/null && \
        files_contain "*.js" "env\\." 2>/dev/null; then
       _cf_issues=$((_cf_issues + 1))
       _cf_details="${_cf_details}\n    Worker uses env vars but no [vars] section in wrangler.toml"
@@ -296,7 +296,7 @@ if [[ "$_cf_detected" == "true" ]]; then
 
   # Check Terraform Cloudflare config
   if files_contain "*.tf" "cloudflare_zone_settings_override" 2>/dev/null; then
-    if files_contain "*.tf" "ssl.*off\|ssl.*flexible" 2>/dev/null; then
+    if files_contain "*.tf" "ssl.*off|ssl.*flexible" 2>/dev/null; then
       _cf_issues=$((_cf_issues + 1))
       _cf_details="${_cf_details}\n    Cloudflare SSL set to off or flexible (use full/strict)"
     fi
@@ -315,9 +315,9 @@ fi
 # ── SAAS-008: Okta / SSO Integration Security ───────────────────────────────
 
 _okta_detected=false
-if files_contain "*.js" "@okta\|okta-sdk\|okta-auth" 2>/dev/null || \
-   files_contain "*.ts" "@okta\|okta-sdk\|okta-auth" 2>/dev/null || \
-   files_contain "*.py" "okta\|pyokta" 2>/dev/null || \
+if files_contain "*.js" "@okta|okta-sdk|okta-auth" 2>/dev/null || \
+   files_contain "*.ts" "@okta|okta-sdk|okta-auth" 2>/dev/null || \
+   files_contain "*.py" "okta|pyokta" 2>/dev/null || \
    files_contain "*.yaml" "okta\\.com" 2>/dev/null; then
   _okta_detected=true
 fi
@@ -336,8 +336,18 @@ if [[ "$_okta_detected" == "true" ]]; then
     fi
   fi
 
-  # Check for PKCE usage in OAuth flows
-  if files_contain "*.js" "pkce.*false\|responseType.*code.*(?!.*pkce)" 2>/dev/null; then
+  # Check for PKCE usage in OAuth flows. ERE (grep -E) has no negative lookahead,
+  # so the "authorization-code flow present but no PKCE anywhere" case is detected
+  # with two checks instead of an inline (?!...) — flag if PKCE is explicitly
+  # disabled, OR a code flow exists while the file never mentions pkce.
+  _okta_no_pkce=false
+  if files_contain "*.js" "pkce.*false" 2>/dev/null; then
+    _okta_no_pkce=true
+  elif files_contain "*.js" "responseType.*code" 2>/dev/null && \
+       ! files_contain "*.js" "pkce" 2>/dev/null; then
+    _okta_no_pkce=true
+  fi
+  if [[ "$_okta_no_pkce" == true ]]; then
     _okta_issues=$((_okta_issues + 1))
     _okta_details="${_okta_details}\n    OAuth flow without PKCE (vulnerable to code interception)"
   fi
@@ -355,9 +365,9 @@ fi
 # ── SAAS-009: SendGrid Email Security ────────────────────────────────────────
 
 _sg_detected=false
-if files_contain "*.js" "@sendgrid\|sendgrid" 2>/dev/null || \
-   files_contain "*.ts" "@sendgrid\|sendgrid" 2>/dev/null || \
-   files_contain "*.py" "sendgrid\|SendGridAPIClient" 2>/dev/null; then
+if files_contain "*.js" "@sendgrid|sendgrid" 2>/dev/null || \
+   files_contain "*.ts" "@sendgrid|sendgrid" 2>/dev/null || \
+   files_contain "*.py" "sendgrid|SendGridAPIClient" 2>/dev/null; then
   _sg_detected=true
 fi
 
@@ -374,7 +384,7 @@ if [[ "$_sg_detected" == "true" ]]; then
   fi
 
   # Check for full access API key (should use restricted keys)
-  if files_contain "*.js" "SENDGRID_API_KEY\|sendgrid.*api.*key" 2>/dev/null; then
+  if files_contain "*.js" "SENDGRID_API_KEY|sendgrid.*api.*key" 2>/dev/null; then
     :  # Using env var is good, but can't verify permissions from code
   fi
 
@@ -393,7 +403,7 @@ fi
 
 _zs_detected=false
 if files_contain "*.yaml" "zscaler" 2>/dev/null || \
-   files_contain "*.tf" "zscaler\|zpa_\|zia_" 2>/dev/null || \
+   files_contain "*.tf" "zscaler|zpa_|zia_" 2>/dev/null || \
    files_contain "*.json" "zscaler" 2>/dev/null; then
   _zs_detected=true
 fi
@@ -403,8 +413,8 @@ if [[ "$_zs_detected" == "true" ]]; then
   _zs_details=""
 
   # Check for Zscaler credentials in config
-  if files_contain "*.tf" "zscaler.*api_key\|zia_api_key\|zpa_client_secret" 2>/dev/null && \
-     ! files_contain "*.tf" "var\\.\|data\\..*vault" 2>/dev/null; then
+  if files_contain "*.tf" "zscaler.*api_key|zia_api_key|zpa_client_secret" 2>/dev/null && \
+     ! files_contain "*.tf" "var\\.|data\\..*vault" 2>/dev/null; then
     _zs_issues=$((_zs_issues + 1))
     _zs_details="${_zs_details}\n    Zscaler API credentials may be hardcoded in Terraform"
   fi
@@ -422,9 +432,9 @@ fi
 # ── SAAS-011: SentinelOne / Endpoint Security ────────────────────────────────
 
 _s1_detected=false
-if files_contain "*.yaml" "sentinelone\|sentinel.one\|s1_agent" 2>/dev/null || \
+if files_contain "*.yaml" "sentinelone|sentinel.one|s1_agent" 2>/dev/null || \
    files_contain "*.tf" "sentinelone" 2>/dev/null || \
-   files_contain "*.py" "sentinelone\|SentinelOneAPI" 2>/dev/null; then
+   files_contain "*.py" "sentinelone|SentinelOneAPI" 2>/dev/null; then
   _s1_detected=true
 fi
 
@@ -452,8 +462,8 @@ fi
 # ── SAAS-012: Jamf Pro / MDM Security ────────────────────────────────────────
 
 _jamf_detected=false
-if files_contain "*.py" "jamf\|JamfPro" 2>/dev/null || \
-   files_contain "*.sh" "jamf\|jamfPro" 2>/dev/null || \
+if files_contain "*.py" "jamf|JamfPro" 2>/dev/null || \
+   files_contain "*.sh" "jamf|jamfPro" 2>/dev/null || \
    files_contain "*.yaml" "jamf" 2>/dev/null; then
   _jamf_detected=true
 fi
@@ -463,8 +473,8 @@ if [[ "$_jamf_detected" == "true" ]]; then
   _jamf_details=""
 
   # Check for Jamf credentials in scripts
-  if files_contain "*.sh" "jamf.*password\|jamf.*api.*key" 2>/dev/null || \
-     files_contain "*.py" "jamf.*password\|jamf.*api.*key" 2>/dev/null; then
+  if files_contain "*.sh" "jamf.*password|jamf.*api.*key" 2>/dev/null || \
+     files_contain "*.py" "jamf.*password|jamf.*api.*key" 2>/dev/null; then
     _jamf_issues=$((_jamf_issues + 1))
     _jamf_details="${_jamf_details}\n    Jamf Pro credentials may be exposed in scripts"
   fi
@@ -483,7 +493,7 @@ fi
 
 _redash_detected=false
 if files_contain "*.yaml" "redash" 2>/dev/null || \
-   files_contain "*.py" "redash\|redash_client" 2>/dev/null || \
+   files_contain "*.py" "redash|redash_client" 2>/dev/null || \
    files_contain "docker-compose*" "redash" 2>/dev/null; then
   _redash_detected=true
 fi
@@ -494,7 +504,7 @@ if [[ "$_redash_detected" == "true" ]]; then
 
   # Check for Redash cookie secret
   if files_contain "docker-compose*" "REDASH_COOKIE_SECRET" 2>/dev/null; then
-    if files_contain "docker-compose*" "REDASH_COOKIE_SECRET=.*change\|REDASH_COOKIE_SECRET=.*default" 2>/dev/null; then
+    if files_contain "docker-compose*" "REDASH_COOKIE_SECRET=.*change|REDASH_COOKIE_SECRET=.*default" 2>/dev/null; then
       _redash_issues=$((_redash_issues + 1))
       _redash_details="${_redash_details}\n    Redash cookie secret is using default/weak value"
     fi
@@ -502,7 +512,7 @@ if [[ "$_redash_detected" == "true" ]]; then
 
   # Check for Redash database credentials
   if files_contain "docker-compose*" "REDASH_DATABASE_URL.*password" 2>/dev/null && \
-     ! files_contain "docker-compose*" "\\$\\{.*PASSWORD\|\\$PASSWORD" 2>/dev/null; then
+     ! files_contain "docker-compose*" "\\$\\{.*PASSWORD|\\$PASSWORD" 2>/dev/null; then
     _redash_issues=$((_redash_issues + 1))
     _redash_details="${_redash_details}\n    Redash database password may be hardcoded in docker-compose"
   fi
@@ -520,7 +530,7 @@ fi
 # ── SAAS-014: QueryPie / Database Access Security ────────────────────────────
 
 _qp_detected=false
-if files_contain "*.yaml" "querypie\|query-pie" 2>/dev/null || \
+if files_contain "*.yaml" "querypie|query-pie" 2>/dev/null || \
    files_contain "*.json" "querypie" 2>/dev/null || \
    files_contain "*.tf" "querypie" 2>/dev/null; then
   _qp_detected=true
@@ -531,8 +541,8 @@ if [[ "$_qp_detected" == "true" ]]; then
   _qp_details=""
 
   # Check for QueryPie API token in config
-  if files_contain "*.yaml" "querypie.*api.*key\|querypie.*token" 2>/dev/null && \
-     ! files_contain "*.yaml" "\\$\\{.*TOKEN\|\\$\\{.*KEY" 2>/dev/null; then
+  if files_contain "*.yaml" "querypie.*api.*key|querypie.*token" 2>/dev/null && \
+     ! files_contain "*.yaml" "\\$\\{.*TOKEN|\\$\\{.*KEY" 2>/dev/null; then
     _qp_issues=$((_qp_issues + 1))
     _qp_details="${_qp_details}\n    QueryPie credentials may be hardcoded"
   fi
@@ -550,10 +560,10 @@ fi
 # ── SAAS-015: Google Workspace / Drive Security ──────────────────────────────
 
 _gw_detected=false
-if files_contain "*.json" "googleapis.com\|client_email.*gserviceaccount" 2>/dev/null || \
-   files_contain "*.py" "google.oauth2\|google-auth\|googleapiclient" 2>/dev/null || \
-   files_contain "*.js" "googleapis\|google-auth-library" 2>/dev/null || \
-   files_contain "*.ts" "googleapis\|google-auth-library" 2>/dev/null; then
+if files_contain "*.json" "googleapis.com|client_email.*gserviceaccount" 2>/dev/null || \
+   files_contain "*.py" "google.oauth2|google-auth|googleapiclient" 2>/dev/null || \
+   files_contain "*.js" "googleapis|google-auth-library" 2>/dev/null || \
+   files_contain "*.ts" "googleapis|google-auth-library" 2>/dev/null; then
   _gw_detected=true
 fi
 
@@ -575,8 +585,8 @@ if [[ "$_gw_detected" == "true" ]]; then
   # Check for overly broad OAuth scopes
   if files_contain "*.py" "https://www.googleapis.com/auth/drive['\"]" 2>/dev/null || \
      files_contain "*.js" "https://www.googleapis.com/auth/drive['\"]" 2>/dev/null; then
-    if ! files_contain "*.py" "drive\\.readonly\|drive\\.file" 2>/dev/null && \
-       ! files_contain "*.js" "drive\\.readonly\|drive\\.file" 2>/dev/null; then
+    if ! files_contain "*.py" "drive\\.readonly|drive\\.file" 2>/dev/null && \
+       ! files_contain "*.js" "drive\\.readonly|drive\\.file" 2>/dev/null; then
       _gw_issues=$((_gw_issues + 1))
       _gw_details="${_gw_details}\n    Using full Google Drive scope (use drive.readonly or drive.file)"
     fi
@@ -600,13 +610,13 @@ _rotation_details=""
 # Check for any hardcoded token/key expiry or rotation config
 if has_file ".github/workflows/rotate-secrets.yml" || \
    has_file ".github/workflows/secret-rotation.yml" || \
-   files_contain "*.yaml" "secret.*rotation\|key.*rotation\|token.*expir" 2>/dev/null; then
+   files_contain "*.yaml" "secret.*rotation|key.*rotation|token.*expir" 2>/dev/null; then
   pass "SAAS-016" "Secret rotation policy or automation detected"
 else
   # Only warn if there are actual integrations that need rotation
   _has_integrations=false
-  if files_contain "*.yml" "DATADOG\|SENTRY\|SENDGRID\|OKTA\|CLOUDFLARE\|VERCEL\|ARGOCD" 2>/dev/null || \
-     files_contain "*.yaml" "DATADOG\|SENTRY\|SENDGRID\|OKTA\|CLOUDFLARE\|VERCEL\|ARGOCD" 2>/dev/null; then
+  if files_contain "*.yml" "DATADOG|SENTRY|SENDGRID|OKTA|CLOUDFLARE|VERCEL|ARGOCD" 2>/dev/null || \
+     files_contain "*.yaml" "DATADOG|SENTRY|SENDGRID|OKTA|CLOUDFLARE|VERCEL|ARGOCD" 2>/dev/null; then
     _has_integrations=true
   fi
 

--- a/scanner/tests/test_check_ai_llm_security.sh
+++ b/scanner/tests/test_check_ai_llm_security.sh
@@ -383,6 +383,20 @@ TS
 SCAN_DIR="$tmpdir/ai_ts" run_check
 assert_has_result "TS openai import, env var key -> PASS AI-001" "PASS" "AI-001"
 
+# ── REGRESSION (grep -E alternation): AI-007 eval() of LLM output -> FAIL ──────
+# The detection pattern was "eval\(.*completion\|...". Under grep -E (ERE) the
+# "\|" is a LITERAL pipe, not alternation, so eval(completion) was never matched
+# and AI-007 always PASSed. With the alternation fixed to (a|b), the eval is
+# detected -> FAIL. (OWASP A03 / LLM01 prompt-injection -> code execution.)
+mkdir -p "$tmpdir/ai_eval"
+cat > "$tmpdir/ai_eval/agent.py" <<'PY'
+import openai
+completion = openai.chat.completions.create(model="gpt-4o", messages=[])
+result = eval(completion)
+PY
+SCAN_DIR="$tmpdir/ai_eval" run_check
+assert_has_result "eval() of LLM completion -> FAIL AI-007 (grep -E alternation regression)" "FAIL" "AI-007"
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 
 echo ""

--- a/scanner/tests/test_check_saas_solutions.sh
+++ b/scanner/tests/test_check_saas_solutions.sh
@@ -6,18 +6,14 @@
 # has_dir, files_contain, file_contains, find). All checks are hermetic: no
 # network calls, no live CLIs. Most checks are fully testable with fixtures.
 #
-# GREP PORTABILITY NOTE:
-# Several detection conditions in solutions.sh use files_contain with "\|"
-# (backslash-pipe) patterns. On macOS BSD grep, "\|" in ERE is NOT alternation —
-# it is a literal pipe character — so those patterns never match a normal file.
-# Only fixtures that trigger detection via patterns WITHOUT "\|" are tested here.
-# The following checks are SKIP-only in this test suite for that reason:
-#   SAAS-003  vercel.json security-header PASS: file_contains uses "\|" (BSD grep)
-#   SAAS-005  Sentry: all detection patterns use "\|" (sentry_sdk\|sentry-sdk)
-#   SAAS-009  SendGrid: all detection patterns use "\|" (@sendgrid\|sendgrid, etc.)
-#   SAAS-011  SentinelOne: all detection patterns use "\|"
-#   SAAS-014  QueryPie: all detection patterns use "\|"
-#   SAAS-015  Google Workspace: all detection patterns use "\|"
+# GREP PORTABILITY NOTE (resolved):
+# solutions.sh previously used files_contain with "\|" (backslash-pipe) in many
+# detection conditions. Under grep -E (ERE) "\|" is a LITERAL pipe, not alternation,
+# so those detectors never matched and always SKIPped. That bug is now fixed — every
+# "\|" was converted to proper (a|b) ERE alternation — and the detection paths for
+# SAAS-005 (Sentry), SAAS-009 (SendGrid), SAAS-011 (SentinelOne), SAAS-014 (QueryPie)
+# and SAAS-015 (Google Workspace) are exercised by the "alternation regression" tests
+# near the end of this file (integration-present fixture -> detected, not SKIP).
 #
 # CHECKS COVERED WITH FIXTURES:
 #   SAAS-001  GitHub security config (needs git repo)
@@ -183,10 +179,9 @@ YML
 SCAN_DIR="$tmpdir/wf_noconcur" run_check
 assert_has_result "Workflow missing concurrency -> WARN SAAS-002" "WARN" "SAAS-002"
 
-# ── SAAS-003: Vercel config (SKIP + WARN paths only) ─────────────────────────
-# NOTE: The PASS path requires file_contains with "\|" alternation which BSD
-# grep -E does not support. Only SKIP (no vercel files) and WARN (vercel.json
-# present but headers pattern never matches on BSD grep) are tested.
+# ── SAAS-003: Vercel config (SKIP + WARN paths) ──────────────────────────────
+# NOTE: only SKIP (no vercel files) and WARN (vercel.json present without security
+# headers) are exercised here; the PASS path (headers present) is left untested.
 
 echo "=== SAAS-003: no vercel files -> SKIP ==="
 
@@ -194,7 +189,7 @@ mkdir -p "$tmpdir/no_vercel"
 SCAN_DIR="$tmpdir/no_vercel" run_check
 assert_has_result "No vercel.json -> SKIP SAAS-003" "SKIP" "SAAS-003"
 
-echo "=== SAAS-003: vercel.json present -> WARN (BSD grep: header pattern won't match) ==="
+echo "=== SAAS-003: vercel.json present without security headers -> WARN ==="
 
 mkdir -p "$tmpdir/vercel_present"
 cat > "$tmpdir/vercel_present/vercel.json" <<'JSON'
@@ -548,6 +543,51 @@ cat > "$tmpdir/ide_bad/.vscode/settings.json" <<'JSON'
 JSON
 SCAN_DIR="$tmpdir/ide_bad" run_check
 assert_has_result ".vscode workspace trust disabled -> WARN SAAS-019" "WARN" "SAAS-019"
+
+# ── REGRESSION (grep -E alternation): integration detection used "\|" ──────────
+# These detectors keyed on patterns like "Sentry.init\|@sentry/node". Under
+# grep -E (ERE) "\|" is a LITERAL pipe, not alternation, so the integration was
+# never detected and the check always emitted SKIP. With the alternation fixed
+# to (a|b), an integration-present fixture is detected and emits PASS/WARN (never
+# SKIP). assert_no_result SKIP is RED on the old code, GREEN on the fix.
+mkdir -p "$tmpdir/sentry_app"
+cat > "$tmpdir/sentry_app/app.js" <<'JS'
+const Sentry = require("@sentry/node");
+Sentry.init({ dsn: process.env.SENTRY_DSN });
+JS
+SCAN_DIR="$tmpdir/sentry_app" run_check
+assert_no_result "Sentry detected -> not SKIP SAAS-005 (alternation regression)" "SKIP" "SAAS-005"
+
+mkdir -p "$tmpdir/sendgrid_app"
+cat > "$tmpdir/sendgrid_app/mail.js" <<'JS'
+const sgMail = require("@sendgrid/mail");
+sgMail.setApiKey(process.env.SENDGRID_API_KEY);
+JS
+SCAN_DIR="$tmpdir/sendgrid_app" run_check
+assert_no_result "SendGrid detected -> not SKIP SAAS-009 (alternation regression)" "SKIP" "SAAS-009"
+
+mkdir -p "$tmpdir/s1_app"
+cat > "$tmpdir/s1_app/agents.yaml" <<'YAML'
+sentinelone:
+  console: https://example.sentinelone.net
+YAML
+SCAN_DIR="$tmpdir/s1_app" run_check
+assert_no_result "SentinelOne detected -> not SKIP SAAS-011 (alternation regression)" "SKIP" "SAAS-011"
+
+mkdir -p "$tmpdir/qp_app"
+cat > "$tmpdir/qp_app/config.yaml" <<'YAML'
+querypie:
+  url: https://example.querypie.com
+YAML
+SCAN_DIR="$tmpdir/qp_app" run_check
+assert_no_result "QueryPie detected -> not SKIP SAAS-014 (alternation regression)" "SKIP" "SAAS-014"
+
+mkdir -p "$tmpdir/gws_app"
+cat > "$tmpdir/gws_app/creds.json" <<'JSON'
+{ "endpoint": "https://www.googleapis.com/admin/directory/v1/users" }
+JSON
+SCAN_DIR="$tmpdir/gws_app" run_check
+assert_no_result "Google Workspace detected -> not SKIP SAAS-015 (alternation regression)" "SKIP" "SAAS-015"
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

`files_contain`/`file_contains` (`scanner/lib/checks.sh`) use **`grep -E` (ERE)**, where **`\|` is a literal pipe, not alternation**. Detection patterns written as `"a\|b\|c"` therefore matched the literal string `a|b|c` and **never fired** — silently disabling ~20 SaaS detectors and the AI-007 eval-of-LLM-output check. (Same bug class as #221's ERE/IFS fixes.)

This converts **every** broken `\|` alternation in the two files to portable `(a|b)` ERE form.

### Changes
- **`scanner/checks/saas/solutions.sh`** — all 51 `\|` alternations → `(a|b)`. **Line 694 left intact**: there `(\\||;)` is an *intentional* literal pipe (detecting `curl | sh` shell-injection), not a broken alternation.
- **`scanner/checks/saas/solutions.sh` SAAS-008 (Okta PKCE)** — the pattern also carried a PCRE `(?!.*pkce)` negative lookahead (invalid in ERE). Restructured into two checks: PKCE explicitly disabled, OR an authorization-code flow present while the file never mentions `pkce`.
- **`scanner/checks/ai/llm-security.sh` AI-007** — eval/exec alternation → `(a|b)`.

### Regression tests (RED on old code, GREEN on fix)
Proven by restoring `origin/main`'s check files and re-running:
- AI-007: `eval(completion)` in source → **FAIL** (was `PASS` — eval undetected).
- SAAS-005/009/011/014/015: Sentry / SendGrid / SentinelOne / QueryPie / Google-Workspace integration fixtures → **detected (not SKIP)** (were all `SKIP` — integration undetected).

## Test plan
- [x] `test_check_ai_llm_security.sh` 31/0, `test_check_saas_solutions.sh` 44/0 (all 39 prior assertions still pass + 6 new)
- [x] RED-on-unfixed proof: 1 + 5 regression assertions fail against `origin/main` checks, pass on fix
- [x] other saas tests (api-checks/api-extended/audit-points/zscaler) 11/13/3/17, all 0 failed
- [x] `pytest scanner/` 1171 passed
- [x] shellcheck clean (only pre-existing CI-tolerated SC1091)
- [x] only the intentional literal pipe at line 694 remains; no `(?!...)` lookahead left
- [x] independent `sec-reviewer` pass: APPROVE, no blocking issues

## Follow-ups (pre-existing, out of scope)
- `solutions.sh:~694`-area `var\.` matches `var`+any-char (ERE `.` unescaped) — pre-existing, surfaced now that the alternation works; low impact (only suppresses a warning). Worth a `var\.[a-zA-Z]` tightening later.
- A repo-wide audit of other `scanner/checks/**` files for the same `\|`-in-ERE pattern is advisable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
