### PR TITLE
fix(scanner): repair remaining \|-as-alternation grep bugs (network/cloud/prowler)

### DIFF
--- a/scanner/checks/cloud/gcp-azure.sh
+++ b/scanner/checks/cloud/gcp-azure.sh
@@ -19,7 +19,7 @@ if has_gcp_credentials 2>/dev/null; then
 
     # CLOUD-011: GCP default service account usage
     default_sa=$(gcloud iam service-accounts list --format="value(email)" 2>/dev/null | \
-      grep -c "compute@developer\|appspot" || echo "0")
+      grep -cE "(compute@developer|appspot)" || echo "0")
     if [[ "$default_sa" -gt 0 ]]; then
       warn "CLOUD-011" "Default service accounts in use" \
         "Create dedicated service accounts with minimal permissions"

--- a/scanner/checks/network/tls.sh
+++ b/scanner/checks/network/tls.sh
@@ -71,7 +71,7 @@ fi
 
 # NET-005: Firewall rules (cloud/IaC)
 if files_contain "*.tf" "0\.0\.0\.0/0" 2>/dev/null; then
-  if files_contain "*.tf" "0\.0\.0\.0/0.*22\|port.*22.*0\.0\.0\.0/0" 2>/dev/null; then
+  if files_contain "*.tf" "(0\.0\.0\.0/0.*22|port.*22.*0\.0\.0\.0/0)" 2>/dev/null; then
     fail "NET-005" "SSH (port 22) open to 0.0.0.0/0 in IaC" "critical" \
       "SSH should not be open to the internet" \
       "Restrict to specific IP ranges or use a bastion host"

--- a/scanner/checks/prowler/integration.sh
+++ b/scanner/checks/prowler/integration.sh
@@ -616,7 +616,7 @@ if _prowler_should_run "nhn" && [[ -n "${NHN_API_URL:-}" || -n "${OS_AUTH_URL:-}
   _nhn_args=()
   [[ -n "${NHN_API_URL:-}" ]] && export OS_AUTH_URL="$NHN_API_URL"
   if [[ -f "$HOME/.config/openstack/clouds.yaml" ]]; then
-    _nhn_cloud=$(grep -B1 -A5 'nhn\|toast\|nhncloud' "$HOME/.config/openstack/clouds.yaml" 2>/dev/null | \
+    _nhn_cloud=$(grep -E -B1 -A5 '(nhn|toast|nhncloud)' "$HOME/.config/openstack/clouds.yaml" 2>/dev/null | \
       grep -oE '^  [a-zA-Z0-9_-]+:' | head -1 | tr -d ' :' || echo "")
     [[ -n "$_nhn_cloud" ]] && _nhn_args+=(--clouds-yaml-cloud "$_nhn_cloud")
   fi

--- a/scanner/tests/test_check_network_tls.sh
+++ b/scanner/tests/test_check_network_tls.sh
@@ -127,6 +127,39 @@ JS
 SCAN_DIR="$tmpdir/cors_ok" run_check
 assert_has_result "Restricted CORS passes" "PASS" "NET-004"
 
+# ── NET-005: SSH open to 0.0.0.0/0 in IaC ──
+
+echo "=== NET-005: firewall rules ==="
+
+# REGRESSION (grep -E alternation): the inner pattern was
+# "0\.0\.0\.0/0.*22\|port.*22.*0\.0\.0\.0/0" — under grep -E "\|" is a LITERAL
+# pipe, so SSH-open-to-world never matched and NET-005 only ever WARNed. Fixed to
+# (a|b); a tf rule with port 22 + 0.0.0.0/0 now -> FAIL.
+mkdir -p "$tmpdir/sg_ssh_open"
+cat > "$tmpdir/sg_ssh_open/sg.tf" <<'TF'
+resource "aws_security_group" "ssh" {
+  ingress { from_port = 22, to_port = 22, cidr_blocks = ["0.0.0.0/0"] }
+}
+TF
+SCAN_DIR="$tmpdir/sg_ssh_open" run_check
+assert_has_result "SSH port 22 open to 0.0.0.0/0 -> FAIL NET-005 (alternation regression)" "FAIL" "NET-005"
+
+# 0.0.0.0/0 without port 22 -> WARN (else branch)
+mkdir -p "$tmpdir/sg_open_nossh"
+cat > "$tmpdir/sg_open_nossh/sg.tf" <<'TF'
+resource "aws_security_group" "web" {
+  ingress { from_port = 443, to_port = 443, cidr_blocks = ["0.0.0.0/0"] }
+}
+TF
+SCAN_DIR="$tmpdir/sg_open_nossh" run_check
+assert_has_result "0.0.0.0/0 without SSH -> WARN NET-005" "WARN" "NET-005"
+
+# No IaC firewall rules -> SKIP
+mkdir -p "$tmpdir/no_tf"
+echo "readme" > "$tmpdir/no_tf/README.md"
+SCAN_DIR="$tmpdir/no_tf" run_check
+assert_has_result "No IaC rules -> SKIP NET-005" "SKIP" "NET-005"
+
 # ── Summary ──
 
 echo ""


### PR DESCRIPTION
## Summary

Repo-wide audit of `\|` misuse in scanner check greps (follow-up to #221/#223). `files_contain`/`file_contains`/`_code_grep` use `grep -E` (ERE) where `\|` is a literal pipe; plain `grep` is BRE where GNU treats `\|` as alternation but **BSD/macOS treats it as a literal** — and ClaudeSec explicitly supports macOS.

### Fixed
- **`network/tls.sh` NET-005**: inner SSH-open-to-world pattern `0\.0\.0\.0/0.*22\|port.*22.*0\.0\.0\.0/0` (ERE `files_contain`) → `(…|…)`. Port-22-open-to-`0.0.0.0/0` now correctly **FAILs (critical)** instead of being silently downgraded to WARN.
- **`cloud/gcp-azure.sh` CLOUD-011** & **`prowler/integration.sh`** (NHN/OpenStack): plain `grep`/`grep -c` with BRE `\|` → `grep -E '(a|b)'`. Worked on Linux CI (GNU) but broke on macOS/BSD.

### Left intentional (documented literal pipes)
- `code/injection.sh` `\|safe` — matches the Jinja/Django `|safe` template filter (XSS check).
- `saas/solutions.sh:704` `(\\||;)` — matches a literal `|`/`;` for `curl | sh`.

`grep -rnE '\\\|' scanner/checks --include='*.sh'` now returns only those two.

## Test plan
- [x] NET-005 regression added to `test_check_network_tls.sh`: FAIL (port 22 + 0.0.0.0/0), WARN (0.0.0.0/0 no SSH), SKIP (no IaC) — `11/0`
- [x] RED-on-unfixed proof: NET-005 FAIL→WARN against origin/main, GREEN on fix (verified by restoring pre-fix check)
- [x] `test_check_cloud_gcp_azure.sh` 14/0 (CLOUD-011 SKIP path unaffected)
- [x] `pytest scanner/` 1171 passed
- [x] shellcheck: no new codes (SC2030/2031/2317 pre-existing, info-level; CI uses severity=error)
- [x] independent `sec-reviewer`: APPROVE, no blocking issues
- [ ] CLOUD-011 / prowler are live-CLI paths — fixed for correctness, no hermetic test

🤖 Generated with [Claude Code](https://claude.com/claude-code)
