### PR TITLE
chore(deps): pin alpine to py3.12 line, ignore alpine minor/major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,14 @@ updates:
       docker:
         patterns:
           - "*"
+    ignore:
+      # Hold alpine on its current minor line (3.20 / Python 3.12). prowler 3.11.3
+      # pins pydantic v1, which cannot run on Python >3.12, and an alpine minor bump
+      # changes the bundled Python (3.24 ships py3.14 -> `prowler -v` crashes with
+      # pydantic ConfigError). Digest/patch rebuilds of 3.20 still flow; minor/major
+      # bumps are blocked until prowler is upgraded to a py3.13+ compatible major.
+      # See PR #220 (alpine 3.20->3.24 build green but prowler broken at runtime).
+      - dependency-name: "alpine"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-major"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@
 # ── Stage 1: build prowler wheels ────────────────────────────────────────────
 # Base image pinned by digest for reproducible, supply-chain-safe builds.
 # Dependabot (docker ecosystem) bumps the digest when alpine:3.20 is rebuilt.
+# DO NOT bump the alpine MINOR version: prowler 3.11.3 pins pydantic v1, which
+# cannot run on Python >3.12. alpine 3.24 ships py3.14 -> `prowler -v` crashes.
+# Dependabot is configured to ignore alpine minor/major bumps (.github/dependabot.yml).
 FROM alpine:3.20@sha256:d9e853e87e55526f6b2917df91a2115c36dd7c696a35be12163d44e6e2a4b6bc AS builder
 
 RUN apk add --no-cache \


### PR DESCRIPTION
## Why

PR #220 (Dependabot: alpine 3.20→3.24, nginx 1.27→1.31) **cannot be merged**. After the Dockerfile fix in #233 the image *builds*, but **prowler 3.11.3 crashes at runtime** on the Python 3.14 that alpine 3.24 ships:

```
.../python3.14/site-packages/prowler/__main__.py
pydantic.errors.ConfigError: unable to infer type for attribute "Compliance"
```

prowler 3.11.3 pins **pydantic v1 (1.10.13)**, which does not run on Python >3.12. This is a fundamental incompatibility — not fixable in the Dockerfile.

## Change

- **`.github/dependabot.yml`**: ignore `alpine` `version-update:semver-minor` and `semver-major` for the docker group. This holds alpine on the **3.20 line (Python 3.12)** while still allowing digest/patch rebuilds. **nginx bumps are unaffected** (different dependency).
- **`Dockerfile`**: comment documenting the constraint so a maintainer does not manually bump the alpine minor version.

## Verification

- `python3 -c "import yaml; ..."` parses `.github/dependabot.yml`; the docker `ignore` rule reads `[{dependency-name: alpine, update-types: [version-update:semver-minor, version-update:semver-major]}]`.
- main is already on alpine 3.20/py3.12, so the running image is unchanged. No build behavior changes.

## Follow-up

- Close #220 with rationale (alpine 3.24/py3.14 × prowler 3.11.3).
- Revisit when prowler is upgraded to a major supporting Python 3.13+ (4.x/5.x — different CLI + provider layout; the Dockerfile strip/sed block will need rework).

🤖 Generated with [Claude Code](https://claude.com/claude-code)