### PR TITLE
refactor(ci): extract shared CI-guard helpers into _ci_guard_util.py

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -37,6 +37,15 @@ All guards follow the same rules (see the existing files for reference):
 - **Non-vacuous**: prove the guard fires on the regression it targets (simulate
   it) before shipping. Avoid regexes that match commentary in the workflow.
 - **Dual-runner**: pass under both `pytest` (CI) and `python3 -m unittest`.
+- **Shared primitives**: comment-stripping, continuation-joining, and `on:`-block
+  extraction live in `scanner/tests/_ci_guard_util.py` (`strip_comment_lines`,
+  `non_comment_lines`, `join_continuations`, `extract_on_block`). Import them as a
+  top-level module after putting the test dir on `sys.path` so they resolve under
+  both runners. The `_`-prefixed name keeps the module out of pytest collection
+  and the `test_ci_*.py` catalog glob (no Catalog row needed). **Always strip
+  comments and scope tokens** before a presence check — a token in a `#` comment
+  or a second weaker assignment must not satisfy an invariant (the false-negative
+  class hardened across these guards).
 
 ## Catalog
 

--- a/scanner/tests/_ci_guard_util.py
+++ b/scanner/tests/_ci_guard_util.py
@@ -1,0 +1,98 @@
+"""
+Shared text-scanning helpers for the `test_ci_*.py` CI config regression guards.
+
+WHY THIS FILE EXISTS
+--------------------
+The guards harden the same false-negative classes the same way: drop `#`
+comment lines before a token-presence check (so a token surviving only in a
+comment cannot satisfy an invariant), join backslash line-continuations (so a
+wrapped instruction is still seen as one command), and locate a workflow's
+top-level `on:` trigger block (handling flow-style and quoted keys). Those
+primitives were introduced independently — `_strip_comment_lines` /
+`_extract_on_block` (branch-protection), `_non_comment_lines` (dependabot),
+`_active_text` (prowler), `_no_comments` (dockerfile) — with divergent
+implementations. This module is the single canonical home so the hardening stays
+consistent across guards and future guards can reuse it.
+
+CONSTRAINTS (same as every guard)
+---------------------------------
+- **stdlib-only** — no PyYAML, no third-party imports.
+- **Not `scanner/lib`** — lives under `scanner/tests/`, so it never touches the
+  99% `scanner/lib` coverage gate.
+- **Not collected / not catalogued** — the leading underscore and absence of a
+  `test_` prefix keep pytest from collecting it, and it does not match the
+  `test_ci_*.py` glob the catalog meta-guards enforce (so it needs no Catalog
+  row).
+
+IMPORT CONTRACT (dual-runner)
+-----------------------------
+Guards put their own directory on `sys.path` and import this as a top-level
+module, which works under BOTH pytest (prepend import mode) and
+`python3 -m unittest scanner.tests.<mod>` (namespace-package import from repo
+root):
+
+    import sys
+    from pathlib import Path
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from _ci_guard_util import strip_comment_lines, extract_on_block
+"""
+
+
+def non_comment_lines(text: str) -> list:
+    """The lines of `text` with whole-line `#` comments dropped."""
+    return [line for line in text.splitlines() if not line.lstrip().startswith("#")]
+
+
+def strip_comment_lines(text: str) -> str:
+    """`text` with whole-line `#` comments removed, so a token living only in a
+    comment cannot satisfy a presence check."""
+    return "\n".join(non_comment_lines(text))
+
+
+def join_continuations(text: str) -> str:
+    """Join backslash-newline line continuations onto one line, so a shell/Docker
+    instruction that wraps an argument onto the next line is seen as one command
+    (e.g. `RUN pip install \\` + `prowler`)."""
+    return text.replace("\\\n", " ")
+
+
+def on_key_inline(line: str):
+    """If `line` is a top-level GitHub Actions `on:` mapping key — bare or quoted
+    (`on:` / `'on':` / `"on":`) — return the text after the colon (possibly empty,
+    or flow-style content like `[push, pull_request]`). Otherwise return None.
+
+    Only un-indented lines qualify: a nested `on:` under another key is not the
+    workflow trigger."""
+    s = line.rstrip()
+    if s != s.lstrip():  # indented → not a top-level key
+        return None
+    for key in ("on:", "'on':", '"on":'):
+        if s == key:
+            return ""
+        if s.startswith(key):
+            return s[len(key):]
+    return None
+
+
+def extract_on_block(text: str) -> str:
+    """Return a workflow's top-level `on:` trigger content: the inline remainder
+    of the `on:` line (flow style) PLUS the indented child lines under it, up to
+    the next top-level key. Whole-line comments are dropped so prose mentioning a
+    trigger is never matched, and bare/quoted `on:` keys are both handled."""
+    body = []
+    in_on = False
+    for line in text.splitlines():
+        if line.lstrip().startswith("#"):
+            continue
+        if not in_on:
+            inline = on_key_inline(line)
+            if inline is not None:
+                in_on = True
+                if inline.strip():
+                    body.append(inline)  # flow-style content on the `on:` line
+            continue
+        # A new top-level key (non-space first char, non-empty) ends the block.
+        if line and not line[0].isspace():
+            break
+        body.append(line)
+    return "\n".join(body)

--- a/scanner/tests/test_ci_branch_protection_codified.py
+++ b/scanner/tests/test_ci_branch_protection_codified.py
@@ -65,6 +65,7 @@ subprocess. Runs under pytest (the CI runner) and `python3 -m unittest`.
 """
 
 import re
+import sys
 import unittest
 from pathlib import Path
 
@@ -72,6 +73,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = REPO_ROOT / "scripts" / "sync-repo-protection.sh"
 WATCH = REPO_ROOT / ".github" / "workflows" / "protection-drift-watch.yml"
+
+# Shared guard primitives (comment-stripping, on:-block extraction). Import as a
+# top-level module so it resolves under both pytest and `python3 -m unittest`.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import extract_on_block, strip_comment_lines  # noqa: E402
 
 # Literal desired-state assignments that MUST be present verbatim in the script.
 # Tightening the posture (e.g. adding a context) is allowed; weakening any of
@@ -114,58 +120,8 @@ BOOLEAN_DESIRED = {
 _ASSIGN_RE = re.compile(r'^\s*(DESIRED_\w+)=["\']?([^"\'\s#]+)')
 
 
-def _strip_comment_lines(text: str) -> str:
-    """Drop whole-line comments (lstrip starts with '#') so a token that lives
-    only in a comment cannot satisfy a presence check (sec-review BP-5/BP-8)."""
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-
-
-def _on_key_inline(line: str):
-    """If `line` is a top-level `on:` mapping key (bare or quoted, BP-2), return
-    the text after the colon — possibly empty, or flow-style content like
-    `[push, pull_request]` (BP-1). Otherwise return None."""
-    s = line.rstrip()
-    # Only top-level keys (no leading indentation) are real `on:` triggers.
-    if s != s.lstrip():
-        return None
-    for key in ("on:", "'on':", '"on":'):
-        if s == key:
-            return ""
-        if s.startswith(key):
-            return s[len(key):]
-    return None
-
-
-def _extract_on_block(text: str) -> str:
-    """Return the workflow's top-level `on:` trigger content: the inline
-    remainder of the `on:` line (flow style, BP-1) PLUS the indented child lines
-    under it, up to the next top-level key. Whole-line comments are dropped so
-    prose like '# ... MUST NOT run on pull_request events' is never matched, and
-    bare/quoted `on:` keys are both handled (BP-2)."""
-    body = []
-    in_on = False
-    for line in text.splitlines():
-        if line.lstrip().startswith("#"):
-            continue
-        if not in_on:
-            inline = _on_key_inline(line)
-            if inline is not None:
-                in_on = True
-                if inline.strip():
-                    body.append(inline)  # flow-style content on the `on:` line
-            continue
-        # Inside the on: block. A new top-level key (non-space first char,
-        # non-empty) ends it.
-        if line and not line[0].isspace():
-            break
-        body.append(line)
-    return "\n".join(body)
-
-
 def script_violations(text: str) -> list:
-    scan = _strip_comment_lines(text)
+    scan = strip_comment_lines(text)
     problems = [
         f"MISSING required script invariant [{name}]: {tok!r}"
         for name, tok in sorted(REQUIRED_SCRIPT_TOKENS.items())
@@ -193,7 +149,7 @@ def script_violations(text: str) -> list:
 
 
 def watch_violations(text: str) -> list:
-    scan = _strip_comment_lines(text)
+    scan = strip_comment_lines(text)
     problems = [
         f"MISSING required watch invariant [{name}]: {tok!r}"
         for name, tok in sorted(REQUIRED_WATCH_TOKENS.items())
@@ -201,7 +157,7 @@ def watch_violations(text: str) -> list:
     ]
     # Bare `pull_request` substring catches both `pull_request:` (block style) and
     # flow-style `[push, pull_request]`, and subsumes `pull_request_target`.
-    if "pull_request" in _extract_on_block(text):
+    if "pull_request" in extract_on_block(text):
         problems.append(
             "FORBIDDEN pull_request(_target) trigger in the on: block — the drift "
             "watch is a scheduled notifier and must never become a PR status check."
@@ -281,7 +237,7 @@ class TestBranchProtectionCodified(unittest.TestCase):
         )
 
     def test_notifier_has_no_pr_trigger(self):
-        on_block = _extract_on_block(self.watch)
+        on_block = extract_on_block(self.watch)
         self.assertNotIn(
             "pull_request", on_block,
             "protection-drift-watch.yml gained a pull_request(_target) trigger in "

--- a/scanner/tests/test_ci_dependabot_config.py
+++ b/scanner/tests/test_ci_dependabot_config.py
@@ -42,12 +42,18 @@ stdlib-only (no PyYAML — not in requirements-ci.txt). Substring checks. No
 subprocess. Runs under pytest (the CI runner) and `python3 -m unittest`.
 """
 
+import sys
 import unittest
 from pathlib import Path
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEPENDABOT = REPO_ROOT / ".github" / "dependabot.yml"
+
+# Shared guard primitive (comment-stripping). Import as a top-level module so it
+# resolves under both pytest and `python3 -m unittest`.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import non_comment_lines  # noqa: E402
 
 # Each ecosystem must stay declared, else that surface stops getting update PRs.
 REQUIRED_ECOSYSTEMS = (
@@ -74,12 +80,6 @@ SCHEMA_VERSION = "version: 2"
 FREEZE_WINDOW = 6
 
 
-def _non_comment_lines(text: str) -> list:
-    """Lines with whole-line comments dropped, so a token living only in a
-    comment cannot satisfy a presence check (sec-review DC-1/DC-2/DC-4)."""
-    return [line for line in text.splitlines() if not line.lstrip().startswith("#")]
-
-
 def _alpine_freeze_colocated(lines: list) -> bool:
     """True if an `alpine` dependency-name line is followed, within FREEZE_WINDOW
     lines, by BOTH excluded update-types (DC-3: the freeze must be one block)."""
@@ -95,7 +95,7 @@ def _alpine_freeze_colocated(lines: list) -> bool:
 
 
 def config_violations(text: str) -> list:
-    lines = _non_comment_lines(text)
+    lines = non_comment_lines(text)
     scan = "\n".join(lines)
     problems = []
     if SCHEMA_VERSION not in scan:

--- a/scanner/tests/test_ci_dockerfile_base_pinned.py
+++ b/scanner/tests/test_ci_dockerfile_base_pinned.py
@@ -44,6 +44,7 @@ CI runner) and `python3 -m unittest`.
 """
 
 import re
+import sys
 import unittest
 from pathlib import Path
 
@@ -51,6 +52,11 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = REPO_ROOT / "Dockerfile"
 DOCKERFILE_NGINX = REPO_ROOT / "Dockerfile.nginx"
+
+# Shared guard primitive (comment-stripping). Import as a top-level module so it
+# resolves under both pytest and `python3 -m unittest`.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_comment_lines  # noqa: E402
 
 # A `FROM [--flag=...]... <image>[ AS stage]` line. Group 1 = the image ref.
 # The `(?:--\S+\s+)*` prefix skips build flags like `--platform=$BUILDPLATFORM`
@@ -65,16 +71,8 @@ VERSION_AGNOSTIC_RE = re.compile(r"-name\s+'python3\.\*'")
 HARDCODED_PY_PATH_RE = re.compile(r"python3\.\d+/site-packages")
 
 
-def _no_comments(text: str) -> str:
-    """Drop whole-line `#` comments so a token in a comment cannot satisfy (or
-    falsely trip) a check (sec-review Finding 6)."""
-    return "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-
-
 def from_refs(text: str) -> list:
-    return FROM_RE.findall(_no_comments(text))
+    return FROM_RE.findall(strip_comment_lines(text))
 
 
 def digest_violations(text: str, label: str) -> list:
@@ -109,7 +107,7 @@ def alpine_freeze_violations(text: str) -> list:
 
 def version_agnostic_violations(text: str) -> list:
     problems = []
-    active = _no_comments(text)
+    active = strip_comment_lines(text)
     if not VERSION_AGNOSTIC_RE.search(active):
         problems.append(
             "version-agnostic site-packages resolution (find ... -name "

--- a/scanner/tests/test_ci_prowler_version_pinned.py
+++ b/scanner/tests/test_ci_prowler_version_pinned.py
@@ -39,12 +39,18 @@ not touch the 99% coverage gate). No network, no subprocess. Runs under pytest
 """
 
 import re
+import sys
 import unittest
 from pathlib import Path
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+# Shared guard primitives (comment-stripping, continuation-joining). Import as a
+# top-level module so it resolves under both pytest and `python3 -m unittest`.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import join_continuations, strip_comment_lines  # noqa: E402
 
 # `ARG PROWLER_VERSION=<x.y.z>` — the pin value must be version-shaped, not blank
 # or a placeholder. Matches e.g. ARG PROWLER_VERSION=5.30.1
@@ -74,10 +80,7 @@ def _active_text(text: str) -> str:
     (so a token in a comment can't satisfy a check — Finding 2/6), and backslash
     line-continuations joined onto one line (so a `RUN pip install \\` that wraps
     `prowler` onto the next line is still seen — Finding 1, CRITICAL)."""
-    no_comments = "\n".join(
-        line for line in text.splitlines() if not line.lstrip().startswith("#")
-    )
-    return no_comments.replace("\\\n", " ")
+    return join_continuations(strip_comment_lines(text))
 
 
 def violations(text: str) -> list:


### PR DESCRIPTION
## Summary

The four CI config regression guards independently grew the same text-scanning primitives with **divergent implementations** — comment-stripping (`_strip_comment_lines` / `_non_comment_lines` / `_no_comments` / `_active_text`), continuation-joining, and `on:`-block extraction (`_extract_on_block` / `_on_key_inline`). This hoists them into one canonical module so the false-negative hardening stays consistent and future guards reuse it.

- **New `scanner/tests/_ci_guard_util.py`** — `strip_comment_lines`, `non_comment_lines`, `join_continuations`, `extract_on_block`, `on_key_inline`. stdlib-only, no `scanner/lib` import. The `_`-prefix keeps it out of pytest collection and the `test_ci_*.py` catalog glob (no Catalog row; meta-guards stay green).
- Each guard imports it as a top-level module after `sys.path.insert(parent)`, resolving under **both** pytest (prepend mode) and `python3 -m unittest scanner.tests.<mod>` (namespace package) — the dual-runner contract.
- Documented in the catalog **Conventions** (incl. the "always strip comments + scope tokens" rule).

Behaviour-preserving refactor — no invariant changed.

## Test plan

- [x] `pytest scanner/tests/test_ci_*.py` → 151 passed (incl. offline-guarded run)
- [x] `python3 -m unittest` across all 4 refactored guards → 59 passed
- [x] `_ci_guard_util.py` confirmed **not collected** as a test by pytest
- [x] catalog completeness + no-ghost meta-guards green; `markdownlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)