### PR TITLE
feat(ci): cross-OS checks Phase 1 — macOS CIS live integration test (non-blocking)

### DIFF
--- a/.github/workflows/cross-os-checks.yml
+++ b/.github/workflows/cross-os-checks.yml
@@ -1,0 +1,42 @@
+# cross-os-checks.yml
+#
+# Intentionally NON-BLOCKING / INFORMATIONAL.
+# This workflow is NOT listed in lint.yml's lint-gate.needs and is NOT a
+# required status check in branch-protection. It runs the macOS CIS scanner
+# check on a real macos-latest runner to surface live platform verdicts
+# without blocking merges on any PR.
+#
+# Phase 1 (macOS only). Phase 2 will add windows-latest.
+
+name: Cross-OS Checks (informational)
+
+on:
+  pull_request:
+    paths:
+      - 'scanner/checks/macos/**'
+      - 'scanner/checks/windows/**'
+      - 'scanner/lib/checks.sh'
+      - 'scanner/lib/output.sh'
+      - 'scanner/tests/test_check_macos_cis_security_live.sh'
+      - '.github/workflows/cross-os-checks.yml'
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-os-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  live-os-checks-macos:
+    name: macOS CIS live checks (structural)
+    runs-on: macos-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - name: Run macOS CIS structural integration test
+        run: bash scanner/tests/test_check_macos_cis_security_live.sh

--- a/scanner/tests/test_check_macos_cis_security_live.sh
+++ b/scanner/tests/test_check_macos_cis_security_live.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2034
+# Live integration test for scanner/checks/macos/cis-security.sh
+#
+# PURPOSE:
+#   Run on a real macOS runner (macos-latest).  Asserts STRUCTURE only:
+#   every check ID (MAC-001..010, CIS-001..010) emits exactly one result
+#   and the verdict type is one of PASS|FAIL|WARN|SKIP.  FAILs must carry
+#   a severity in {critical,high,medium,low}.  Specific verdicts are NOT
+#   asserted — runner security state is uncontrolled.
+#
+#   CIS-005 may legitimately SKIP when Homebrew is absent.
+#   CIS-006 is guaranteed to emit exactly one result because we plant a
+#   strong-cipher $HOME/.ssh/config so ssh_config_checked=1, ssh_ciphers_ok=1.
+#
+# HERMETIC GUARDS:
+#   - SCAN_DIR  → fresh tmpdir (no real project files)
+#   - HOME      → fresh tmpdir (no runner dotfiles; .ssh/config planted below)
+#   This file is intentionally NOT listed in scanner-unit-tests in lint.yml
+#   (it is macOS-only); the offline SKIP test is registered there instead.
+#
+# Run: bash scanner/tests/test_check_macos_cis_security_live.sh
+export CLAUDESEC_DASHBOARD_OFFLINE=1
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+CHECKS_DIR="$SCRIPT_DIR/../checks"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+# Stub color codes (checks.sh uses these for output formatting)
+NC="" GREEN="" RED="" YELLOW="" BLUE="" DIM="" BOLD="" MAGENTA="" CYAN=""
+
+# Capture pass/fail/warn/skip calls instead of printing
+RESULTS=()
+pass()  { RESULTS+=("PASS:$1"); }
+fail()  { RESULTS+=("FAIL:$1:${3:-unknown}"); }
+warn()  { RESULTS+=("WARN:$1"); }
+skip()  { RESULTS+=("SKIP:$1"); }
+info()  { true; }
+
+# shellcheck source=../lib/checks.sh
+source "$LIB_DIR/checks.sh"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+assert_exactly_one_result() {
+  local check_id="$1"
+  local count=0
+  local verdict=""
+  for r in "${RESULTS[@]+"${RESULTS[@]}"}"; do
+    if [[ "$r" == PASS:"${check_id}"* || "$r" == FAIL:"${check_id}"* || \
+          "$r" == WARN:"${check_id}"* || "$r" == SKIP:"${check_id}"* ]]; then
+      ((count++))
+      verdict="$r"
+    fi
+  done
+
+  if [[ "$count" -eq 1 ]]; then
+    echo "  PASS: $check_id emitted exactly one result ($verdict)"
+    ((TEST_PASSED++))
+  elif [[ "$count" -eq 0 ]]; then
+    echo "  FAIL: $check_id emitted NO result (expected exactly 1)"
+    ((TEST_FAILED++))
+    return
+  else
+    echo "  FAIL: $check_id emitted $count results (expected exactly 1): ${RESULTS[*]:-}"
+    ((TEST_FAILED++))
+    return
+  fi
+
+  # Assert verdict type is one of PASS|FAIL|WARN|SKIP
+  local vtype="${verdict%%:*}"
+  case "$vtype" in
+    PASS|FAIL|WARN|SKIP)
+      echo "  PASS: $check_id verdict type '$vtype' is valid"
+      ((TEST_PASSED++))
+      ;;
+    *)
+      echo "  FAIL: $check_id verdict type '$vtype' is not PASS|FAIL|WARN|SKIP"
+      ((TEST_FAILED++))
+      return
+      ;;
+  esac
+
+  # If FAIL, assert severity is in {critical,high,medium,low}
+  if [[ "$vtype" == "FAIL" ]]; then
+    # RESULTS format: FAIL:<id>:<severity>
+    local severity="${verdict#"FAIL:${check_id}:"}"
+    case "$severity" in
+      critical|high|medium|low)
+        echo "  PASS: $check_id FAIL severity '$severity' is valid"
+        ((TEST_PASSED++))
+        ;;
+      *)
+        echo "  FAIL: $check_id FAIL severity '$severity' not in {critical,high,medium,low}"
+        ((TEST_FAILED++))
+        ;;
+    esac
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Setup: isolated SCAN_DIR and HOME
+# ---------------------------------------------------------------------------
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+SCAN_DIR="$tmpdir/scan"
+mkdir -p "$SCAN_DIR"
+
+# Override HOME so no runner dotfiles (e.g. ~/.ssh/config) are read.
+# Plant a strong-cipher ~/.ssh/config so CIS-006 reaches the PASS branch:
+#   ssh_config_checked=1, ssh_ciphers_ok=1 → one result (PASS)
+fake_home="$tmpdir/home"
+mkdir -p "$fake_home/.ssh"
+cat > "$fake_home/.ssh/config" <<'SSHCONF'
+Host *
+Ciphers aes256-gcm@openssh.com,chacha20-poly1305@openssh.com
+MACs hmac-sha2-512,hmac-sha2-256
+KexAlgorithms curve25519-sha256,diffie-hellman-group16-sha512
+SSHCONF
+export HOME="$fake_home"
+
+# ---------------------------------------------------------------------------
+# Run the live macOS CIS check
+# ---------------------------------------------------------------------------
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "ERROR: this test requires macOS (Darwin). Current uname: $(uname)"
+  echo "Run it on a macos-latest GitHub Actions runner or a local Mac."
+  exit 1
+fi
+
+echo "=== Running live macOS CIS check on $(uname -r) ==="
+echo "    SCAN_DIR=$SCAN_DIR"
+echo "    HOME=$HOME"
+echo ""
+
+RESULTS=()
+# shellcheck source=../checks/macos/cis-security.sh
+source "$CHECKS_DIR/macos/cis-security.sh"
+
+echo ""
+echo "=== Raw RESULTS array ==="
+for r in "${RESULTS[@]+"${RESULTS[@]}"}"; do
+  echo "  $r"
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Structural assertions: exactly one result per ID, valid type, valid severity
+# ---------------------------------------------------------------------------
+
+echo "=== Structural assertions: MAC-001..010 ==="
+for id in MAC-001 MAC-002 MAC-003 MAC-004 MAC-005 \
+           MAC-006 MAC-007 MAC-008 MAC-009 MAC-010; do
+  assert_exactly_one_result "$id"
+done
+
+echo ""
+echo "=== Structural assertions: CIS-001..010 ==="
+for id in CIS-001 CIS-002 CIS-003 CIS-004 CIS-005 \
+           CIS-006 CIS-007 CIS-008 CIS-009 CIS-010; do
+  assert_exactly_one_result "$id"
+done
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

**Phase 1** of `.omc/plans/live-os-check-integration-testing.md`: a new **non-blocking** workflow that runs the macOS CIS scanner check (`scanner/checks/macos/cis-security.sh`) on a real `macos-latest` runner, asserting **structure** (every check ID emits exactly one well-formed verdict) — not specific verdicts (runner state is uncontrolled).

Why: the live MAC-/CIS- paths only execute on macOS; on Linux CI they all short-circuit to SKIP, so they had zero live coverage.

### What's added
- **`.github/workflows/cross-os-checks.yml`** — `pull_request` (path-gated to macos/windows checks + lib + the live test + itself) + `workflow_dispatch` + weekly `schedule`. `runs-on: macos-latest`, `permissions: contents: read`, ref-keyed `concurrency` with cancel-in-progress, `actions/checkout` SHA-pinned to lint.yml's SHA.
- **`scanner/tests/test_check_macos_cis_security_live.sh`** — mirrors the existing harness; temp `SCAN_DIR`/`HOME`; asserts each of MAC-001..010 + CIS-001..010 emits exactly one verdict of a legal type (+ legal severity on FAIL); allows documented SKIPs (CIS-005 no brew). No specific-verdict assertions.

### Non-blocking guarantee
NOT in `lint.yml`'s `lint-gate.needs` and NOT a required status context (`grep -c cross-os lint.yml` → 0). A failing/absent run cannot block a PR. Top-of-file comment states this explicitly.

## Test plan
- [x] Ran the live test on real macOS (Darwin 25.5.0): **43 passed, 0 failed**, all 20 IDs emit exactly one well-formed verdict
- [x] `cross-os-checks.yml` valid YAML; `lint.yml` unchanged and contains 0 references to the new workflow
- [x] shellcheck-clean (SC1091 tolerated), `set -uo pipefail`, hermetic
- [ ] Real `macos-latest` runner result visible in the Actions tab once merged (informational)

Next: Phase 2 adds a `windows-latest` matrix leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
