### PR TITLE
fix(docker): pin prowler==5.30.1 for reproducible builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,14 @@ RUN apk add --no-cache \
     py3-pip \
     libffi-dev
 
-RUN pip install --no-cache-dir --no-compile --break-system-packages --prefix=/install prowler \
+# Pin prowler explicitly for reproducible builds. UNPINNED installs are resolved
+# against the base image's Python: py3.12 -> 5.30.1, but py3.14 silently backtracks
+# to ancient 3.11.3 (pydantic v1, crashes at runtime) instead of failing fast.
+# prowler requires Python >=3.10,<3.13 (no 3.13/3.14 support yet — see
+# prowler-cloud/prowler#6737), which is why alpine is held on the py3.12 line
+# (.github/dependabot.yml). Bump in lockstep with prowler releases.
+ARG PROWLER_VERSION=5.30.1
+RUN pip install --no-cache-dir --no-compile --break-system-packages --prefix=/install "prowler==${PROWLER_VERSION}" \
     # Resolve site-packages without hardcoding the Python minor version, so an
     # alpine base bump (e.g. 3.20/py3.12 -> 3.24/py3.13) does not break the build.
     && SITE="$(find /install/lib -maxdepth 1 -type d -name 'python3.*' | sort | head -n1)/site-packages" \


### PR DESCRIPTION
## Why

The Dockerfile installed prowler **unpinned** (`pip install prowler`), so the resolved version silently depended on the base image's Python:

| Base | Python | Resolved prowler |
|------|--------|------------------|
| alpine 3.20 | 3.12 | **5.30.1** (intended) |
| alpine 3.24 | 3.14 | **3.11.3** (pip backtracks; pydantic v1, crashes at runtime) |

This silent backtrack was the **root enabler of the #220 failure** — a base Python bump produced an ancient, broken prowler instead of failing fast. (prowler requires Python `>=3.10,<3.13`; no 3.13/3.14 support yet — [prowler#6737](https://github.com/prowler-cloud/prowler/issues/6737) — which is why alpine is held on the py3.12 line in #234.)

## Change

- Add `ARG PROWLER_VERSION=5.30.1` (mirrors the existing `TRIVY_VERSION` pattern) and install `prowler==${PROWLER_VERSION}`.
- Comment documenting the rationale.

Benefits: **reproducible builds** (consistent with the digest-pin philosophy already stated in the Dockerfile) + **fail-fast** on an unsupported Python (`No matching distribution`) instead of a silent broken install. Defense-in-depth alongside the dependabot alpine pin (#234).

## Verification (local full `docker build`, alpine 3.20 / py3.12)

- Build exits 0; `pip` installs `prowler-5.30.1`.
- `prowler -v` → `Prowler 5.30.1`, **exit 0** — the exact command CI's `dashboard-regression-check` (`Verify container tooling`) and `scanner/checks/prowler/integration.sh` run.
- Providers after strip: `aws, common, github, iac, kubernetes` (+ `okta/scaleway/stackit/vercel`); `kubectl version --client` OK.

## Notes / follow-up

- Dependabot's pip ecosystem does not track inline `pip install` in a Dockerfile, so bump `PROWLER_VERSION` manually in lockstep with prowler releases.
- Separate latent issue (out of scope here): the provider strip removes `azure/gcp/googleworkspace/m365/cloudflare/nhn/oraclecloud/alibabacloud/openstack/image/llm`, but `integration.sh` scans them. 5.x imports are lazy so `prowler -v`/`aws`/`kubernetes` work, but `prowler azure` etc. in-container would fail — to be reconciled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)