### PR TITLE
test(ci): guard NET-005 FAIL escalation + cross-OS non-required topology

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -48,6 +48,8 @@ All guards follow the same rules (see the existing files for reference):
 | `scanner/tests/test_ci_required_jobs_exist.py` | Existence of security/enforcement jobs in `lint.yml` | `{gitleaks, pii-check, dependency-review, workflow-fork-guard, scanner-unit-tests, scanner-shell-coverage}` are all present — deleting a whole job is a silent control loss the topology guard cannot see | #215 |
 | `scanner/tests/test_ci_codeql_single_model.py` | Single CodeQL model (default setup only) | no workflow uses `github/codeql-action/init` or `/analyze` (a repo-level analysis would duplicate the default-setup model); `upload-sarif` is allowed (DAST SARIF upload, not analysis) | #215 |
 | `scanner/tests/test_ci_npm_publish.py` | npm release supply-chain integrity (`npm-publish.yml`) | every `npm publish` carries `--provenance` (SLSA attestation); workflow-level `permissions:` stays `contents: read` (job-level `id-token: write` is not flagged) | #216 |
+| `scanner/tests/test_ci_cross_os_non_required.py` | Cross-OS live-runner workflow stays non-required | `cross-os-checks.yml` exists and keeps `workflow_dispatch` (standalone informational lane); `lint.yml` references none of `{cross-os, live-os-checks, macos-latest, windows-latest}` — so the costly/flaky macOS+Windows runs never become a required merge gate | #228 |
+| `scanner/tests/test_ci_net005_fail_escalation.py` | NET-005 SSH-open-to-world FAIL escalation (`network/tls.sh`) | NET-005 keeps `fail "NET-005" ... "critical"` and an ERE `(0\.0\.0\.0/0.*22\|port.*22.*0\.0\.0\.0/0)` alternation; no `\|` literal-pipe regression (which silently downgraded it to WARN, fixed in #224) | #228 |
 
 ### Related enforcement (not a pytest guard)
 

--- a/scanner/tests/test_ci_cross_os_non_required.py
+++ b/scanner/tests/test_ci_cross_os_non_required.py
@@ -1,0 +1,93 @@
+"""
+Regression guard: the cross-OS live-runner workflow must stay NON-REQUIRED.
+
+`.github/workflows/cross-os-checks.yml` runs the macOS CIS / Windows KISA scanner
+checks on real `macos-latest` / `windows-latest` runners. Those runners are
+expensive (macOS billed 10x, Windows 2x Linux) and their verdicts depend on
+uncontrolled runner state, so the workflow is INTENTIONALLY informational: it is
+a standalone workflow, NOT wired into `lint.yml`'s required `lint-gate` pipeline,
+and its jobs are NOT branch-protection required contexts. Branch protection
+requires only `Lint` (lint-gate) + `Security Scan Gate`.
+
+The silent-weakening this guards: someone folds the OS-runner jobs into `lint.yml`
+(or adds them to `lint-gate.needs`), making every PR merge-block on a flaky,
+costly cross-OS run. Branch-protection config lives in GitHub settings (not the
+repo), so the strongest STATIC proxy is: the OS-runner workflow stays a separate
+file, and `lint.yml` never references it or its OS runners.
+
+stdlib-only (regex/line scanning, no PyYAML — not installed in the
+`scanner-unit-tests` job). No network/subprocess. Passes under pytest and
+`python3 -m unittest`.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+CROSS_OS_YML = WORKFLOW_DIR / "cross-os-checks.yml"
+LINT_YML = WORKFLOW_DIR / "lint.yml"
+
+# Tokens that, if they appear in lint.yml, would mean the OS-runner jobs were
+# pulled into the required lint pipeline (the exact regression this guards).
+FORBIDDEN_IN_LINT = ("cross-os", "live-os-checks", "macos-latest", "windows-latest")
+
+
+class TestCrossOsWorkflowNonRequired(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.cross = CROSS_OS_YML.read_text(encoding="utf-8") if CROSS_OS_YML.is_file() else ""
+        cls.lint = LINT_YML.read_text(encoding="utf-8") if LINT_YML.is_file() else ""
+
+    def test_cross_os_workflow_exists(self):
+        # Canary: a moved/renamed file should fail loudly here, not vacuously.
+        self.assertTrue(
+            CROSS_OS_YML.is_file(),
+            f"{CROSS_OS_YML} not found — if the cross-OS workflow was renamed, "
+            "update CROSS_OS_YML and FORBIDDEN_IN_LINT in this guard.",
+        )
+
+    def test_cross_os_is_a_standalone_informational_lane(self):
+        # workflow_dispatch + schedule are the informational triggers that mark
+        # this as a non-PR-gating lane; their presence confirms intent.
+        self.assertRegex(
+            self.cross,
+            r"(?m)^\s*workflow_dispatch:\s*$",
+            "cross-os-checks.yml lost its workflow_dispatch trigger — it should "
+            "remain a standalone, manually/scheduled informational lane.",
+        )
+        self.assertIn(
+            "macos-latest",
+            self.cross,
+            "cross-os-checks.yml no longer references an OS runner — parsing/intent broke.",
+        )
+
+    def test_lint_yml_does_not_absorb_cross_os(self):
+        self.assertTrue(LINT_YML.is_file(), f"{LINT_YML} not found")
+        hits = [tok for tok in FORBIDDEN_IN_LINT if tok in self.lint]
+        self.assertEqual(
+            hits,
+            [],
+            "lint.yml now references the cross-OS live-runner workflow / OS runners "
+            f"({', '.join(hits)}). That would make the expensive, flaky macOS/Windows "
+            "runs part of the REQUIRED lint pipeline and block merges. Keep cross-OS "
+            "checks in their own non-required workflow. If this is truly intended, "
+            "update FORBIDDEN_IN_LINT here with a justification.",
+        )
+
+    def test_cross_os_job_names_do_not_collide_with_required_contexts(self):
+        # Required contexts are "Lint" and "Security Scan Gate". A cross-OS job
+        # display name matching either would let it masquerade as a required check.
+        for ctx in ("Security Scan Gate",):
+            self.assertNotRegex(
+                self.cross,
+                rf"(?m)^\s*name:\s*{re.escape(ctx)}\s*$",
+                f"A cross-OS job is named '{ctx}', colliding with a required "
+                "branch-protection context. Rename it.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_ci_net005_fail_escalation.py
+++ b/scanner/tests/test_ci_net005_fail_escalation.py
@@ -1,0 +1,90 @@
+"""
+Regression guard: NET-005 must ESCALATE SSH-open-to-the-world to FAIL.
+
+`scanner/checks/network/tls.sh` NET-005 flags an IaC ingress rule that exposes
+SSH (port 22) to `0.0.0.0/0` as a CRITICAL FAIL. The inner detection pattern is
+an ERE alternation passed to `files_contain` (which uses `grep -E`):
+
+    (0\\.0\\.0\\.0/0.*22|port.*22.*0\\.0\\.0\\.0/0)
+
+It previously used `\\|` for the alternation. Under `grep -E` (ERE) `\\|` is a
+LITERAL pipe, not alternation, so the SSH-port-22 case never matched and NET-005
+silently downgraded to a mere WARN ("Ingress rule allows 0.0.0.0/0"). Fixed in
+PR #224; the behavioral RED/GREEN test lives in test_check_network_tls.sh.
+
+This is the fast STATIC tripwire that complements that behavioral test: it fails
+immediately if the alternation regresses to `\\|` or the FAIL escalation is
+removed — even if someone also weakened the behavioral test.
+
+stdlib-only, no network/subprocess. Passes under pytest and `python3 -m unittest`.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TLS_SH = REPO_ROOT / "scanner" / "checks" / "network" / "tls.sh"
+
+
+class TestNet005FailEscalation(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = TLS_SH.read_text(encoding="utf-8") if TLS_SH.is_file() else ""
+        # Isolate the NET-005 section (from its banner to the next "# NET-" or EOF)
+        # so assertions don't accidentally match other checks.
+        lines = cls.text.splitlines()
+        start = next(
+            (i for i, ln in enumerate(lines) if "NET-005" in ln and ln.lstrip().startswith("#")),
+            None,
+        )
+        if start is None:
+            cls.section = ""
+        else:
+            end = len(lines)
+            for j in range(start + 1, len(lines)):
+                s = lines[j].lstrip()
+                if s.startswith("# NET-") and "NET-005" not in lines[j]:
+                    end = j
+                    break
+            cls.section = "\n".join(lines[start:end])
+
+    def test_tls_check_exists(self):
+        self.assertTrue(TLS_SH.is_file(), f"{TLS_SH} not found")
+
+    def test_net005_section_found(self):
+        self.assertTrue(
+            self.section,
+            "NET-005 section not found in tls.sh — parsing assumption broke.",
+        )
+
+    def test_net005_escalates_to_critical_fail(self):
+        self.assertRegex(
+            self.section,
+            r'fail\s+"NET-005"[^\n]*"critical"',
+            'NET-005 no longer emits a CRITICAL `fail "NET-005" ... "critical"`. '
+            "SSH open to 0.0.0.0/0 must escalate to FAIL, not WARN.",
+        )
+
+    def test_net005_uses_ere_alternation_not_literal_pipe(self):
+        # The port-22 detection must use a real ERE alternation `(a|b)`.
+        self.assertRegex(
+            self.section,
+            r"\(0\\\.0\\\.0\\\.0/0\.\*22\|port\.\*22\.\*0\\\.0\\\.0\\\.0/0\)",
+            "NET-005's SSH-port-22 detection pattern changed shape. It must stay an "
+            r"ERE alternation `(0\.0\.0\.0/0.*22|port.*22.*0\.0\.0\.0/0)`.",
+        )
+        # And it must NOT contain a backslash-pipe (the broken literal-pipe form
+        # that disabled the match under grep -E).
+        self.assertNotRegex(
+            self.section,
+            r"22\\\|port",
+            r"NET-005 reintroduced a literal `\|` in its grep -E detection pattern "
+            "(it means a LITERAL pipe in ERE, not alternation, and silently breaks "
+            r"detection). Use `(a|b)` alternation instead.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two stdlib-only CI regression guards (auto-discovered by `pytest scanner/tests/`), both **non-vacuously verified** (each fails on the mutated regression, passes on the real files).

### `test_ci_cross_os_non_required.py`
The cross-OS live-runner workflow (`cross-os-checks.yml` — `macos-latest` + `windows-latest`, #225/#226) must stay a **standalone, NON-required** lane. macOS/Windows runners are costly (10x/2x) and verdict-nondeterministic, so they must never become a required merge gate. Asserts: the workflow exists + keeps `workflow_dispatch`; and `lint.yml` references **none** of `{cross-os, live-os-checks, macos-latest, windows-latest}` (the OS-runner jobs were never folded into the required `lint-gate` pipeline). Branch protection lives in GitHub settings, so this is the strongest *static* proxy.

### `test_ci_net005_fail_escalation.py`
`network/tls.sh` NET-005 must escalate SSH-open-to-`0.0.0.0/0` to a **CRITICAL FAIL** via a working ERE alternation. Asserts `fail "NET-005" … "critical"` and the `(0\.0\.0\.0/0.*22|port.*22.*0\.0\.0\.0/0)` alternation, and that **no `\|` literal-pipe regression** returns (the form that silently downgraded NET-005 to WARN under `grep -E`, fixed in #224). Fast static tripwire complementing the behavioral test in `test_check_network_tls.sh`.

Catalog (`docs/devsecops/ci-config-regression-guards.md`) updated with both rows.

## Test plan
- [x] Positive: both guards pass on real files (8 tests)
- [x] Non-vacuous: G1 fails when `lint.yml` is mutated to absorb cross-os; G2 fails when NET-005 is mutated back to `\|`
- [x] Dual-runner: pass under `pytest` and `python3 -m unittest`
- [x] Full `test_ci_*.py` suite green; markdownlint clean on the catalog doc
- [x] stdlib-only (no PyYAML), no `scanner/lib` import (coverage gate unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)