### PR TITLE
fix(scanner): skip prowler providers absent from lean build instead of misleading auth warning

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -207,6 +207,8 @@ jobs:
         run: bash scanner/tests/test_check_saas_solutions.sh
       - name: Run bash unit tests (saas/zscaler)
         run: bash scanner/tests/test_check_saas_zscaler.sh
+      - name: Run bash unit tests (prowler provider build parity)
+        run: bash scanner/tests/test_prowler_provider_build_parity.sh
       - name: Run scanner pytest + coverage gate (>=99%)
         id: scanner_tests
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,9 @@ RUN pip install --no-cache-dir --no-compile --break-system-packages --prefix=/in
     && find /install -type d -name '__pycache__' -exec rm -rf {} + 2>/dev/null || true \
     && find /install -type d -name 'tests' -exec rm -rf {} + 2>/dev/null || true \
     && find /install -name '*.dist-info' -type d -exec sh -c 'rm -rf "$1"/top_level.txt "$1"/RECORD' _ {} \; 2>/dev/null || true \
-    # Remove unused cloud provider SDKs (OCI, Azure, GCP, Alibaba, Cloudflare)
+    # Remove unused cloud provider SDKs (OCI, Azure, GCP, Alibaba, Cloudflare).
+    # scanner/checks/prowler/integration.sh detects absent provider dirs at runtime
+    # and emits an accurate skip message instead of a misleading auth warning.
     && rm -rf \
        "${SITE}"/oci* \
        "${SITE}"/azure* \

--- a/scanner/checks/prowler/integration.sh
+++ b/scanner/checks/prowler/integration.sh
@@ -16,6 +16,30 @@ fi
 _prowler_version=$(prowler -v 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "unknown")
 info "Prowler v${_prowler_version} detected"
 
+# ── Build-parity: detect which provider modules are present ──────────────────
+# The lean container image (Dockerfile) strips unused cloud SDK dependencies and
+# removes provider module dirs to save ~700MB. integration.sh detects available
+# providers at runtime so it can emit an accurate skip message instead of
+# attempting a scan that would fail at the commented import and misleadingly
+# warning about authentication. See Dockerfile builder stage for the strip list.
+#
+# If detection is inconclusive (no python3, empty install dir), we default to
+# AVAILABLE so a full local `pip install prowler` is never regressed.
+
+_prowler_install_dir=$(python3 -c 'import prowler,os;print(os.path.dirname(prowler.__file__))' 2>/dev/null || true)
+
+# _prowler_provider_available <provider>
+# Returns 0 (available/unknown) or 1 (positively absent).
+# nhn uses the openstack provider module — map it accordingly.
+_prowler_provider_available() {
+  local provider="$1"
+  # Map nhn -> openstack (NHN Cloud scans via the openstack provider)
+  [[ "$provider" == "nhn" ]] && provider="openstack"
+  # If we couldn't resolve the install dir, default to available (full install)
+  [[ -z "$_prowler_install_dir" ]] && return 0
+  [[ -d "${_prowler_install_dir}/providers/${provider}" ]]
+}
+
 # ── Configuration ──────────────────────────────────────────────────────────
 
 PROWLER_OUTPUT_DIR="${SCAN_DIR}/.claudesec-prowler"
@@ -332,13 +356,21 @@ fi
 # ── Azure ──────────────────────────────────────────────────────────────────
 
 if _prowler_should_run "azure" && [[ -n "${AZURE_CLIENT_ID:-}" && -n "${AZURE_TENANT_ID:-}" ]]; then
-  info "Prowler: Scanning Azure (service principal)"
-  _azure_json=$(_prowler_scan "azure" --sp-env-auth)
-  _prowler_report "Azure" "$_azure_json" "PROWLER-AZ"
+  if ! _prowler_provider_available "azure"; then
+    skip "PROWLER-AZ-001" "Prowler Azure scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning Azure (service principal)"
+    _azure_json=$(_prowler_scan "azure" --sp-env-auth)
+    _prowler_report "Azure" "$_azure_json" "PROWLER-AZ"
+  fi
 elif _prowler_should_run "azure" && has_command az && az account show &>/dev/null; then
-  info "Prowler: Scanning Azure (CLI auth)"
-  _azure_json=$(_prowler_scan "azure" --az-cli-auth)
-  _prowler_report "Azure" "$_azure_json" "PROWLER-AZ"
+  if ! _prowler_provider_available "azure"; then
+    skip "PROWLER-AZ-001" "Prowler Azure scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning Azure (CLI auth)"
+    _azure_json=$(_prowler_scan "azure" --az-cli-auth)
+    _prowler_report "Azure" "$_azure_json" "PROWLER-AZ"
+  fi
 elif ! _prowler_should_run "azure"; then
   skip "PROWLER-AZ-001" "Prowler Azure scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
 else
@@ -356,14 +388,22 @@ elif [[ -n "${GCP_PROJECT:-}" ]]; then
 fi
 
 if _prowler_should_run "gcp" && has_gcp_credentials 2>/dev/null; then
-  _gcp_project=$(gcloud config get-value project 2>/dev/null || echo "")
-  info "Prowler: Scanning GCP (gcloud auth${_gcp_project:+, project: ${_gcp_project}})"
-  _gcp_json=$(_prowler_scan "gcp" "${_gcp_prowler_args[@]}")
-  _prowler_report "GCP" "$_gcp_json" "PROWLER-GCP"
+  if ! _prowler_provider_available "gcp"; then
+    skip "PROWLER-GCP-001" "Prowler GCP scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    _gcp_project=$(gcloud config get-value project 2>/dev/null || echo "")
+    info "Prowler: Scanning GCP (gcloud auth${_gcp_project:+, project: ${_gcp_project}})"
+    _gcp_json=$(_prowler_scan "gcp" "${_gcp_prowler_args[@]}")
+    _prowler_report "GCP" "$_gcp_json" "PROWLER-GCP"
+  fi
 elif _prowler_should_run "gcp" && [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
-  info "Prowler: Scanning GCP (service account key)"
-  _gcp_json=$(_prowler_scan "gcp" "${_gcp_prowler_args[@]}")
-  _prowler_report "GCP" "$_gcp_json" "PROWLER-GCP"
+  if ! _prowler_provider_available "gcp"; then
+    skip "PROWLER-GCP-001" "Prowler GCP scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning GCP (service account key)"
+    _gcp_json=$(_prowler_scan "gcp" "${_gcp_prowler_args[@]}")
+    _prowler_report "GCP" "$_gcp_json" "PROWLER-GCP"
+  fi
 elif ! _prowler_should_run "gcp"; then
   skip "PROWLER-GCP-001" "Prowler GCP scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
 else
@@ -482,15 +522,23 @@ fi
 # ── Microsoft 365 ──────────────────────────────────────────────────────────
 
 if _prowler_should_run "m365" && [[ -n "${AZURE_CLIENT_ID:-}" && -n "${AZURE_TENANT_ID:-}" && -n "${AZURE_CLIENT_SECRET:-}" ]]; then
-  export CLAUDESEC_ENV_M365_CONNECTED="true"
-  info "Prowler: Scanning Microsoft 365 (service principal)"
-  _m365_json=$(_prowler_scan "m365" --sp-env-auth)
-  _prowler_report "M365" "$_m365_json" "PROWLER-M365"
+  if ! _prowler_provider_available "m365"; then
+    skip "PROWLER-M365-001" "Prowler M365 scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    export CLAUDESEC_ENV_M365_CONNECTED="true"
+    info "Prowler: Scanning Microsoft 365 (service principal)"
+    _m365_json=$(_prowler_scan "m365" --sp-env-auth)
+    _prowler_report "M365" "$_m365_json" "PROWLER-M365"
+  fi
 elif _prowler_should_run "m365" && has_command az && az account show &>/dev/null; then
-  export CLAUDESEC_ENV_M365_CONNECTED="true"
-  info "Prowler: Scanning Microsoft 365 (CLI auth)"
-  _m365_json=$(_prowler_scan "m365" --az-cli-auth)
-  _prowler_report "M365" "$_m365_json" "PROWLER-M365"
+  if ! _prowler_provider_available "m365"; then
+    skip "PROWLER-M365-001" "Prowler M365 scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    export CLAUDESEC_ENV_M365_CONNECTED="true"
+    info "Prowler: Scanning Microsoft 365 (CLI auth)"
+    _m365_json=$(_prowler_scan "m365" --az-cli-auth)
+    _prowler_report "M365" "$_m365_json" "PROWLER-M365"
+  fi
 elif ! _prowler_should_run "m365"; then
   skip "PROWLER-M365-001" "Prowler M365 scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
 else
@@ -501,13 +549,17 @@ fi
 
 if _prowler_should_run "googleworkspace" && [[ -n "${GOOGLE_WORKSPACE_CUSTOMER_ID:-}" ]] && \
    { has_gcp_credentials 2>/dev/null || [[ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; }; then
-  export CLAUDESEC_ENV_GWS_CONNECTED="true"
-  export CLAUDESEC_ENV_GWS_CUSTOMER_ID="${GOOGLE_WORKSPACE_CUSTOMER_ID}"
-  info "Prowler: Scanning Google Workspace (customer: ${GOOGLE_WORKSPACE_CUSTOMER_ID})"
-  _gws_args=()
-  [[ -n "${GOOGLE_WORKSPACE_CUSTOMER_ID:-}" ]] && _gws_args+=(--customer-id "$GOOGLE_WORKSPACE_CUSTOMER_ID")
-  _gws_json=$(_prowler_scan "googleworkspace" "${_gws_args[@]}")
-  _prowler_report "Google Workspace" "$_gws_json" "PROWLER-GWS"
+  if ! _prowler_provider_available "googleworkspace"; then
+    skip "PROWLER-GWS-001" "Prowler Google Workspace scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    export CLAUDESEC_ENV_GWS_CONNECTED="true"
+    export CLAUDESEC_ENV_GWS_CUSTOMER_ID="${GOOGLE_WORKSPACE_CUSTOMER_ID}"
+    info "Prowler: Scanning Google Workspace (customer: ${GOOGLE_WORKSPACE_CUSTOMER_ID})"
+    _gws_args=()
+    [[ -n "${GOOGLE_WORKSPACE_CUSTOMER_ID:-}" ]] && _gws_args+=(--customer-id "$GOOGLE_WORKSPACE_CUSTOMER_ID")
+    _gws_json=$(_prowler_scan "googleworkspace" "${_gws_args[@]}")
+    _prowler_report "Google Workspace" "$_gws_json" "PROWLER-GWS"
+  fi
 elif has_gcp_credentials 2>/dev/null; then
   if ! _prowler_should_run "googleworkspace"; then
     skip "PROWLER-GWS-001" "Prowler Google Workspace scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
@@ -525,17 +577,25 @@ fi
 # ── Cloudflare ─────────────────────────────────────────────────────────────
 
 if _prowler_should_run "cloudflare" && [[ -n "${CLOUDFLARE_API_TOKEN:-}" || ( -n "${CLOUDFLARE_API_KEY:-}" && -n "${CLOUDFLARE_API_EMAIL:-}" ) ]]; then
-  export CLAUDESEC_ENV_CF_CONNECTED="true"
-  info "Prowler: Scanning Cloudflare (API token)"
-  _cf_json=$(_prowler_scan "cloudflare")
-  _prowler_report "Cloudflare" "$_cf_json" "PROWLER-CF"
+  if ! _prowler_provider_available "cloudflare"; then
+    skip "PROWLER-CF-001" "Prowler Cloudflare scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    export CLAUDESEC_ENV_CF_CONNECTED="true"
+    info "Prowler: Scanning Cloudflare (API token)"
+    _cf_json=$(_prowler_scan "cloudflare")
+    _prowler_report "Cloudflare" "$_cf_json" "PROWLER-CF"
+  fi
 elif _prowler_should_run "cloudflare" && [[ -n "${CF_API_TOKEN:-}" ]]; then
-  export CLOUDFLARE_API_TOKEN="${CF_API_TOKEN}"
-  export CLAUDESEC_ENV_CF_CONNECTED="true"
-  info "Prowler: Scanning Cloudflare (CF_API_TOKEN)"
-  _cf_json=$(_prowler_scan "cloudflare")
-  _prowler_report "Cloudflare" "$_cf_json" "PROWLER-CF"
-  unset CLOUDFLARE_API_TOKEN
+  if ! _prowler_provider_available "cloudflare"; then
+    skip "PROWLER-CF-001" "Prowler Cloudflare scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    export CLOUDFLARE_API_TOKEN="${CF_API_TOKEN}"
+    export CLAUDESEC_ENV_CF_CONNECTED="true"
+    info "Prowler: Scanning Cloudflare (CF_API_TOKEN)"
+    _cf_json=$(_prowler_scan "cloudflare")
+    _prowler_report "Cloudflare" "$_cf_json" "PROWLER-CF"
+    unset CLOUDFLARE_API_TOKEN
+  fi
 else
   if ! _prowler_should_run "cloudflare"; then
     skip "PROWLER-CF-001" "Prowler Cloudflare scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
@@ -547,11 +607,15 @@ fi
 # ── MongoDB Atlas ──────────────────────────────────────────────────────────
 
 if _prowler_should_run "mongodbatlas" && [[ -n "${MONGODB_ATLAS_PUBLIC_KEY:-}" && -n "${MONGODB_ATLAS_PRIVATE_KEY:-}" ]]; then
-  info "Prowler: Scanning MongoDB Atlas"
-  _mongo_args=()
-  [[ -n "${MONGODB_ATLAS_ORG_ID:-}" ]] && _mongo_args+=(--organization-id "$MONGODB_ATLAS_ORG_ID")
-  _mongo_json=$(_prowler_scan "mongodbatlas" "${_mongo_args[@]}")
-  _prowler_report "MongoDB Atlas" "$_mongo_json" "PROWLER-MONGO"
+  if ! _prowler_provider_available "mongodbatlas"; then
+    skip "PROWLER-MONGO-001" "Prowler MongoDB Atlas scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning MongoDB Atlas"
+    _mongo_args=()
+    [[ -n "${MONGODB_ATLAS_ORG_ID:-}" ]] && _mongo_args+=(--organization-id "$MONGODB_ATLAS_ORG_ID")
+    _mongo_json=$(_prowler_scan "mongodbatlas" "${_mongo_args[@]}")
+    _prowler_report "MongoDB Atlas" "$_mongo_json" "PROWLER-MONGO"
+  fi
 elif ! _prowler_should_run "mongodbatlas"; then
   skip "PROWLER-MONGO-001" "Prowler MongoDB Atlas scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
 else
@@ -561,13 +625,21 @@ fi
 # ── Oracle Cloud (OCI) ────────────────────────────────────────────────────
 
 if _prowler_should_run "oraclecloud" && [[ -f "$HOME/.oci/config" || -n "${OCI_CLI_AUTH:-}" ]]; then
-  info "Prowler: Scanning Oracle Cloud (OCI)"
-  _oci_json=$(_prowler_scan "oraclecloud")
-  _prowler_report "Oracle Cloud" "$_oci_json" "PROWLER-OCI"
+  if ! _prowler_provider_available "oraclecloud"; then
+    skip "PROWLER-OCI-001" "Prowler Oracle Cloud scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning Oracle Cloud (OCI)"
+    _oci_json=$(_prowler_scan "oraclecloud")
+    _prowler_report "Oracle Cloud" "$_oci_json" "PROWLER-OCI"
+  fi
 elif _prowler_should_run "oraclecloud" && [[ -n "${OCI_TENANCY:-}" && -n "${OCI_USER:-}" && -n "${OCI_FINGERPRINT:-}" ]]; then
-  info "Prowler: Scanning Oracle Cloud (env auth)"
-  _oci_json=$(_prowler_scan "oraclecloud")
-  _prowler_report "Oracle Cloud" "$_oci_json" "PROWLER-OCI"
+  if ! _prowler_provider_available "oraclecloud"; then
+    skip "PROWLER-OCI-001" "Prowler Oracle Cloud scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning Oracle Cloud (env auth)"
+    _oci_json=$(_prowler_scan "oraclecloud")
+    _prowler_report "Oracle Cloud" "$_oci_json" "PROWLER-OCI"
+  fi
 elif ! _prowler_should_run "oraclecloud"; then
   skip "PROWLER-OCI-001" "Prowler Oracle Cloud scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
 else
@@ -577,13 +649,21 @@ fi
 # ── Alibaba Cloud ─────────────────────────────────────────────────────────
 
 if _prowler_should_run "alibabacloud" && [[ -n "${ALIBABA_CLOUD_ACCESS_KEY_ID:-}" && -n "${ALIBABA_CLOUD_ACCESS_KEY_SECRET:-}" ]]; then
-  info "Prowler: Scanning Alibaba Cloud"
-  _ali_json=$(_prowler_scan "alibabacloud")
-  _prowler_report "Alibaba Cloud" "$_ali_json" "PROWLER-ALI"
+  if ! _prowler_provider_available "alibabacloud"; then
+    skip "PROWLER-ALI-001" "Prowler Alibaba Cloud scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning Alibaba Cloud"
+    _ali_json=$(_prowler_scan "alibabacloud")
+    _prowler_report "Alibaba Cloud" "$_ali_json" "PROWLER-ALI"
+  fi
 elif _prowler_should_run "alibabacloud" && [[ -f "$HOME/.aliyun/config.json" ]]; then
-  info "Prowler: Scanning Alibaba Cloud (CLI config)"
-  _ali_json=$(_prowler_scan "alibabacloud")
-  _prowler_report "Alibaba Cloud" "$_ali_json" "PROWLER-ALI"
+  if ! _prowler_provider_available "alibabacloud"; then
+    skip "PROWLER-ALI-001" "Prowler Alibaba Cloud scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning Alibaba Cloud (CLI config)"
+    _ali_json=$(_prowler_scan "alibabacloud")
+    _prowler_report "Alibaba Cloud" "$_ali_json" "PROWLER-ALI"
+  fi
 elif ! _prowler_should_run "alibabacloud"; then
   skip "PROWLER-ALI-001" "Prowler Alibaba Cloud scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
 else
@@ -593,14 +673,18 @@ fi
 # ── OpenStack ──────────────────────────────────────────────────────────────
 
 if _prowler_should_run "openstack" && [[ -n "${OS_AUTH_URL:-}" || -f "$HOME/.config/openstack/clouds.yaml" ]]; then
-  info "Prowler: Scanning OpenStack"
-  _os_args=()
-  if [[ -f "$HOME/.config/openstack/clouds.yaml" ]]; then
-    _os_cloud=$(grep -oE '^  [a-zA-Z0-9_-]+:' "$HOME/.config/openstack/clouds.yaml" 2>/dev/null | head -1 | tr -d ' :' || echo "")
-    [[ -n "$_os_cloud" ]] && _os_args+=(--clouds-yaml-cloud "$_os_cloud")
+  if ! _prowler_provider_available "openstack"; then
+    skip "PROWLER-OS-001" "Prowler OpenStack scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning OpenStack"
+    _os_args=()
+    if [[ -f "$HOME/.config/openstack/clouds.yaml" ]]; then
+      _os_cloud=$(grep -oE '^  [a-zA-Z0-9_-]+:' "$HOME/.config/openstack/clouds.yaml" 2>/dev/null | head -1 | tr -d ' :' || echo "")
+      [[ -n "$_os_cloud" ]] && _os_args+=(--clouds-yaml-cloud "$_os_cloud")
+    fi
+    _os_json=$(_prowler_scan "openstack" "${_os_args[@]}")
+    _prowler_report "OpenStack" "$_os_json" "PROWLER-OS"
   fi
-  _os_json=$(_prowler_scan "openstack" "${_os_args[@]}")
-  _prowler_report "OpenStack" "$_os_json" "PROWLER-OS"
 elif ! _prowler_should_run "openstack"; then
   skip "PROWLER-OS-001" "Prowler OpenStack scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
 else
@@ -611,17 +695,21 @@ fi
 
 if _prowler_should_run "nhn" && [[ -n "${NHN_API_URL:-}" || -n "${OS_AUTH_URL:-}" ]] && \
    [[ "${OS_AUTH_URL:-}" == *"nhncloud"* || "${OS_AUTH_URL:-}" == *"toast"* || -n "${NHN_API_URL:-}" ]]; then
-  export CLAUDESEC_ENV_NHN_CONNECTED="true"
-  info "Prowler: Scanning NHN Cloud (via OpenStack provider)"
-  _nhn_args=()
-  [[ -n "${NHN_API_URL:-}" ]] && export OS_AUTH_URL="$NHN_API_URL"
-  if [[ -f "$HOME/.config/openstack/clouds.yaml" ]]; then
-    _nhn_cloud=$(grep -E -B1 -A5 '(nhn|toast|nhncloud)' "$HOME/.config/openstack/clouds.yaml" 2>/dev/null | \
-      grep -oE '^  [a-zA-Z0-9_-]+:' | head -1 | tr -d ' :' || echo "")
-    [[ -n "$_nhn_cloud" ]] && _nhn_args+=(--clouds-yaml-cloud "$_nhn_cloud")
+  if ! _prowler_provider_available "nhn"; then
+    skip "PROWLER-NHN-001" "Prowler NHN Cloud scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    export CLAUDESEC_ENV_NHN_CONNECTED="true"
+    info "Prowler: Scanning NHN Cloud (via OpenStack provider)"
+    _nhn_args=()
+    [[ -n "${NHN_API_URL:-}" ]] && export OS_AUTH_URL="$NHN_API_URL"
+    if [[ -f "$HOME/.config/openstack/clouds.yaml" ]]; then
+      _nhn_cloud=$(grep -E -B1 -A5 '(nhn|toast|nhncloud)' "$HOME/.config/openstack/clouds.yaml" 2>/dev/null | \
+        grep -oE '^  [a-zA-Z0-9_-]+:' | head -1 | tr -d ' :' || echo "")
+      [[ -n "$_nhn_cloud" ]] && _nhn_args+=(--clouds-yaml-cloud "$_nhn_cloud")
+    fi
+    _nhn_json=$(_prowler_scan "openstack" "${_nhn_args[@]}")
+    _prowler_report "NHN Cloud" "$_nhn_json" "PROWLER-NHN"
   fi
-  _nhn_json=$(_prowler_scan "openstack" "${_nhn_args[@]}")
-  _prowler_report "NHN Cloud" "$_nhn_json" "PROWLER-NHN"
 elif ! _prowler_should_run "nhn"; then
   skip "PROWLER-NHN-001" "Prowler NHN Cloud scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
 else
@@ -649,10 +737,14 @@ fi
 # ── LLM (AI Red-Team via promptfoo) ──────────────────────────────────────
 
 if _prowler_should_run "llm" && has_command promptfoo && [[ -n "${OPENAI_API_KEY:-}" || -n "${ANTHROPIC_API_KEY:-}" ]]; then
-  export CLAUDESEC_ENV_LLM_CONNECTED="true"
-  info "Prowler: Running LLM red-team checks"
-  _llm_json=$(_prowler_scan "llm")
-  _prowler_report "LLM" "$_llm_json" "PROWLER-LLM"
+  if ! _prowler_provider_available "llm"; then
+    skip "PROWLER-LLM-001" "Prowler LLM red-team" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    export CLAUDESEC_ENV_LLM_CONNECTED="true"
+    info "Prowler: Running LLM red-team checks"
+    _llm_json=$(_prowler_scan "llm")
+    _prowler_report "LLM" "$_llm_json" "PROWLER-LLM"
+  fi
 else
   if ! _prowler_should_run "llm"; then
     skip "PROWLER-LLM-001" "Prowler LLM red-team" "Disabled by config (set prowler_providers in .claudesec.yml)"
@@ -672,9 +764,13 @@ if [[ -z "$_scan_image" ]]; then
 fi
 
 if _prowler_should_run "image" && [[ -n "$_scan_image" ]]; then
-  info "Prowler: Scanning container image ${_scan_image}"
-  _img_json=$(_prowler_scan "image" --image "$_scan_image")
-  _prowler_report "Image" "$_img_json" "PROWLER-IMG"
+  if ! _prowler_provider_available "image"; then
+    skip "PROWLER-IMG-001" "Prowler Image scan" "Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install."
+  else
+    info "Prowler: Scanning container image ${_scan_image}"
+    _img_json=$(_prowler_scan "image" --image "$_scan_image")
+    _prowler_report "Image" "$_img_json" "PROWLER-IMG"
+  fi
 elif ! _prowler_should_run "image"; then
   skip "PROWLER-IMG-001" "Prowler Image scan" "Disabled by config (set prowler_providers in .claudesec.yml)"
 else

--- a/scanner/tests/test_prowler_provider_build_parity.sh
+++ b/scanner/tests/test_prowler_provider_build_parity.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Unit tests for the _prowler_provider_available helper introduced in
+# scanner/checks/prowler/integration.sh to detect absent provider modules
+# and emit accurate skip messages in the lean container image.
+#
+# Strategy: define _prowler_provider_available inline (same body as the
+# production function) so the test is fully hermetic — no prowler binary,
+# no network, no live install needed.  A separate group verifies the body
+# matches the production source so the copy cannot silently drift.
+#
+# Run: bash scanner/tests/test_prowler_provider_build_parity.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEGRATION_SH="$SCRIPT_DIR/../checks/prowler/integration.sh"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+# ── Inline copy of the helper (must stay in sync with integration.sh) ────────
+# _prowler_install_dir is the control variable; tests override it directly.
+_prowler_install_dir=""
+
+_prowler_provider_available() {
+  local provider="$1"
+  # Map nhn -> openstack (NHN Cloud scans via the openstack provider)
+  [[ "$provider" == "nhn" ]] && provider="openstack"
+  # If we couldn't resolve the install dir, default to available (full install)
+  [[ -z "$_prowler_install_dir" ]] && return 0
+  [[ -d "${_prowler_install_dir}/providers/${provider}" ]]
+}
+
+# ── Drift guard: verify the inline body matches what's in integration.sh ─────
+# Extract the production function body and compare it to ours.
+assert_helper_in_sync() {
+  # Pull the function body from integration.sh between the function definition
+  # and its closing brace.
+  local prod_body
+  prod_body=$(awk '
+    /^_prowler_provider_available\(\)/ { found=1; next }
+    found && /^\}/ { exit }
+    found { print }
+  ' "$INTEGRATION_SH" 2>/dev/null | sed 's/^[[:space:]]*//' | grep -v '^$' || true)
+
+  local test_body
+  test_body=$(awk '
+    /^_prowler_provider_available\(\)/ { found=1; next }
+    found && /^\}/ { exit }
+    found { print }
+  ' "${BASH_SOURCE[0]}" 2>/dev/null | sed 's/^[[:space:]]*//' | grep -v '^$' || true)
+
+  if [[ "$prod_body" == "$test_body" ]]; then
+    echo "  PASS: inline helper body matches integration.sh"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: inline helper has drifted from integration.sh"
+    echo "    --- integration.sh ---"
+    echo "$prod_body"
+    echo "    --- this test ---"
+    echo "$test_body"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_available() {
+  local desc="$1" provider="$2"
+  if _prowler_provider_available "$provider"; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (expected available, got absent)"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_absent() {
+  local desc="$1" provider="$2"
+  if ! _prowler_provider_available "$provider"; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (expected absent, got available)"
+    ((TEST_FAILED++))
+  fi
+}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# ── Drift check ───────────────────────────────────────────────────────────────
+
+echo "=== Drift guard: inline helper matches integration.sh ==="
+assert_helper_in_sync
+
+# ── Group 1: lean container layout (subset of providers) ─────────────────────
+
+echo "=== Group 1: lean container — kept providers are available ==="
+
+# Simulate lean image: only aws, kubernetes, github, iac present
+mkdir -p \
+  "$tmpdir/providers/aws" \
+  "$tmpdir/providers/kubernetes" \
+  "$tmpdir/providers/github" \
+  "$tmpdir/providers/iac"
+
+_prowler_install_dir="$tmpdir"
+
+assert_available "aws present in lean image"        "aws"
+assert_available "kubernetes present in lean image" "kubernetes"
+assert_available "github present in lean image"     "github"
+assert_available "iac present in lean image"        "iac"
+
+echo "=== Group 1: lean container — stripped providers are absent ==="
+
+assert_absent "azure stripped from lean image"           "azure"
+assert_absent "gcp stripped from lean image"             "gcp"
+assert_absent "m365 stripped from lean image"            "m365"
+assert_absent "googleworkspace stripped from lean image" "googleworkspace"
+assert_absent "cloudflare stripped from lean image"      "cloudflare"
+assert_absent "mongodbatlas stripped from lean image"    "mongodbatlas"
+assert_absent "oraclecloud stripped from lean image"     "oraclecloud"
+assert_absent "alibabacloud stripped from lean image"    "alibabacloud"
+assert_absent "openstack stripped from lean image"       "openstack"
+assert_absent "llm stripped from lean image"             "llm"
+assert_absent "image stripped from lean image"           "image"
+
+echo "=== Group 1: nhn maps to openstack module ==="
+
+# nhn uses the openstack provider; openstack is absent -> nhn is absent
+assert_absent "nhn absent when openstack stripped" "nhn"
+
+# Add openstack back and re-check
+mkdir -p "$tmpdir/providers/openstack"
+assert_available "nhn available when openstack present" "nhn"
+rmdir "$tmpdir/providers/openstack"
+
+# ── Group 2: full local install (all 16 providers present) ───────────────────
+
+echo "=== Group 2: full install — all providers available ==="
+
+tmpdir2=$(mktemp -d)
+trap 'rm -rf "$tmpdir" "$tmpdir2"' EXIT
+
+mkdir -p \
+  "$tmpdir2/providers/aws" \
+  "$tmpdir2/providers/azure" \
+  "$tmpdir2/providers/gcp" \
+  "$tmpdir2/providers/kubernetes" \
+  "$tmpdir2/providers/github" \
+  "$tmpdir2/providers/m365" \
+  "$tmpdir2/providers/googleworkspace" \
+  "$tmpdir2/providers/cloudflare" \
+  "$tmpdir2/providers/mongodbatlas" \
+  "$tmpdir2/providers/oraclecloud" \
+  "$tmpdir2/providers/alibabacloud" \
+  "$tmpdir2/providers/openstack" \
+  "$tmpdir2/providers/iac" \
+  "$tmpdir2/providers/llm" \
+  "$tmpdir2/providers/image"
+
+_prowler_install_dir="$tmpdir2"
+
+for _p in aws azure gcp kubernetes github m365 googleworkspace cloudflare \
+           mongodbatlas oraclecloud alibabacloud openstack iac llm image nhn; do
+  assert_available "full install: $_p available" "$_p"
+done
+
+# ── Group 3: inconclusive detection defaults to available (no false negatives) ─
+
+echo "=== Group 3: empty install dir defaults to available ==="
+
+_prowler_install_dir=""
+
+assert_available "empty install dir: aws defaults available"   "aws"
+assert_available "empty install dir: azure defaults available" "azure"
+assert_available "empty install dir: nhn defaults available"   "nhn"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

- **Discrepancy fixed**: `scanner/checks/prowler/integration.sh` declares 16 providers; the Dockerfile builder stage strips 12 of them (`azure`, `gcp`, `m365`, `googleworkspace`, `cloudflare`, `mongodbatlas`, `oraclecloud`, `alibabacloud`, `openstack`, `nhn`, `llm`, `image`) to save ~700 MB. Before this fix, if a user ran the lean container with credentials for a stripped provider, `integration.sh` attempted the scan, prowler failed at the commented import, and `_prowler_report` emitted **"Check authentication and permissions"** — a misleading message that sends users on a false auth-debugging chase.
- **Lean image is the established direction**: providers are NOT re-added. The fix is purely in `integration.sh`.
- **NHN Cloud detail**: NHN Cloud scans via the `openstack` provider module. `openstack` is stripped, so `nhn` also breaks. The new `_prowler_provider_available` helper maps `nhn` → `openstack` for the module check.

## What changed

### `scanner/checks/prowler/integration.sh`
Added a runtime detection block immediately after the `has_command prowler` guard:

```bash
_prowler_install_dir=$(python3 -c 'import prowler,os;print(os.path.dirname(prowler.__file__))' 2>/dev/null || true)

_prowler_provider_available() {
  local provider="$1"
  [[ "$provider" == "nhn" ]] && provider="openstack"
  [[ -z "$_prowler_install_dir" ]] && return 0   # inconclusive → available
  [[ -d "${_prowler_install_dir}/providers/${provider}" ]]
}
```

Each of the 12 stripped providers' "would scan" branches now guards with `_prowler_provider_available` and emits an accurate skip:

> `Provider not included in this build (lean container image — see Dockerfile). Use a full prowler install.`

The 4 kept providers (`aws`, `kubernetes`, `github`, `iac`) are untouched.

### `scanner/tests/test_prowler_provider_build_parity.sh` (new)
37 tests covering:
- Lean layout: kept providers available, stripped providers absent
- `nhn` → `openstack` mapping in both absent and present states
- Full install layout: all 16 providers report available
- Empty install dir (inconclusive detection): defaults to available — no regressions on full local installs
- Drift guard: inline helper body is verified to match `integration.sh` at test runtime

### `.github/workflows/lint.yml`
New test registered in the `scanner-unit-tests` explicit list.

### `Dockerfile`
One-line cross-reference note added to the provider-strip block for traceability.

## Test evidence

```
=== Drift guard: inline helper matches integration.sh ===
  PASS: inline helper body matches integration.sh
=== Group 1: lean container — kept providers are available ===
  PASS: aws present in lean image
  PASS: kubernetes present in lean image
  PASS: github present in lean image
  PASS: iac present in lean image
=== Group 1: lean container — stripped providers are absent ===
  PASS: azure stripped from lean image
  PASS: gcp stripped from lean image
  PASS: m365 stripped from lean image
  PASS: googleworkspace stripped from lean image
  PASS: cloudflare stripped from lean image
  PASS: mongodbatlas stripped from lean image
  PASS: oraclecloud stripped from lean image
  PASS: alibabacloud stripped from lean image
  PASS: openstack stripped from lean image
  PASS: llm stripped from lean image
  PASS: image stripped from lean image
=== Group 1: nhn maps to openstack module ===
  PASS: nhn absent when openstack stripped
  PASS: nhn available when openstack present
=== Group 2: full install — all providers available ===
  PASS: full install: aws available
  ... (16 providers)
  PASS: full install: nhn available
=== Group 3: empty install dir defaults to available ===
  PASS: empty install dir: aws defaults available
  PASS: empty install dir: azure defaults available
  PASS: empty install dir: nhn defaults available

=== Results: 37 passed, 0 failed ===
```

`shellcheck` (severity: error): 0 new findings in changed files.
`bash -n scanner/checks/prowler/integration.sh`: clean.

## Test plan

- [ ] Verify CI `scanner-unit-tests` job passes (includes new bash test)
- [ ] Verify CI `shell-lint` job passes (no new error-level shellcheck findings)
- [ ] Manual: run `bash scanner/tests/test_prowler_provider_build_parity.sh` locally
- [ ] Manual: in the lean container, set `AZURE_CLIENT_ID` and confirm the skip message reads "Provider not included in this build" rather than "Check authentication and permissions"

🤖 Generated with [Claude Code](https://claude.com/claude-code)