### PR TITLE
chore: gitignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,6 +115,7 @@ docs/architecture/*.pdf
 .claude/settings.json
 .claude/settings.local.json
 .claude/hooks/
+.claude/worktrees/
 .omc/
 .omc-config.json
 


### PR DESCRIPTION
## Summary

Add `.claude/worktrees/` to `.gitignore`. Background-agent worktrees are created under this path and can surface as untracked entries in the repo root (and risk accidental commit). This ignores them, as a sibling to the existing `.claude/settings*.json` and `.claude/hooks/` ignores. Shared `.claude/agents/` and `.claude/commands/` remain tracked (unaffected).

## Why

Discovered during multi-agent work: `git check-ignore .claude/worktrees/` returned *not ignored*, and a stale orphan worktree dir lingers under it. Ignoring the path prevents future churn.

## Validation

- `git check-ignore .claude/worktrees/` → now reports ignored ✓
- `git status` → clean (only `.gitignore` changed)
- Non-code change; no test impact.

> Note (out of scope for this PR): one orphaned worktree dir `.claude/worktrees/agent-ab630ddc...` from a prior session can be removed manually (`git worktree prune` + `rm -rf`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)