### PR TITLE
fix(scanner): stop CLOUD-010/011 grep -c emitting two-line "0\n0"

### DIFF
--- a/scanner/checks/cloud/gcp-azure.sh
+++ b/scanner/checks/cloud/gcp-azure.sh
@@ -8,8 +8,11 @@ if has_gcp_credentials 2>/dev/null; then
 
   if [[ -n "$project" ]]; then
     # CLOUD-010: GCP audit logging
+    # `grep -c` already prints the count (0 on no match) and exits 1 when zero;
+    # use `|| true` (not `|| echo 0`, which would append a SECOND "0" and yield a
+    # two-line "0\n0" that breaks the `-gt` arithmetic below).
     audit_policy=$(gcloud projects get-iam-policy "$project" --format=json 2>/dev/null | \
-      grep -c "auditLogConfigs" 2>/dev/null || echo "0")
+      grep -c "auditLogConfigs" 2>/dev/null || true)
     if [[ "$audit_policy" -gt 0 ]]; then
       pass "CLOUD-010" "GCP audit logging configured"
     else
@@ -19,7 +22,7 @@ if has_gcp_credentials 2>/dev/null; then
 
     # CLOUD-011: GCP default service account usage
     default_sa=$(gcloud iam service-accounts list --format="value(email)" 2>/dev/null | \
-      grep -cE "(compute@developer|appspot)" || echo "0")
+      grep -cE "(compute@developer|appspot)" || true)
     if [[ "$default_sa" -gt 0 ]]; then
       warn "CLOUD-011" "Default service accounts in use" \
         "Create dedicated service accounts with minimal permissions"


### PR DESCRIPTION
## Summary

`grep -c` always prints the count (`0` on no match) **and exits 1 when zero**, so `|| echo "0"` fired *on top of* grep's `0`, yielding a two-line `0\n0` that broke the `[[ "$count" -gt 0 ]]` arithmetic (newline → arithmetic syntax error → false). Verdicts stayed correct for these "count>0 = finding" checks but it emitted stderr noise and was fragile.

Fixed CLOUD-010 (audit logging) and CLOUD-011 (default service accounts) in `gcp-azure.sh`: `|| echo "0"` → `|| true` (grep's single-line `0` preserved, non-zero exit swallowed).

## Test plan
- [x] `test_check_cloud_gcp_azure.sh` 16/0 — no `0\n0` arithmetic error in stderr
- [x] shellcheck clean

## Follow-up (out of scope)
Same `grep -c … || echo "0"` anti-pattern in ~33 other sites (`infra/kubernetes.sh`, `saas/api-checks.sh`, `saas/api-extended.sh`) — worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)