### PR TITLE
test(ci): guard prowler version pin + Dockerfile base pins (Tier 2)

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -58,6 +58,8 @@ All guards follow the same rules (see the existing files for reference):
 | `scanner/tests/test_ci_catalog_no_ghost_rows.py` | No ghost rows in this catalog vs the on-disk guard suite | every concrete `scanner/tests/test_ci_<name>.py` path cited in this catalog resolves to a real file (existence) — the reverse of the completeness guard: a renamed/deleted guard left in the table is a ghost row that makes the inventory overstate coverage. Together the two guards verify a 1:1 catalog↔suite mapping | #255 |
 | `scanner/tests/test_ci_branch_protection_codified.py` | Codified branch protection (`scripts/sync-repo-protection.sh`) + its nightly notifier (`protection-drift-watch.yml`) | the desired state keeps `DESIRED_CONTEXTS=["Lint","Security Scan Gate"]` (both required checks), `DESIRED_ENFORCE_ADMINS="true"` (admins not exempt — no force-push to main), `strict`/`require_code_owner_reviews` true, `set -euo pipefail`, and the default-arm dry-run; the `DRIFT DETECTED` marker contract holds on both producer (script) and consumer (`grep -q`) sides; the watch keeps `schedule:` + tooling-error `exit 1` and its `on:` block never gains a `pull_request(_target)` trigger (scheduled notifier, must not become a required PR check). Protects the #250/#251 codification | #256 |
 | `scanner/tests/test_ci_dependabot_config.py` | `.github/dependabot.yml` update coverage + alpine version freeze | all four ecosystems stay declared (`github-actions`, `npm`, `pip`, `docker`) so no surface silently stops getting update PRs (OWASP CICD-SEC-3); the `docker` `ignore` keeps the `alpine` `semver-minor`+`semver-major` freeze that holds alpine on its py3.12 minor line — loosening it would let Dependabot propose the bump that ships py3.14 and crashes prowler (pydantic v1, incident #220). Distinct from `test_ci_dependabot_automerge.py` (guards the *workflow*, not this *config*) | #256 |
+| `scanner/tests/test_ci_prowler_version_pinned.py` | prowler install pin in `Dockerfile` | prowler is installed via an exact `==` pin through the `PROWLER_VERSION` build arg (version-shaped value), never a bare unpinned `pip install ... prowler`. An unpinned spec silently backtracks to ancient prowler 3.11.3 (pydantic v1) on a newer Python and crashes at runtime (incident #237). Pins the *pinning*, so a lockstep version bump stays green | #257 |
+| `scanner/tests/test_ci_dockerfile_base_pinned.py` | Container base-image pins (`Dockerfile`, `Dockerfile.nginx`) | every `FROM` carries an `@sha256:` digest (OWASP A08 — no moving-tag swap); the prowler `Dockerfile` holds every `FROM alpine:` on the `alpine:3.20` (py3.12) minor line and resolves site-packages with the version-agnostic `find ... -name 'python3.*'` glob (no hardcoded `python3.<n>/site-packages`, #234). Complements `test_ci_dependabot_config.py` (config freeze policy) by locking the actual image | #257 |
 
 ### Related enforcement (not a pytest guard)
 
@@ -92,12 +94,14 @@ triaged by the same bar used to add one (an incident, past or plausible, where
 *silent* weakening disables enforcement — no incident means it likely is not
 worth a guard, to avoid sprawl). Reviewed 2026-06-19.
 
-### Tier 2 — incident-backed, worth a guard next
+### Tier 2 — incident-backed (now implemented)
 
-| Candidate guard | Invariant | Incident / rationale |
-|-----------------|-----------|----------------------|
-| `test_ci_prowler_version_pinned.py` | `Dockerfile` keeps the **exact** `prowler==` pin (`PROWLER_VERSION`, currently `5.30.1`) — equality, not a floor | #237: an unpinned prowler drifted; prowler 3.11.3/pydantic-v1 cannot run on py3.13+, so an unpinned bump silently breaks `prowler -v` at runtime. Complements the alpine freeze (`test_ci_dependabot_config.py`) and the provider-ordering guard (`test_ci_prowler_provider_guard_ordering.py`). |
-| `test_ci_dockerfile_base_pinned.py` | `Dockerfile`/`Dockerfile.nginx` keep their `alpine:3.20` (py3.12) base pin and stay version-agnostic | #233/#234/#220: a minor alpine bump ships py3.14 and crashes prowler. The dependabot guard locks the *freeze policy* in `dependabot.yml`; this would lock the *actual image* a manual edit could still bump. |
+Both former Tier-2 candidates landed in #257 and are now in the Catalog above:
+
+- `test_ci_prowler_version_pinned.py` — exact `prowler==${PROWLER_VERSION}` pin
+  in `Dockerfile` (#237).
+- `test_ci_dockerfile_base_pinned.py` — `@sha256:` digest pins + `alpine:3.20`
+  minor freeze + version-agnostic site resolution (#233/#234/#220).
 
 ### Tier 3 — monitor only (no guard yet; would be sprawl)
 

--- a/scanner/tests/test_ci_dockerfile_base_pinned.py
+++ b/scanner/tests/test_ci_dockerfile_base_pinned.py
@@ -1,0 +1,215 @@
+"""
+Regression guard: container base images stay supply-chain pinned, and the
+prowler image stays held on the alpine 3.20 (py3.12) line and Python-version
+agnostic.
+
+Background
+----------
+Two invariants protect the ClaudeSec images (OWASP Top 10:2021 A08 — Software
+and Data Integrity Failures; NIST SSDF SP 800-218 PW.4):
+
+  1. **Digest-pinned bases** — every `FROM` in `Dockerfile` and `Dockerfile.nginx`
+     must carry an `@sha256:` digest, so a moving tag cannot swap the base image
+     out from under a "reproducible" build.
+  2. **alpine MINOR freeze + version-agnostic resolution** — in the prowler
+     `Dockerfile`, every `FROM alpine:` must stay `alpine:3.20@sha256:...`
+     (py3.12). A minor bump ships a newer Python (3.24 → py3.14) on which prowler
+     3.11.3 / pydantic v1 crashes (#220/#237). And the build must resolve
+     site-packages with the version-agnostic `find ... -name 'python3.*'` glob
+     (#234) rather than a hardcoded `python3.12/site-packages` path — a hardcoded
+     path would break the build the moment the base Python changes, defeating the
+     graceful-bump design.
+
+`Dockerfile.nginx` uses a *different* base (`nginx:*-alpine`), so the alpine-3.20
+minor freeze applies only to the prowler `Dockerfile`; the digest-pin invariant
+applies to both. This guard complements `test_ci_dependabot_config.py` (which
+locks the *freeze policy* in `dependabot.yml`) by locking the *actual image* a
+manual edit could still bump.
+
+Direction: alpine minor `== 3.20` (a bump trips); digest pin = presence of
+`@sha256:`; version-agnostic = presence of the `python3.*` glob + absence of a
+hardcoded `python3.<n>/site-packages` path. Bumping prowler/alpine in lockstep
+once prowler supports py3.13+ means updating this guard with a rationale.
+
+Mutation self-test
+------------------
+`TestDockerfileBasePinnedMutation` builds synthetic snippets and confirms the
+detector fires on an un-digest-pinned FROM, a bumped alpine minor, and a
+hardcoded python3.N path, and stays quiet on the known-good form and the real
+on-disk Dockerfiles.
+
+stdlib-only (no PyYAML). Regex/line scanning. No `scanner/lib` import (does not
+touch the 99% coverage gate). No network, no subprocess. Runs under pytest (the
+CI runner) and `python3 -m unittest`.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+DOCKERFILE_NGINX = REPO_ROOT / "Dockerfile.nginx"
+
+# A `FROM <image>[ AS stage]` line. Group 1 = the image ref (everything up to an
+# optional ` AS name` suffix).
+FROM_RE = re.compile(r"^\s*FROM\s+(\S+)(?:\s+AS\s+\S+)?\s*$", re.MULTILINE | re.IGNORECASE)
+
+# Version-agnostic site-packages resolution (#234).
+VERSION_AGNOSTIC_RE = re.compile(r"-name\s+'python3\.\*'")
+# A hardcoded python minor in a site-packages path — the regression #234 removed.
+HARDCODED_PY_PATH_RE = re.compile(r"python3\.\d+/site-packages")
+
+
+def from_refs(text: str) -> list:
+    return FROM_RE.findall(text)
+
+
+def digest_violations(text: str, label: str) -> list:
+    """Every FROM must be @sha256: digest pinned."""
+    problems = []
+    refs = from_refs(text)
+    if not refs:
+        problems.append(f"[{label}] no FROM line found — Dockerfile moved or emptied.")
+    for ref in refs:
+        if "@sha256:" not in ref:
+            problems.append(
+                f"[{label}] FROM {ref!r} is not digest-pinned (@sha256:) — a moving "
+                "tag could swap the base image (OWASP A08)."
+            )
+    return problems
+
+
+def alpine_freeze_violations(text: str) -> list:
+    """Every alpine FROM in the prowler Dockerfile must stay alpine:3.20@sha256:."""
+    problems = []
+    for ref in from_refs(text):
+        if ref.startswith("alpine:") or ref.startswith("alpine@"):
+            if not ref.startswith("alpine:3.20@sha256:"):
+                problems.append(
+                    f"FROM {ref!r} drifted off the alpine:3.20 (py3.12) line — a "
+                    "minor bump ships a newer Python and crashes prowler "
+                    "(pydantic v1, #220/#237). Hold alpine on 3.20 until prowler "
+                    "supports py3.13+."
+                )
+    return problems
+
+
+def version_agnostic_violations(text: str) -> list:
+    problems = []
+    if not VERSION_AGNOSTIC_RE.search(text):
+        problems.append(
+            "version-agnostic site-packages resolution (find ... -name "
+            "'python3.*') is gone — restore it so an alpine base bump does not "
+            "break the build (#234)."
+        )
+    if HARDCODED_PY_PATH_RE.search(text):
+        problems.append(
+            "a hardcoded pythonX.Y/site-packages path was re-introduced — this is "
+            "the #234 regression; use the version-agnostic glob instead."
+        )
+    return problems
+
+
+class TestDockerfileBasePinned(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.df = DOCKERFILE.read_text(encoding="utf-8") if DOCKERFILE.is_file() else ""
+        cls.nginx = (
+            DOCKERFILE_NGINX.read_text(encoding="utf-8")
+            if DOCKERFILE_NGINX.is_file()
+            else ""
+        )
+
+    def test_dockerfile_exists(self):
+        self.assertTrue(DOCKERFILE.is_file(), f"{DOCKERFILE} not found.")
+
+    def test_dockerfile_nginx_exists(self):
+        self.assertTrue(DOCKERFILE_NGINX.is_file(), f"{DOCKERFILE_NGINX} not found.")
+
+    def test_all_from_lines_digest_pinned(self):
+        problems = digest_violations(self.df, "Dockerfile") + digest_violations(
+            self.nginx, "Dockerfile.nginx"
+        )
+        self.assertEqual(
+            problems, [],
+            "A base image lost its digest pin:\n  " + "\n  ".join(problems),
+        )
+
+    def test_alpine_minor_frozen_at_320(self):
+        problems = alpine_freeze_violations(self.df)
+        self.assertEqual(
+            problems, [],
+            "The prowler Dockerfile alpine base drifted:\n  " + "\n  ".join(problems),
+        )
+
+    def test_version_agnostic_site_resolution(self):
+        problems = version_agnostic_violations(self.df)
+        self.assertEqual(
+            problems, [],
+            "The prowler Dockerfile lost its version-agnostic site resolution:\n  "
+            + "\n  ".join(problems),
+        )
+
+
+class TestDockerfileBasePinnedMutation(unittest.TestCase):
+    _GOOD = "\n".join(
+        [
+            "FROM alpine:3.20@sha256:deadbeef AS builder",
+            "ARG PROWLER_VERSION=5.30.1",
+            "RUN SITE=\"$(find /install/lib -maxdepth 1 -type d -name 'python3.*' | head -n1)/site-packages\"",
+            "FROM alpine:3.20@sha256:deadbeef",
+        ]
+    )
+    _GOOD_NGINX = "FROM nginx:1.31-alpine@sha256:cafef00d"
+
+    def test_good_passes(self):
+        self.assertEqual(digest_violations(self._GOOD, "df"), [])
+        self.assertEqual(digest_violations(self._GOOD_NGINX, "nginx"), [])
+        self.assertEqual(alpine_freeze_violations(self._GOOD), [])
+        self.assertEqual(version_agnostic_violations(self._GOOD), [])
+
+    def test_untagged_digest_is_detected(self):
+        mutant = self._GOOD.replace("alpine:3.20@sha256:deadbeef AS builder", "alpine:3.20 AS builder")
+        self.assertTrue(
+            any("not digest-pinned" in p for p in digest_violations(mutant, "df")),
+            "Mutation FAILED: a FROM without @sha256: digest was NOT detected.",
+        )
+
+    def test_alpine_minor_bump_is_detected(self):
+        mutant = self._GOOD.replace(
+            "alpine:3.20@sha256:deadbeef AS builder",
+            "alpine:3.24@sha256:deadbeef AS builder",
+        )
+        self.assertTrue(
+            any("3.20" in p for p in alpine_freeze_violations(mutant)),
+            "Mutation FAILED: an alpine minor bump (3.20 -> 3.24) was NOT detected.",
+        )
+
+    def test_hardcoded_python_path_is_detected(self):
+        mutant = self._GOOD.replace(
+            "find /install/lib -maxdepth 1 -type d -name 'python3.*' | head -n1)/site-packages",
+            "echo /install/lib/python3.12/site-packages",
+        )
+        self.assertTrue(
+            any("hardcoded" in p for p in version_agnostic_violations(mutant)),
+            "Mutation FAILED: a hardcoded python3.12/site-packages path was NOT "
+            "detected.",
+        )
+
+    def test_real_dockerfiles_clean(self):
+        if DOCKERFILE.is_file():
+            df = DOCKERFILE.read_text(encoding="utf-8")
+            self.assertEqual(digest_violations(df, "Dockerfile"), [])
+            self.assertEqual(alpine_freeze_violations(df), [])
+            self.assertEqual(version_agnostic_violations(df), [])
+        if DOCKERFILE_NGINX.is_file():
+            self.assertEqual(
+                digest_violations(DOCKERFILE_NGINX.read_text(encoding="utf-8"), "Dockerfile.nginx"),
+                [],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_ci_prowler_version_pinned.py
+++ b/scanner/tests/test_ci_prowler_version_pinned.py
@@ -1,0 +1,174 @@
+"""
+Regression guard: prowler is installed from an EXACT version pin in `Dockerfile`,
+never an unpinned/floating spec.
+
+Background
+----------
+The ClaudeSec image installs the prowler CLI so the prowler/cloud scanner
+categories can run. prowler's resolvable version depends on the base image's
+Python: on alpine 3.20 (py3.12) an UNPINNED `pip install prowler` resolves to a
+modern release, but on a newer Python (py3.13/3.14) pip silently backtracks to
+ancient prowler 3.11.3 (pydantic v1) instead of failing fast — which then
+crashes at runtime (`prowler -v` → pydantic ConfigError). PR #237 fixed this by
+pinning prowler explicitly; the Dockerfile comment documents the lockstep
+relationship with the alpine freeze (#220).
+
+The load-bearing invariant is therefore: **prowler must be installed via an
+exact `==` pin (through the `PROWLER_VERSION` build arg), never as a bare
+unpinned `prowler` spec.** Silent removal of the pin would re-introduce the #237
+drift with no build failure. This complements:
+  - `test_ci_dependabot_config.py` — locks the alpine MINOR freeze policy.
+  - `test_ci_prowler_provider_guard_ordering.py` — locks the runtime provider
+    skip ordering.
+
+Direction: presence of an exact `==` pin + a concrete `PROWLER_VERSION` value;
+absence of any unpinned `pip install ... prowler` spec. A legitimate version
+bump (`5.30.1` → `5.31.0`) stays green — the guard pins the *pinning*, not a
+specific number — but un-pinning trips it. (The exact number is asserted to be
+present and version-shaped so a blank/placeholder arg cannot pass.)
+
+Mutation self-test
+------------------
+`TestProwlerVersionPinnedMutation` builds synthetic known-good/known-bad
+Dockerfile snippets and confirms the detector fires on the un-pinned forms and
+stays quiet on the pinned form and the real on-disk Dockerfile.
+
+stdlib-only (no PyYAML). Regex/substring scanning. No `scanner/lib` import (does
+not touch the 99% coverage gate). No network, no subprocess. Runs under pytest
+(the CI runner) and `python3 -m unittest`.
+"""
+
+import re
+import unittest
+from pathlib import Path
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+# `ARG PROWLER_VERSION=<x.y.z>` — the pin value must be version-shaped, not blank
+# or a placeholder. Matches e.g. ARG PROWLER_VERSION=5.30.1
+ARG_PIN_RE = re.compile(r"^\s*ARG\s+PROWLER_VERSION=(\d+\.\d+(?:\.\d+)?)\s*$", re.MULTILINE)
+
+# The install must use the pinned form: prowler==${PROWLER_VERSION} (or an
+# inline ==<version>). We match a `prowler==` immediately followed by either the
+# build arg or a literal version.
+PINNED_INSTALL_RE = re.compile(r"prowler==(?:\$\{PROWLER_VERSION\}|\d+\.\d+)")
+
+# Any `pip install ... prowler` where the prowler token is NOT followed by `==`
+# (i.e. unpinned / floating). This is the #237 regression we forbid.
+UNPINNED_INSTALL_RE = re.compile(
+    r"pip install[^\n]*?(?<![=\w])prowler(?!==)(?![=\w/.-])"
+)
+
+
+def violations(text: str) -> list:
+    problems = []
+    m = ARG_PIN_RE.search(text)
+    if not m:
+        problems.append(
+            "MISSING exact ARG PROWLER_VERSION=<x.y.z> pin (unpinned prowler "
+            "re-introduces the #237 py3.13 backtrack-to-3.11.3 crash)."
+        )
+    if not PINNED_INSTALL_RE.search(text):
+        problems.append(
+            "MISSING pinned install form prowler==${PROWLER_VERSION} (or "
+            "prowler==<version>)."
+        )
+    if UNPINNED_INSTALL_RE.search(text):
+        problems.append(
+            "FORBIDDEN unpinned `pip install ... prowler` spec found — prowler "
+            "must always be installed with an exact == pin."
+        )
+    return problems
+
+
+class TestProwlerVersionPinned(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.text = DOCKERFILE.read_text(encoding="utf-8") if DOCKERFILE.is_file() else ""
+
+    def test_dockerfile_exists(self):
+        self.assertTrue(
+            DOCKERFILE.is_file(),
+            f"{DOCKERFILE} not found — the prowler install (and its pin) moved or "
+            "was deleted.",
+        )
+
+    def test_arg_pin_present_and_version_shaped(self):
+        m = ARG_PIN_RE.search(self.text)
+        self.assertIsNotNone(
+            m,
+            "ARG PROWLER_VERSION=<x.y.z> not found or not version-shaped — prowler "
+            "would be unpinned and could silently backtrack to 3.11.3 on a newer "
+            "Python (incident #237). Restore the exact pin.",
+        )
+
+    def test_install_uses_pinned_form(self):
+        self.assertRegex(
+            self.text, PINNED_INSTALL_RE,
+            "The prowler install no longer uses the prowler==${PROWLER_VERSION} "
+            "pinned form.",
+        )
+
+    def test_no_unpinned_install(self):
+        self.assertNotRegex(
+            self.text, UNPINNED_INSTALL_RE,
+            "An unpinned `pip install ... prowler` spec is present — that is the "
+            "exact #237 regression. Pin it with ==${PROWLER_VERSION}.",
+        )
+
+    def test_all_invariants_hold(self):
+        problems = violations(self.text)
+        self.assertEqual(
+            problems, [],
+            "Dockerfile weakened the prowler version pin:\n  " + "\n  ".join(problems),
+        )
+
+
+class TestProwlerVersionPinnedMutation(unittest.TestCase):
+    _GOOD = "\n".join(
+        [
+            "ARG PROWLER_VERSION=5.30.1",
+            'RUN pip install --no-cache-dir --break-system-packages "prowler==${PROWLER_VERSION}" \\',
+            "    && find /install -type d -name tests -exec rm -rf {} +",
+        ]
+    )
+
+    def test_good_passes(self):
+        self.assertEqual(violations(self._GOOD), [])
+
+    def test_removing_arg_pin_is_detected(self):
+        mutant = self._GOOD.replace("ARG PROWLER_VERSION=5.30.1\n", "")
+        self.assertTrue(
+            any("ARG PROWLER_VERSION" in p for p in violations(mutant)),
+            "Mutation FAILED: removing the ARG pin was NOT detected.",
+        )
+
+    def test_blank_arg_pin_is_detected(self):
+        mutant = self._GOOD.replace("ARG PROWLER_VERSION=5.30.1", "ARG PROWLER_VERSION=")
+        self.assertTrue(
+            any("ARG PROWLER_VERSION" in p for p in violations(mutant)),
+            "Mutation FAILED: a blank/placeholder ARG pin was NOT detected.",
+        )
+
+    def test_unpinned_install_is_detected(self):
+        mutant = self._GOOD.replace('"prowler==${PROWLER_VERSION}"', "prowler")
+        problems = violations(mutant)
+        self.assertTrue(
+            any("unpinned" in p.lower() for p in problems),
+            "Mutation FAILED: an unpinned `pip install ... prowler` was NOT "
+            "detected.\n  " + "\n  ".join(problems),
+        )
+
+    def test_real_dockerfile_clean(self):
+        if not DOCKERFILE.is_file():
+            self.skipTest("Dockerfile not found — covered by TestProwlerVersionPinned")
+        self.assertEqual(
+            violations(DOCKERFILE.read_text(encoding="utf-8")), [],
+            "The real Dockerfile failed the prowler-pin validator.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Stacked on #256. Implements the two **Tier-2 backlog** guards triaged in #256's "Unguarded invariants backlog" section.

- **`test_ci_prowler_version_pinned.py`** — `Dockerfile` installs prowler via an exact `==${PROWLER_VERSION}` pin (version-shaped arg), never a bare unpinned `pip install ... prowler`. Forbids the **#237** regression (unpinned prowler backtracks to 3.11.3 / pydantic v1 on a newer Python → runtime crash). Pins the *pinning*, so a lockstep version bump stays green.
- **`test_ci_dockerfile_base_pinned.py`** — every `FROM` in `Dockerfile`/`Dockerfile.nginx` is `@sha256:` digest-pinned (OWASP A08); the prowler image holds every `alpine` `FROM` on `alpine:3.20` (py3.12) and keeps the version-agnostic `find ... -name 'python3.*'` site resolution (no hardcoded `python3.<n>/site-packages`, **#234**).

Both complement `test_ci_dependabot_config.py` (config freeze policy) by locking the *actual image*.

## Test plan

- [x] `pytest scanner/tests/test_ci_*.py` → 138 passed (18 guard files)
- [x] Dual-runner: pass under `python3 -m unittest`
- [x] Non-vacuous against synthetic snippets **and** the real Dockerfiles (un-pin / digest-strip / alpine-minor-bump / hardcoded-py-path all fire)
- [x] Catalog completeness + no-ghost meta-guards green
- [x] `markdownlint` + `lychee` clean on the catalog doc

> Note: base is the #256 branch (stacked). Rebase onto `main` once #256 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)