### PR TITLE
test(ci): guard codified branch protection + dependabot.yml config

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -56,6 +56,8 @@ All guards follow the same rules (see the existing files for reference):
 | `scanner/tests/test_ci_prowler_provider_guard_ordering.py` | `_prowler_provider_available` precedes `_prowler_report` per provider (`scanner/checks/prowler/integration.sh`) | within each provider section of the Provider Scans block, `min(guard line) < min(report line)` — reordering would silently regress the #238 build-parity fix (lean image would emit a misleading auth warning instead of an accurate "not in this build" skip); promotes the shell-level `#241` assertion into the pytest CI gate | #242 |
 | `scanner/tests/test_ci_catalog_completeness.py` | Completeness of this catalog vs the on-disk guard suite | every `scanner/tests/test_ci_*.py` file has its repo-relative path listed in this catalog (presence) — a new guard added without a Catalog row is silent documentation drift that makes the inventory understate coverage; the meta-guard documents itself so the invariant is uniform | #254 |
 | `scanner/tests/test_ci_catalog_no_ghost_rows.py` | No ghost rows in this catalog vs the on-disk guard suite | every concrete `scanner/tests/test_ci_<name>.py` path cited in this catalog resolves to a real file (existence) — the reverse of the completeness guard: a renamed/deleted guard left in the table is a ghost row that makes the inventory overstate coverage. Together the two guards verify a 1:1 catalog↔suite mapping | #255 |
+| `scanner/tests/test_ci_branch_protection_codified.py` | Codified branch protection (`scripts/sync-repo-protection.sh`) + its nightly notifier (`protection-drift-watch.yml`) | the desired state keeps `DESIRED_CONTEXTS=["Lint","Security Scan Gate"]` (both required checks), `DESIRED_ENFORCE_ADMINS="true"` (admins not exempt — no force-push to main), `strict`/`require_code_owner_reviews` true, `set -euo pipefail`, and the default-arm dry-run; the `DRIFT DETECTED` marker contract holds on both producer (script) and consumer (`grep -q`) sides; the watch keeps `schedule:` + tooling-error `exit 1` and its `on:` block never gains a `pull_request(_target)` trigger (scheduled notifier, must not become a required PR check). Protects the #250/#251 codification | #256 |
+| `scanner/tests/test_ci_dependabot_config.py` | `.github/dependabot.yml` update coverage + alpine version freeze | all four ecosystems stay declared (`github-actions`, `npm`, `pip`, `docker`) so no surface silently stops getting update PRs (OWASP CICD-SEC-3); the `docker` `ignore` keeps the `alpine` `semver-minor`+`semver-major` freeze that holds alpine on its py3.12 minor line — loosening it would let Dependabot propose the bump that ships py3.14 and crashes prowler (pydantic v1, incident #220). Distinct from `test_ci_dependabot_automerge.py` (guards the *workflow*, not this *config*) | #256 |
 
 ### Related enforcement (not a pytest guard)
 
@@ -82,6 +84,38 @@ The topology guards check that every *present* job is gated; they cannot see a
 job that is **deleted entirely** (a removed job simply leaves the gated set, and
 the aggregator stays green). `test_ci_required_jobs_exist.py` closes that
 complementary gap by asserting the load-bearing security jobs still exist.
+
+## Unguarded invariants backlog
+
+A standing list of CI invariants that are **not yet** protected by a guard,
+triaged by the same bar used to add one (an incident, past or plausible, where
+*silent* weakening disables enforcement — no incident means it likely is not
+worth a guard, to avoid sprawl). Reviewed 2026-06-19.
+
+### Tier 2 — incident-backed, worth a guard next
+
+| Candidate guard | Invariant | Incident / rationale |
+|-----------------|-----------|----------------------|
+| `test_ci_prowler_version_pinned.py` | `Dockerfile` keeps the **exact** `prowler==` pin (`PROWLER_VERSION`, currently `5.30.1`) — equality, not a floor | #237: an unpinned prowler drifted; prowler 3.11.3/pydantic-v1 cannot run on py3.13+, so an unpinned bump silently breaks `prowler -v` at runtime. Complements the alpine freeze (`test_ci_dependabot_config.py`) and the provider-ordering guard (`test_ci_prowler_provider_guard_ordering.py`). |
+| `test_ci_dockerfile_base_pinned.py` | `Dockerfile`/`Dockerfile.nginx` keep their `alpine:3.20` (py3.12) base pin and stay version-agnostic | #233/#234/#220: a minor alpine bump ships py3.14 and crashes prowler. The dependabot guard locks the *freeze policy* in `dependabot.yml`; this would lock the *actual image* a manual edit could still bump. |
+
+### Tier 3 — monitor only (no guard yet; would be sprawl)
+
+- **Auxiliary scheduled workflows** — `prowler-python-watch.yml`,
+  `dashboard-refresh.yml`, `og-meta-verify.yml`: none is a required status check
+  and none runs on `pull_request_target` with a write token, so silent weakening
+  does not disable a merge gate. Add a guard only if one later gains enforcement
+  responsibility (becomes required, or gains a write-token PR trigger).
+- **DAST trigger invariants** — `dast-baseline.yml` (`pull_request`) and
+  `dast-full-scan.yml` (`schedule:`) triggers are already asserted by
+  `test_ci_security_gate.py`; no separate guard needed.
+
+### Verified already-guarded during this review (not backlog)
+
+lychee `v0.23.0` pin (`test_ci_gate_topology.py`), the `Security Scan Gate`
+CRITICAL `exit 1` severity block (`test_ci_security_gate.py`), CODEOWNERS
+coverage, ERE-pipe regressions, prowler provider ordering, coverage floors, npm
+`--provenance`, and the cross-OS non-required invariant.
 
 ## Adding a new guard
 

--- a/scanner/tests/test_ci_branch_protection_codified.py
+++ b/scanner/tests/test_ci_branch_protection_codified.py
@@ -1,0 +1,330 @@
+"""
+Regression guard: branch protection is codified as infrastructure-as-code in
+`scripts/sync-repo-protection.sh`, and the nightly `protection-drift-watch.yml`
+notifier stays wired to it correctly.
+
+Background
+----------
+`main` branch protection is the outermost control: it is what forces every
+change through the two required status checks (`Lint`, `Security Scan Gate`),
+through CODEOWNERS review, and what keeps repo admins from force-pushing. Those
+settings live on GitHub's side, but their *desired state* is codified in
+`scripts/sync-repo-protection.sh` (single source of truth, #250) and watched for
+drift nightly by `protection-drift-watch.yml` (#251).
+
+Silently weakening the codified desired state would not fail any build — it would
+just quietly make `--apply` reconfigure the repo to a weaker posture, or make the
+drift watch stop detecting a regression. Each invariant below is therefore a
+control whose silent removal disables enforcement
+(OWASP CICD-SEC-1 Insufficient Flow Control / CICD-SEC-7 Insecure System
+Configuration; NIST SSDF SP 800-218 PO.3/PW.4):
+
+  1. **Required-status contexts** — `DESIRED_CONTEXTS` must keep BOTH
+     `"Lint"` and `"Security Scan Gate"`. Dropping either un-requires that
+     aggregator, so a PR could merge with that whole gate red. (The "two
+     required checks" contract documented in ci-config-regression-guards.md.)
+  2. **enforce_admins=true** — admins (including the owner) are NOT exempt from
+     branch protection. Flipping to false would let an admin force-push to main.
+  3. **strict=true** — PRs must be up to date with main before merge.
+  4. **require_code_owner_reviews=true** — every touched path needs a CODEOWNERS
+     match; this is what makes `require_code_owner_reviews` actually gate.
+  5. **Safe-by-default dry-run** — the script must `set -euo pipefail` and the
+     no-flag / `--dry-run` invocation must NOT write (only `--apply` mutates).
+  6. **Drift marker contract** — the script emits the literal `DRIFT DETECTED`
+     string and the watch workflow greps for exactly that string to tell real
+     drift apart from a tooling/auth error. If either side changes the marker,
+     the nightly watch silently reclassifies every drift as a tooling error and
+     never opens an alert issue.
+  7. **Notifier is not a PR gate** — `protection-drift-watch.yml` must keep its
+     `schedule:` trigger and must NEVER gain a `pull_request` /
+     `pull_request_target` trigger (it is a scheduled notifier and must not
+     become a required PR status check), and its tooling-error branch must keep
+     `exit 1` so a silent auth failure is never read as "clean".
+
+Direction: presence/`==` (exact desired values). Tightening (adding contexts,
+adding more `exit 1` paths) stays green; loosening trips the guard.
+
+Mutation self-test
+------------------
+`TestBranchProtectionCodifiedMutation` builds synthetic known-good script/workflow
+snippets, confirms they pass, then verifies each invariant is detected when
+weakened, and that the real on-disk files pass cleanly.
+
+stdlib-only (no PyYAML — not in requirements-ci.txt). Substring / line scanning,
+no regex on the YAML body so commentary like the "MUST NOT run on pull_request"
+comment is never mistaken for a trigger. No `scanner/lib` import (does not touch
+the 99% coverage gate). No network, no subprocess. Runs under pytest (the CI
+runner) and `python3 -m unittest`.
+"""
+
+import unittest
+from pathlib import Path
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "sync-repo-protection.sh"
+WATCH = REPO_ROOT / ".github" / "workflows" / "protection-drift-watch.yml"
+
+# Literal desired-state assignments that MUST be present verbatim in the script.
+# Tightening the posture (e.g. adding a context) is allowed; weakening any of
+# these requires revising this guard with a documented rationale.
+REQUIRED_SCRIPT_TOKENS = {
+    # 1. Both required status-check contexts (order-exact: this is how the script
+    #    writes the desired set).
+    "desired_contexts": 'DESIRED_CONTEXTS=\'["Lint","Security Scan Gate"]\'',
+    # 2. Admins are not exempt from branch protection.
+    "enforce_admins_true": 'DESIRED_ENFORCE_ADMINS="true"',
+    # 3. Up-to-date-before-merge.
+    "strict_true": 'DESIRED_STRICT="true"',
+    # 4. CODEOWNERS review required.
+    "code_owner_reviews_true": 'DESIRED_CODE_OWNER_REVIEWS="true"',
+    # 5. Safe-by-default: strict bash mode + default dry-run arm.
+    "strict_bash_mode": "set -euo pipefail",
+    "default_is_dry_run": '--dry-run|"") MODE="dry-run"',
+    # 6. The drift marker the watch workflow greps for.
+    "drift_marker": "DRIFT DETECTED",
+}
+
+# Required tokens in the drift-watch workflow.
+REQUIRED_WATCH_TOKENS = {
+    # 6. Same marker, on the consumer side.
+    "drift_marker_grep": 'grep -q "DRIFT DETECTED"',
+    # 7. Scheduled notifier + fail-on-tooling-error.
+    "schedule_trigger": "schedule:",
+    "fail_on_error_exit": "exit 1",
+}
+
+
+def _extract_on_block(text: str) -> str:
+    """Return the body of the workflow's top-level `on:` block (the indented
+    lines under `on:`, up to the next top-level key). Comment lines are dropped
+    so prose like '# ... MUST NOT run on pull_request events' is never matched.
+    """
+    lines = text.splitlines()
+    body = []
+    in_on = False
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if not in_on:
+            # Top-level `on:` key (no indentation).
+            if line.rstrip() == "on:" or line.startswith("on:"):
+                in_on = True
+            continue
+        # Inside the on: block. A new top-level key (non-space first char,
+        # non-empty) ends it.
+        if line and not line[0].isspace():
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
+def script_violations(text: str) -> list:
+    return [
+        f"MISSING required script invariant [{name}]: {tok!r}"
+        for name, tok in sorted(REQUIRED_SCRIPT_TOKENS.items())
+        if tok not in text
+    ]
+
+
+def watch_violations(text: str) -> list:
+    problems = [
+        f"MISSING required watch invariant [{name}]: {tok!r}"
+        for name, tok in sorted(REQUIRED_WATCH_TOKENS.items())
+        if tok not in text
+    ]
+    on_block = _extract_on_block(text)
+    for forbidden in ("pull_request:", "pull_request_target:"):
+        if forbidden in on_block:
+            problems.append(
+                f"FORBIDDEN trigger in on: block [{forbidden}] — the drift watch "
+                "is a scheduled notifier and must never become a PR status check."
+            )
+    return problems
+
+
+class TestBranchProtectionCodified(unittest.TestCase):
+    """Guards the on-disk codified branch protection + its drift watch."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.script = SCRIPT.read_text(encoding="utf-8") if SCRIPT.is_file() else ""
+        cls.watch = WATCH.read_text(encoding="utf-8") if WATCH.is_file() else ""
+
+    def test_script_exists(self):
+        self.assertTrue(
+            SCRIPT.is_file(),
+            f"{SCRIPT} not found — the codified branch-protection desired state "
+            "has been deleted or moved.",
+        )
+
+    def test_watch_workflow_exists(self):
+        self.assertTrue(
+            WATCH.is_file(),
+            f"{WATCH} not found — the nightly branch-protection drift watch has "
+            "been deleted or moved.",
+        )
+
+    def test_required_contexts_present(self):
+        self.assertIn(
+            REQUIRED_SCRIPT_TOKENS["desired_contexts"], self.script,
+            "DESIRED_CONTEXTS no longer pins both 'Lint' and 'Security Scan Gate' "
+            "— --apply would un-require a mandatory status check, letting a PR "
+            "merge with that whole gate red. Restore both contexts or update this "
+            "guard with a rationale.",
+        )
+
+    def test_enforce_admins_true(self):
+        self.assertIn(
+            REQUIRED_SCRIPT_TOKENS["enforce_admins_true"], self.script,
+            "DESIRED_ENFORCE_ADMINS is no longer \"true\" — admins would become "
+            "exempt from branch protection and could force-push to main.",
+        )
+
+    def test_all_script_invariants_hold(self):
+        problems = script_violations(self.script)
+        self.assertEqual(
+            problems, [],
+            "scripts/sync-repo-protection.sh weakened a codified branch-protection "
+            "invariant:\n  " + "\n  ".join(problems)
+            + "\n\nRestore the desired value, or (if intentional) update "
+            "REQUIRED_SCRIPT_TOKENS in this guard with a rationale.",
+        )
+
+    def test_all_watch_invariants_hold(self):
+        problems = watch_violations(self.watch)
+        self.assertEqual(
+            problems, [],
+            "protection-drift-watch.yml lost a drift-watch invariant:\n  "
+            + "\n  ".join(problems)
+            + "\n\nRestore it, or (if intentional) update REQUIRED_WATCH_TOKENS / "
+            "this guard with a rationale.",
+        )
+
+    def test_drift_marker_contract(self):
+        # The marker is a contract between producer (script) and consumer (watch).
+        self.assertIn(
+            "DRIFT DETECTED", self.script,
+            "Script no longer emits the 'DRIFT DETECTED' marker.",
+        )
+        self.assertIn(
+            'grep -q "DRIFT DETECTED"', self.watch,
+            "Watch workflow no longer greps for the 'DRIFT DETECTED' marker — it "
+            "would silently reclassify real drift as a tooling error and never "
+            "open an alert issue.",
+        )
+
+    def test_notifier_has_no_pr_trigger(self):
+        on_block = _extract_on_block(self.watch)
+        self.assertNotIn(
+            "pull_request", on_block,
+            "protection-drift-watch.yml gained a pull_request(_target) trigger in "
+            "its on: block — it is a scheduled notifier and must never become a "
+            "required PR status check.",
+        )
+        self.assertIn(
+            "schedule:", on_block,
+            "protection-drift-watch.yml lost its schedule: trigger — drift would "
+            "no longer be caught nightly.",
+        )
+
+
+class TestBranchProtectionCodifiedMutation(unittest.TestCase):
+    """Mutation self-tests: the detectors must fire on known-bad inputs and stay
+    quiet on the known-good real files."""
+
+    _GOOD_SCRIPT = "\n".join(
+        [
+            "set -euo pipefail",
+            'DESIRED_STRICT="true"',
+            'DESIRED_CONTEXTS=\'["Lint","Security Scan Gate"]\'',
+            'DESIRED_CODE_OWNER_REVIEWS="true"',
+            'DESIRED_ENFORCE_ADMINS="true"',
+            '  --dry-run|"") MODE="dry-run" ;;',
+            '    lines.append(f"  DRIFT DETECTED in: {x}")',
+        ]
+    )
+
+    _GOOD_WATCH = "\n".join(
+        [
+            "# This workflow MUST NOT run on pull_request events.",
+            "on:",
+            "  schedule:",
+            "    - cron: '0 16 * * *'",
+            "  workflow_dispatch:",
+            "permissions:",
+            "  contents: read",
+            '          elif grep -q "DRIFT DETECTED" /tmp/drift-report.txt; then',
+            "          exit 1",
+        ]
+    )
+
+    def test_good_snippets_pass(self):
+        self.assertEqual(script_violations(self._GOOD_SCRIPT), [])
+        self.assertEqual(watch_violations(self._GOOD_WATCH), [])
+
+    def test_dropping_a_required_context_is_detected(self):
+        mutant = self._GOOD_SCRIPT.replace(
+            'DESIRED_CONTEXTS=\'["Lint","Security Scan Gate"]\'',
+            'DESIRED_CONTEXTS=\'["Lint"]\'',
+        )
+        self.assertTrue(
+            any("desired_contexts" in p for p in script_violations(mutant)),
+            "Mutation FAILED: dropping 'Security Scan Gate' from the required "
+            "contexts was NOT detected.",
+        )
+
+    def test_disabling_enforce_admins_is_detected(self):
+        mutant = self._GOOD_SCRIPT.replace(
+            'DESIRED_ENFORCE_ADMINS="true"', 'DESIRED_ENFORCE_ADMINS="false"'
+        )
+        self.assertTrue(
+            any("enforce_admins_true" in p for p in script_violations(mutant)),
+            "Mutation FAILED: flipping enforce_admins to false was NOT detected.",
+        )
+
+    def test_changing_the_drift_marker_is_detected(self):
+        mutant = self._GOOD_SCRIPT.replace("DRIFT DETECTED", "DRIFT FOUND")
+        self.assertTrue(
+            any("drift_marker" in p for p in script_violations(mutant)),
+            "Mutation FAILED: renaming the DRIFT DETECTED marker (breaking the "
+            "watch grep contract) was NOT detected.",
+        )
+
+    def test_pr_trigger_in_on_block_is_detected(self):
+        mutant = self._GOOD_WATCH.replace(
+            "  workflow_dispatch:",
+            "  workflow_dispatch:\n  pull_request:\n    branches: [main]",
+        )
+        problems = watch_violations(mutant)
+        self.assertTrue(
+            any("pull_request" in p for p in problems),
+            "Mutation FAILED: a pull_request trigger added to the on: block was "
+            "NOT detected.",
+        )
+
+    def test_comment_mentioning_pull_request_does_not_false_positive(self):
+        # The real workflow has a '# MUST NOT run on pull_request events' comment
+        # OUTSIDE the on: block — it must not be read as a trigger.
+        self.assertEqual(
+            watch_violations(self._GOOD_WATCH), [],
+            "False positive: prose mentioning 'pull_request' was treated as a "
+            "trigger. Only the on: block should be scanned for triggers.",
+        )
+
+    def test_real_files_clean(self):
+        if SCRIPT.is_file():
+            self.assertEqual(
+                script_violations(SCRIPT.read_text(encoding="utf-8")), [],
+                "The real sync-repo-protection.sh failed the invariant validator.",
+            )
+        if WATCH.is_file():
+            self.assertEqual(
+                watch_violations(WATCH.read_text(encoding="utf-8")), [],
+                "The real protection-drift-watch.yml failed the invariant validator.",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_ci_branch_protection_codified.py
+++ b/scanner/tests/test_ci_branch_protection_codified.py
@@ -50,13 +50,21 @@ Mutation self-test
 snippets, confirms they pass, then verifies each invariant is detected when
 weakened, and that the real on-disk files pass cleanly.
 
-stdlib-only (no PyYAML — not in requirements-ci.txt). Substring / line scanning,
-no regex on the YAML body so commentary like the "MUST NOT run on pull_request"
-comment is never mistaken for a trigger. No `scanner/lib` import (does not touch
-the 99% coverage gate). No network, no subprocess. Runs under pytest (the CI
-runner) and `python3 -m unittest`.
+Hardened (sec-review, 2026-06-19) against false negatives: whole-line comments
+are stripped before every presence check so a token living only in a comment
+cannot satisfy it (BP-5/BP-8); the `on:` block parser handles flow-style
+(`on: [push, pull_request]`) and quoted (`'on':` / `"on":`) keys (BP-1/BP-2);
+and each boolean `DESIRED_*` var must be assigned exactly once to its expected
+value, so a second last-wins `="false"` cannot hide behind the first `="true"`
+(BP-4).
+
+stdlib-only (no PyYAML — not in requirements-ci.txt). Line scanning + small
+regexes that never match commentary (comments are stripped first). No
+`scanner/lib` import (does not touch the 99% coverage gate). No network, no
+subprocess. Runs under pytest (the CI runner) and `python3 -m unittest`.
 """
 
+import re
 import unittest
 from pathlib import Path
 
@@ -95,22 +103,58 @@ REQUIRED_WATCH_TOKENS = {
 }
 
 
+# Boolean desired-state vars that must be assigned exactly once to "true"
+# (BP-4: a second last-wins `="false"` would weaken the posture while the first
+# `="true"` still satisfies the token presence check).
+BOOLEAN_DESIRED = {
+    "DESIRED_ENFORCE_ADMINS": "true",
+    "DESIRED_STRICT": "true",
+    "DESIRED_CODE_OWNER_REVIEWS": "true",
+}
+_ASSIGN_RE = re.compile(r'^\s*(DESIRED_\w+)=["\']?([^"\'\s#]+)')
+
+
+def _strip_comment_lines(text: str) -> str:
+    """Drop whole-line comments (lstrip starts with '#') so a token that lives
+    only in a comment cannot satisfy a presence check (sec-review BP-5/BP-8)."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def _on_key_inline(line: str):
+    """If `line` is a top-level `on:` mapping key (bare or quoted, BP-2), return
+    the text after the colon — possibly empty, or flow-style content like
+    `[push, pull_request]` (BP-1). Otherwise return None."""
+    s = line.rstrip()
+    # Only top-level keys (no leading indentation) are real `on:` triggers.
+    if s != s.lstrip():
+        return None
+    for key in ("on:", "'on':", '"on":'):
+        if s == key:
+            return ""
+        if s.startswith(key):
+            return s[len(key):]
+    return None
+
+
 def _extract_on_block(text: str) -> str:
-    """Return the body of the workflow's top-level `on:` block (the indented
-    lines under `on:`, up to the next top-level key). Comment lines are dropped
-    so prose like '# ... MUST NOT run on pull_request events' is never matched.
-    """
-    lines = text.splitlines()
+    """Return the workflow's top-level `on:` trigger content: the inline
+    remainder of the `on:` line (flow style, BP-1) PLUS the indented child lines
+    under it, up to the next top-level key. Whole-line comments are dropped so
+    prose like '# ... MUST NOT run on pull_request events' is never matched, and
+    bare/quoted `on:` keys are both handled (BP-2)."""
     body = []
     in_on = False
-    for line in lines:
-        stripped = line.strip()
-        if stripped.startswith("#"):
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
             continue
         if not in_on:
-            # Top-level `on:` key (no indentation).
-            if line.rstrip() == "on:" or line.startswith("on:"):
+            inline = _on_key_inline(line)
+            if inline is not None:
                 in_on = True
+                if inline.strip():
+                    body.append(inline)  # flow-style content on the `on:` line
             continue
         # Inside the on: block. A new top-level key (non-space first char,
         # non-empty) ends it.
@@ -121,26 +165,47 @@ def _extract_on_block(text: str) -> str:
 
 
 def script_violations(text: str) -> list:
-    return [
+    scan = _strip_comment_lines(text)
+    problems = [
         f"MISSING required script invariant [{name}]: {tok!r}"
         for name, tok in sorted(REQUIRED_SCRIPT_TOKENS.items())
-        if tok not in text
+        if tok not in scan
     ]
+    # BP-4: each boolean desired var assigned exactly once, to its expected value.
+    for var, expected in sorted(BOOLEAN_DESIRED.items()):
+        assigns = []
+        for line in scan.splitlines():
+            m = _ASSIGN_RE.match(line)
+            if m and m.group(1) == var:
+                assigns.append(m.group(2))
+        if len(assigns) != 1:
+            problems.append(
+                f"BP-4 [{var}] must be assigned exactly once (found {len(assigns)}: "
+                f"{assigns}) — a second assignment (bash last-wins) could silently "
+                "override the posture."
+            )
+        elif assigns[0] != expected:
+            problems.append(
+                f"BP-4 [{var}] assigned {assigns[0]!r}, expected {expected!r} — "
+                "branch-protection posture weakened."
+            )
+    return problems
 
 
 def watch_violations(text: str) -> list:
+    scan = _strip_comment_lines(text)
     problems = [
         f"MISSING required watch invariant [{name}]: {tok!r}"
         for name, tok in sorted(REQUIRED_WATCH_TOKENS.items())
-        if tok not in text
+        if tok not in scan
     ]
-    on_block = _extract_on_block(text)
-    for forbidden in ("pull_request:", "pull_request_target:"):
-        if forbidden in on_block:
-            problems.append(
-                f"FORBIDDEN trigger in on: block [{forbidden}] — the drift watch "
-                "is a scheduled notifier and must never become a PR status check."
-            )
+    # Bare `pull_request` substring catches both `pull_request:` (block style) and
+    # flow-style `[push, pull_request]`, and subsumes `pull_request_target`.
+    if "pull_request" in _extract_on_block(text):
+        problems.append(
+            "FORBIDDEN pull_request(_target) trigger in the on: block — the drift "
+            "watch is a scheduled notifier and must never become a PR status check."
+        )
     return problems
 
 
@@ -311,6 +376,67 @@ class TestBranchProtectionCodifiedMutation(unittest.TestCase):
             watch_violations(self._GOOD_WATCH), [],
             "False positive: prose mentioning 'pull_request' was treated as a "
             "trigger. Only the on: block should be scanned for triggers.",
+        )
+
+    def test_flow_style_pull_request_trigger_is_detected(self):
+        # BP-1: flow-style on: list with pull_request must be caught.
+        mutant = "\n".join(
+            [
+                "on: [schedule, workflow_dispatch, pull_request]",
+                "permissions:",
+                "  contents: read",
+                '          elif grep -q "DRIFT DETECTED" /tmp/drift-report.txt; then',
+                "          exit 1",
+                "  schedule:",  # keep the schedule token present in full text
+            ]
+        )
+        self.assertTrue(
+            any("pull_request" in p for p in watch_violations(mutant)),
+            "Mutation FAILED (BP-1): a flow-style `on: [..., pull_request]` trigger "
+            "was NOT detected.",
+        )
+
+    def test_quoted_on_key_pull_request_is_detected(self):
+        # BP-2: quoted 'on': key must still be parsed as the on: block.
+        mutant = "\n".join(
+            [
+                "'on':",
+                "  schedule:",
+                "    - cron: '0 16 * * *'",
+                "  pull_request:",
+                "    branches: [main]",
+                "permissions:",
+                '          elif grep -q "DRIFT DETECTED" /tmp/drift-report.txt; then',
+                "          exit 1",
+            ]
+        )
+        self.assertTrue(
+            any("pull_request" in p for p in watch_violations(mutant)),
+            "Mutation FAILED (BP-2): a quoted `'on':` key with a pull_request "
+            "trigger was NOT detected.",
+        )
+
+    def test_comment_only_token_does_not_satisfy_check(self):
+        # BP-5: enforce_admins="true" only in a comment, active value "false".
+        mutant = self._GOOD_SCRIPT.replace(
+            'DESIRED_ENFORCE_ADMINS="true"',
+            '# legacy: DESIRED_ENFORCE_ADMINS="true"\nDESIRED_ENFORCE_ADMINS="false"',
+        )
+        problems = script_violations(mutant)
+        self.assertTrue(
+            problems,
+            "Mutation FAILED (BP-5): enforce_admins='true' surviving only in a "
+            "comment while the active assignment is 'false' was NOT detected.",
+        )
+
+    def test_second_enforce_admins_assignment_is_detected(self):
+        # BP-4: a second last-wins assignment to "false".
+        mutant = self._GOOD_SCRIPT + '\nDESIRED_ENFORCE_ADMINS="false"'
+        self.assertTrue(
+            any("BP-4" in p and "DESIRED_ENFORCE_ADMINS" in p
+                for p in script_violations(mutant)),
+            "Mutation FAILED (BP-4): a duplicate DESIRED_ENFORCE_ADMINS assignment "
+            "(last-wins override) was NOT detected.",
         )
 
     def test_real_files_clean(self):

--- a/scanner/tests/test_ci_dependabot_config.py
+++ b/scanner/tests/test_ci_dependabot_config.py
@@ -1,0 +1,215 @@
+"""
+Regression guard: `.github/dependabot.yml` keeps its dependency-update coverage
+and the load-bearing alpine version freeze.
+
+Background
+----------
+Dependabot is ClaudeSec's supply-chain freshness control: it opens the PRs that
+keep actions, npm, pip, and Docker base images current (OWASP CICD-SEC-3
+Dependency Chain Abuse; NIST SSDF SP 800-218 PW.4). This guard protects two
+things that would silently regress coverage if removed:
+
+  1. **Ecosystem coverage** — all four ecosystems must stay declared:
+     `github-actions`, `npm`, `pip`, `docker`. Deleting one stops that surface
+     from ever receiving update PRs, so it quietly rots (no build failure — the
+     scheduler just goes silent for that ecosystem).
+  2. **Alpine version freeze** — the `docker` ecosystem must keep its `ignore`
+     entry holding `alpine` on its current minor line by excluding
+     `version-update:semver-minor` AND `version-update:semver-major`.
+     This is incident-backed: an alpine minor bump changes the bundled Python
+     (3.24 ships py3.14), and prowler 3.11.3 pins pydantic v1 which cannot run on
+     py>3.12, so `prowler -v` crashes with a pydantic ConfigError. PR #220 proved
+     the alpine 3.20->3.24 build is green but prowler is broken at runtime.
+     Removing the freeze would let Dependabot propose the breaking bump; digest /
+     patch rebuilds of 3.20 still flow.
+
+This is DISTINCT from `test_ci_dependabot_automerge.py`, which guards the
+`dependabot-auto-merge.yml` *workflow* (the pull_request_target auto-arm safety).
+This guard protects the `.github/dependabot.yml` *config* (what gets updated).
+
+Direction: presence (each ecosystem / freeze token must exist). Adding ecosystems
+or tightening the freeze stays green; dropping coverage or loosening the freeze
+trips the guard.
+
+Mutation self-test
+------------------
+`TestDependabotConfigGuardMutation` builds a synthetic known-good config,
+confirms it passes, then verifies each invariant is detected when removed, and
+that the real on-disk config passes cleanly.
+
+stdlib-only (no PyYAML — not in requirements-ci.txt). Substring checks. No
+`scanner/lib` import (does not touch the 99% coverage gate). No network, no
+subprocess. Runs under pytest (the CI runner) and `python3 -m unittest`.
+"""
+
+import unittest
+from pathlib import Path
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEPENDABOT = REPO_ROOT / ".github" / "dependabot.yml"
+
+# Each ecosystem must stay declared, else that surface stops getting update PRs.
+REQUIRED_ECOSYSTEMS = (
+    'package-ecosystem: "github-actions"',
+    'package-ecosystem: "npm"',
+    'package-ecosystem: "pip"',
+    'package-ecosystem: "docker"',
+)
+
+# The alpine freeze: holding alpine on its current minor line. All three tokens
+# must be present (the dependency-name plus BOTH excluded update-types).
+ALPINE_FREEZE_TOKENS = {
+    "alpine_dependency": 'dependency-name: "alpine"',
+    "freeze_minor": "version-update:semver-minor",
+    "freeze_major": "version-update:semver-major",
+}
+
+# Schema sanity.
+SCHEMA_VERSION = "version: 2"
+
+
+def config_violations(text: str) -> list:
+    problems = []
+    if SCHEMA_VERSION not in text:
+        problems.append(f"MISSING dependabot schema marker: {SCHEMA_VERSION!r}")
+    for eco in REQUIRED_ECOSYSTEMS:
+        if eco not in text:
+            problems.append(f"MISSING ecosystem coverage: {eco!r}")
+    for name, tok in sorted(ALPINE_FREEZE_TOKENS.items()):
+        if tok not in text:
+            problems.append(f"MISSING alpine-freeze token [{name}]: {tok!r}")
+    return problems
+
+
+class TestDependabotConfigGuard(unittest.TestCase):
+    """Guards the on-disk .github/dependabot.yml config."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.text = DEPENDABOT.read_text(encoding="utf-8") if DEPENDABOT.is_file() else ""
+
+    def test_config_exists(self):
+        self.assertTrue(
+            DEPENDABOT.is_file(),
+            f"{DEPENDABOT} not found — Dependabot dependency-update coverage has "
+            "been deleted or moved.",
+        )
+
+    def test_all_ecosystems_present(self):
+        missing = [eco for eco in REQUIRED_ECOSYSTEMS if eco not in self.text]
+        self.assertEqual(
+            missing, [],
+            "dependabot.yml dropped ecosystem coverage: "
+            + ", ".join(missing)
+            + " — that surface stops receiving update PRs and silently rots. "
+            "Restore the entry, or update REQUIRED_ECOSYSTEMS with a rationale.",
+        )
+
+    def test_alpine_freeze_intact(self):
+        missing = [
+            f"{name}={tok!r}"
+            for name, tok in sorted(ALPINE_FREEZE_TOKENS.items())
+            if tok not in self.text
+        ]
+        self.assertEqual(
+            missing, [],
+            "The alpine version freeze weakened (missing: "
+            + ", ".join(missing)
+            + "). Without holding alpine on its current minor line, Dependabot "
+            "could propose a bump that ships py3.14 and breaks prowler "
+            "(pydantic v1, incident #220). Restore the ignore entry or update the "
+            "guard once prowler supports py3.13+.",
+        )
+
+    def test_all_invariants_hold(self):
+        problems = config_violations(self.text)
+        self.assertEqual(
+            problems, [],
+            "dependabot.yml lost a supply-chain coverage/freeze invariant:\n  "
+            + "\n  ".join(problems),
+        )
+
+
+class TestDependabotConfigGuardMutation(unittest.TestCase):
+    """Mutation self-tests: the detector must fire on known-bad inputs and stay
+    quiet on the known-good real config."""
+
+    _GOOD = "\n".join(
+        [
+            "version: 2",
+            "updates:",
+            '  - package-ecosystem: "github-actions"',
+            '  - package-ecosystem: "npm"',
+            '  - package-ecosystem: "pip"',
+            '  - package-ecosystem: "docker"',
+            "    ignore:",
+            '      - dependency-name: "alpine"',
+            "        update-types:",
+            '          - "version-update:semver-minor"',
+            '          - "version-update:semver-major"',
+        ]
+    )
+
+    def test_good_config_passes(self):
+        self.assertEqual(
+            config_violations(self._GOOD), [],
+            "Mutation self-test BROKEN: a known-good config reported violations:\n  "
+            + "\n  ".join(config_violations(self._GOOD)),
+        )
+
+    def test_dropping_an_ecosystem_is_detected(self):
+        mutant = self._GOOD.replace('  - package-ecosystem: "docker"\n', "")
+        self.assertTrue(
+            any("docker" in p for p in config_violations(mutant)),
+            "Mutation FAILED: dropping the docker ecosystem was NOT detected.",
+        )
+
+    def test_dropping_pip_is_detected(self):
+        mutant = self._GOOD.replace('  - package-ecosystem: "pip"\n', "")
+        self.assertTrue(
+            any('"pip"' in p for p in config_violations(mutant)),
+            "Mutation FAILED: dropping the pip ecosystem was NOT detected.",
+        )
+
+    def test_loosening_alpine_minor_freeze_is_detected(self):
+        mutant = self._GOOD.replace(
+            '          - "version-update:semver-minor"\n', ""
+        )
+        self.assertTrue(
+            any("freeze_minor" in p for p in config_violations(mutant)),
+            "Mutation FAILED: removing the semver-minor alpine freeze was NOT "
+            "detected.",
+        )
+
+    def test_loosening_alpine_major_freeze_is_detected(self):
+        # No trailing newline: semver-major is the last line of _GOOD.
+        mutant = self._GOOD.replace(
+            '          - "version-update:semver-major"', ""
+        )
+        self.assertTrue(
+            any("freeze_major" in p for p in config_violations(mutant)),
+            "Mutation FAILED: removing the semver-major alpine freeze was NOT "
+            "detected.",
+        )
+
+    def test_removing_alpine_dependency_is_detected(self):
+        mutant = self._GOOD.replace('      - dependency-name: "alpine"\n', "")
+        self.assertTrue(
+            any("alpine_dependency" in p for p in config_violations(mutant)),
+            "Mutation FAILED: removing the alpine ignore entry was NOT detected.",
+        )
+
+    def test_real_config_clean(self):
+        if not DEPENDABOT.is_file():
+            self.skipTest("config not found — covered by TestDependabotConfigGuard")
+        problems = config_violations(DEPENDABOT.read_text(encoding="utf-8"))
+        self.assertEqual(
+            problems, [],
+            "The real .github/dependabot.yml failed the invariant validator:\n  "
+            + "\n  ".join(problems),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_ci_dependabot_config.py
+++ b/scanner/tests/test_ci_dependabot_config.py
@@ -68,17 +68,55 @@ ALPINE_FREEZE_TOKENS = {
 # Schema sanity.
 SCHEMA_VERSION = "version: 2"
 
+# Co-location window (lines): the alpine dependency-name and BOTH excluded
+# update-types must appear within this many lines of each other, i.e. inside one
+# `ignore:` block — not scattered across unrelated blocks (sec-review DC-3).
+FREEZE_WINDOW = 6
+
+
+def _non_comment_lines(text: str) -> list:
+    """Lines with whole-line comments dropped, so a token living only in a
+    comment cannot satisfy a presence check (sec-review DC-1/DC-2/DC-4)."""
+    return [line for line in text.splitlines() if not line.lstrip().startswith("#")]
+
+
+def _alpine_freeze_colocated(lines: list) -> bool:
+    """True if an `alpine` dependency-name line is followed, within FREEZE_WINDOW
+    lines, by BOTH excluded update-types (DC-3: the freeze must be one block)."""
+    for i, line in enumerate(lines):
+        if ALPINE_FREEZE_TOKENS["alpine_dependency"] in line:
+            window = "\n".join(lines[i : i + FREEZE_WINDOW + 1])
+            if (
+                ALPINE_FREEZE_TOKENS["freeze_minor"] in window
+                and ALPINE_FREEZE_TOKENS["freeze_major"] in window
+            ):
+                return True
+    return False
+
 
 def config_violations(text: str) -> list:
+    lines = _non_comment_lines(text)
+    scan = "\n".join(lines)
     problems = []
-    if SCHEMA_VERSION not in text:
+    if SCHEMA_VERSION not in scan:
         problems.append(f"MISSING dependabot schema marker: {SCHEMA_VERSION!r}")
     for eco in REQUIRED_ECOSYSTEMS:
-        if eco not in text:
+        if eco not in scan:
             problems.append(f"MISSING ecosystem coverage: {eco!r}")
     for name, tok in sorted(ALPINE_FREEZE_TOKENS.items()):
-        if tok not in text:
+        if tok not in scan:
             problems.append(f"MISSING alpine-freeze token [{name}]: {tok!r}")
+    # DC-3: all three freeze tokens present but NOT co-located in one ignore
+    # block means the alpine freeze was moved/split and is no longer effective.
+    if (
+        all(tok in scan for tok in ALPINE_FREEZE_TOKENS.values())
+        and not _alpine_freeze_colocated(lines)
+    ):
+        problems.append(
+            "DC-3: alpine-freeze tokens are present but not co-located in a single "
+            f"ignore block (within {FREEZE_WINDOW} lines) — the freeze may have "
+            "been split across unrelated blocks and is no longer effective."
+        )
     return problems
 
 
@@ -198,6 +236,61 @@ class TestDependabotConfigGuardMutation(unittest.TestCase):
         self.assertTrue(
             any("alpine_dependency" in p for p in config_violations(mutant)),
             "Mutation FAILED: removing the alpine ignore entry was NOT detected.",
+        )
+
+    def test_commented_out_ecosystem_is_detected(self):
+        # DC-2: an ecosystem present only in a comment must NOT satisfy the check.
+        mutant = self._GOOD.replace(
+            '  - package-ecosystem: "docker"',
+            '  # - package-ecosystem: "docker"  (removed)',
+        )
+        self.assertTrue(
+            any('"docker"' in p for p in config_violations(mutant)),
+            "Mutation FAILED (DC-2): a commented-out docker ecosystem was NOT "
+            "detected.",
+        )
+
+    def test_commented_alpine_freeze_is_detected(self):
+        # DC-1: the freeze surviving only in a comment must NOT satisfy the check.
+        mutant = self._GOOD.replace(
+            '      - dependency-name: "alpine"',
+            '      # - dependency-name: "alpine"  (freeze removed)',
+        )
+        self.assertTrue(
+            any("alpine_dependency" in p for p in config_violations(mutant)),
+            "Mutation FAILED (DC-1): a commented-out alpine freeze was NOT detected.",
+        )
+
+    def test_non_colocated_alpine_freeze_is_detected(self):
+        # DC-3: alpine dependency-name in one block, the semver tokens in an
+        # unrelated block far away — all three tokens present, freeze ineffective.
+        mutant = "\n".join(
+            [
+                "version: 2",
+                "updates:",
+                '  - package-ecosystem: "github-actions"',
+                '  - package-ecosystem: "npm"',
+                '  - package-ecosystem: "pip"',
+                '  - package-ecosystem: "docker"',
+                "    ignore:",
+                '      - dependency-name: "alpine"',
+                "        update-types: []",
+                "        # padding to push the semver tokens out of the window",
+                "        a: 1",
+                "        b: 2",
+                "        c: 3",
+                "        d: 4",
+                "        e: 5",
+                '      - dependency-name: "some-other-pkg"',
+                "        update-types:",
+                '          - "version-update:semver-minor"',
+                '          - "version-update:semver-major"',
+            ]
+        )
+        self.assertTrue(
+            any("DC-3" in p for p in config_violations(mutant)),
+            "Mutation FAILED (DC-3): a non-co-located (split) alpine freeze was "
+            "NOT detected.",
         )
 
     def test_real_config_clean(self):


### PR DESCRIPTION
Add two Tier-1 CI config regression guards (stdlib-only pytest, run by the
scanner-unit-tests job; no scanner/lib import, no PyYAML):

- test_ci_branch_protection_codified.py — guards scripts/sync-repo-protection.sh
  (#250) + protection-drift-watch.yml (#251): DESIRED_CONTEXTS keeps both
  required checks (Lint + Security Scan Gate), enforce_admins/strict/code-owner
  reviews true, the DRIFT DETECTED marker contract on both producer & consumer
  sides, and the notifier never gains a pull_request(_target) trigger. Parses
  only the on: block so the "MUST NOT run on pull_request" comment never
  false-positives.
- test_ci_dependabot_config.py — guards .github/dependabot.yml: all four
  ecosystems declared + the docker alpine semver-minor/major ignore freeze
  (incident #220). Distinct from test_ci_dependabot_automerge.py (workflow).

Both verified non-vacuous against synthetic snippets AND the real on-disk files.
Add catalog rows and an "Unguarded invariants backlog" section (Tier 2: prowler
version pin, Dockerfile base pin) to docs/devsecops/ci-config-regression-guards.md.

Maps to OWASP CICD-SEC-1/-7 and NIST SSDF PO.3/PW.4. 118 test_ci_* tests pass.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
