### PR TITLE
chore: cleanup shellcheck warnings, sync versions, slim npm package

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "claudesec",
   "displayName": "ClaudeSec — DevSecOps Scanner & Dashboard",
-  "version": "0.5.1",
+  "version": "0.7.1",
   "description": "Security scanner, ISMS dashboard, and asset management for AI-assisted development",
   "author": "Twodragon0",
   "license": "MIT",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,87 @@
+# Changelog
+
+All notable changes to ClaudeSec are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Releases are published to npm via the `npm-publish.yml` workflow (Trusted
+Publisher + SLSA provenance), triggered by pushing a `v*` tag. For the complete
+per-commit history, see the git log and `MEMORY.md` (delta log).
+
+## [Unreleased]
+
+### Changed
+
+- Synced the Claude plugin manifest version (`.claude-plugin/marketplace.json`)
+  with `package.json` (0.7.1).
+- Cleaned up `shellcheck` warnings across the scanner test suite and hooks
+  (`SC2034` test-stub directives, `SC2188` redirection fixes in
+  `scanner/checks/saas/api-checks.sh`). CI `shell-lint` (severity `error`) was
+  already green; this clears the remaining non-blocking warnings.
+- Refreshed the `MEMORY.md` backlog to mark the Dependabot auto-merge policy as
+  resolved (#249/#250/#251).
+
+### Fixed
+
+- **npm package slimming.** The published tarball dropped from ~43 MB to ~580 kB
+  (536 → 220 files): removed `docs/` from the `files` allowlist (not needed at
+  runtime — it shipped two large `.pptx` seminar templates totalling ~38 MB), and
+  excluded operator-only scripts (cost/license/PC-sheet and Google-Sheets-auth
+  helpers) that are not part of the CLI surface. `.npmignore` could not exclude
+  these because paths listed in `files` take precedence over it; the exclusions
+  are now expressed as negated `files` patterns. Added `CHANGELOG.md` to `files`.
+
+## [0.7.1]
+
+### Changed
+
+- Upgraded the Node.js engine baseline and CI to **Node 22 LTS**.
+- Bumped the embedded version string across the CLI, dashboard generator, and
+  agent docs to keep them in sync with `package.json`.
+
+## [0.7.0]
+
+### Added
+
+- DAST reference target (`docker-compose.staging.yml`) and integration tests
+  for the scanner pipeline.
+
+### Fixed
+
+- DAST workflow configuration.
+- Security code-quality pass (CRITICAL/HIGH/MEDIUM findings remediated).
+
+### Highlights since 0.6.x
+
+This release rolls up a large body of scanner-correctness, CI-hardening, and
+supply-chain work (see `MEMORY.md` delta log for the full cycle history):
+
+- **Scanner correctness:** repaired a class of `grep -E` ERE bugs — lookahead,
+  `\|`-as-alternation, and `IFS` pipe-split detections — across the AI, SaaS,
+  network, cloud, and prowler check modules (#221, #223, #224, #227, #229, #231).
+- **Supply chain / Docker:** base images pinned by digest with Dependabot
+  tracking; the builder stage made Python-version-agnostic; `prowler==5.30.1`
+  pinned for reproducible builds; prowler providers absent from the lean build
+  are now skipped instead of emitting a misleading auth warning (#218, #233,
+  #237, #238).
+- **CI hardening:** kcov shell-coverage offline guard fixed a multi-minute hang
+  (120s → ~3.7s); per-test timeout capped at 30s; job-level path gating with an
+  `always()` aggregator replaces workflow-level `paths-ignore` so required
+  checks still report on docs PRs (#186, #190, #193). A family of CI config
+  regression guards (`scanner/tests/test_ci_*.py`) protects coverage floors,
+  action SHA pins, required-check topology, and severity gates.
+- **Dependabot auto-merge:** dropped the broken approve-as-bot step; auto-merge
+  is now armed only for safe semver-patch/minor pip/docker/actions updates, with
+  human code-owner approval remaining the gate (#249/#250/#251).
+
+## [0.6.5] and earlier
+
+Branding (OG social cards, light-mode variants), accessibility fixes, Docker
+image size optimization (1.47 GB → 479 MB), the Claude plugin manifest, and the
+quickstart Docker flow. See the git history for details.
+
+[Unreleased]: https://github.com/Twodragon0/claudesec/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/Twodragon0/claudesec/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/Twodragon0/claudesec/compare/v0.6.5...v0.7.0
+[0.6.5]: https://github.com/Twodragon0/claudesec/releases/tag/v0.6.5

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -105,14 +105,16 @@ tags: [memory, operations, quality, continuous-improvement]
   prowler ships py3.13+ compatibility. **Now auto-watched** by the #246 scheduled action
   (alerts via issue when prowler's PyPI `Requires-Python` drops the `<3.13` ceiling). Manual
   check: `curl -fsSL https://pypi.org/pypi/prowler/json | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d["info"]["version"], d["info"]["requires_python"])'`.
-- **Dependabot auto-merge policy is broken / TODO.** The existing
-  `.github/workflows/dependabot-auto-merge.yml` auto-approves with `GITHUB_TOKEN`, but
-  `github-actions[bot]` is NOT a code owner so those approvals do NOT satisfy
-  `require_code_owner_reviews` (proven by #235: 4 bot approvals, still BLOCKED, human had to
-  approve+merge). Its `--auto` is also a silent no-op because repo `allow_auto_merge=false`.
-  Recommended fix (architect plan, this session): enable repo auto-merge, drop the broken
-  approve-as-bot step, and only auto-*arm* auto-merge on safe patch/minor pip/docker updates
-  (never Dockerfile/base-image/major) — human code-owner approval stays the gate.
+- **Dependabot auto-merge policy** — DONE (#249/#250/#251 merged). The original
+  `dependabot-auto-merge.yml` auto-approved with `GITHUB_TOKEN`, but `github-actions[bot]`
+  is NOT a code owner so those approvals did NOT satisfy `require_code_owner_reviews`
+  (proven by #235: 4 bot approvals, still BLOCKED, human had to approve+merge); its `--auto`
+  was also a silent no-op while repo `allow_auto_merge=false`. Fix: #249 dropped the broken
+  approve-as-bot step and now only *arms* server-side auto-merge for semver-patch/minor
+  pip/docker/actions updates (sensitive paths — Dockerfile/base-image/.github/scanner/hooks/
+  scripts — and major bumps are excluded); #250 codified branch-protection + `allow_auto_merge`
+  via an idempotent `gh` script; #251 added a nightly branch-protection drift-watch workflow.
+  Human code-owner approval remains the gate.
 - **`.claude/worktrees/` not gitignored** — DONE (#240 merged).
 
 > Reference: CIS Controls v8 (secure configuration & continuous vulnerability

--- a/hooks/security-lint.sh
+++ b/hooks/security-lint.sh
@@ -10,6 +10,7 @@
 
 set -euo pipefail
 
+# shellcheck disable=SC2034  # $1 (file path) documents the hook arg contract; only CONTENT is scanned
 FILE="${1:-}"
 CONTENT="${2:-}"
 

--- a/package.json
+++ b/package.json
@@ -16,9 +16,14 @@
     "bin/",
     "scanner/",
     "scripts/",
+    "!scripts/sync-cost-xlsx.py",
+    "!scripts/update-license-active-accounts.py",
+    "!scripts/update-pc-sheet.py",
+    "!scripts/full-asset-sync.py",
+    "!scripts/gsheet-auth.py",
+    "!scripts/gsheet-auth-setup.py",
     "hooks/",
     "templates/",
-    "docs/",
     ".claude-plugin/",
     "Dockerfile",
     "Dockerfile.nginx",
@@ -27,6 +32,7 @@
     "nginx/",
     ".env.example",
     "README.md",
+    "CHANGELOG.md",
     "LICENSE"
   ],
   "keywords": [

--- a/scanner/checks/saas/api-checks.sh
+++ b/scanner/checks/saas/api-checks.sh
@@ -116,19 +116,19 @@ if has_command gh && is_git_repo; then
       wait "$_pid_secret" 2>/dev/null || true
       wait "$_pid_actions" 2>/dev/null || true
 
-      _code_alerts=$(<"$_tmpdir_gh/code_alerts" 2>/dev/null || echo "")
+      _code_alerts=$(cat "$_tmpdir_gh/code_alerts" 2>/dev/null || echo "")
       if [[ -n "$_code_alerts" && "$_code_alerts" =~ ^[0-9]+$ && "$_code_alerts" -gt 0 ]]; then
         _gh_api_issues=$((_gh_api_issues + 1))
         _gh_api_details="${_gh_api_details}\n    ${_code_alerts} open code scanning alert(s)"
       fi
 
-      _secret_alerts=$(<"$_tmpdir_gh/secret_alerts" 2>/dev/null || echo "")
+      _secret_alerts=$(cat "$_tmpdir_gh/secret_alerts" 2>/dev/null || echo "")
       if [[ -n "$_secret_alerts" && "$_secret_alerts" =~ ^[0-9]+$ && "$_secret_alerts" -gt 0 ]]; then
         _gh_api_issues=$((_gh_api_issues + 1))
         _gh_api_details="${_gh_api_details}\n    ${_secret_alerts} open secret scanning alert(s)"
       fi
 
-      _actions_perms=$(<"$_tmpdir_gh/actions_perms" 2>/dev/null || echo "")
+      _actions_perms=$(cat "$_tmpdir_gh/actions_perms" 2>/dev/null || echo "")
       _allowed_actions=$(echo "$_actions_perms" | grep -o '"allowed_actions":"[^"]*"' | cut -d'"' -f4 || echo "")
       if [[ "$_allowed_actions" == "all" ]]; then
         _gh_api_details="${_gh_api_details}\n    All GitHub Actions are allowed (consider restricting)"
@@ -169,8 +169,8 @@ if has_command gh && [[ -n "${_gh_repo:-}" ]] && echo "${_gh_auth:-}" | grep -q 
     > "$_tmpdir_wf/total" 2>/dev/null &
   wait
 
-  _recent_failures=$(<"$_tmpdir_wf/failures" 2>/dev/null || echo "")
-  _total_runs=$(<"$_tmpdir_wf/total" 2>/dev/null || echo "0")
+  _recent_failures=$(cat "$_tmpdir_wf/failures" 2>/dev/null || echo "")
+  _total_runs=$(cat "$_tmpdir_wf/total" 2>/dev/null || echo "0")
   rm -rf "$_tmpdir_wf"
 
   if [[ -n "$_total_runs" && "$_total_runs" -gt 0 ]]; then

--- a/scanner/tests/test_checks_lib_direct.sh
+++ b/scanner/tests/test_checks_lib_direct.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 # Direct-call coverage tests for scanner/lib/checks.sh.
 #
 # The existing test_checks_coverage.sh relies on var=$( source ...; cmd )

--- a/scanner/tests/test_generate_html_dashboard.sh
+++ b/scanner/tests/test_generate_html_dashboard.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 # Unit tests for output.sh::generate_html_dashboard()
 # Focus: scan-report.json persistence + HTML output (legacy fallback path)
 # Run: bash scanner/tests/test_generate_html_dashboard.sh

--- a/scanner/tests/test_kube_discovery.sh
+++ b/scanner/tests/test_kube_discovery.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 # Unit tests for kubectl_auto_find_kubeconfig() and kubectl_current_context_uses_oidc_exec()
 # Run: bash scanner/tests/test_kubeconfig_discovery.sh
 

--- a/scanner/tests/test_output_coverage.sh
+++ b/scanner/tests/test_output_coverage.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 # Unit tests for output.sh: coverage for previously-uncovered branches.
 # Targets: _id_to_category (L651-668), _emit_finding_json FINDINGS_WARN/LOW (L697-701),
 #          _print_finding_inline_fail severity-color branches (L93-99),

--- a/scanner/tests/test_output_functions.sh
+++ b/scanner/tests/test_output_functions.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 # Unit tests for output.sh: fail(), append_json(), _emit_finding_json()
 # Run: bash scanner/tests/test_output_functions.sh
 set -uo pipefail

--- a/scanner/tests/test_output_prowler_severity.sh
+++ b/scanner/tests/test_output_prowler_severity.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 # Cover scanner/lib/output.sh L545-561: _prowler_dashboard_summary main
 # rendering loop including the awk severity counter at L551-558.
 #

--- a/scanner/tests/test_prowler_dashboard_summary.sh
+++ b/scanner/tests/test_prowler_dashboard_summary.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 # Unit tests for output.sh::_prowler_dashboard_summary()
 # Run: bash scanner/tests/test_prowler_dashboard_summary.sh
 set -uo pipefail

--- a/scanner/tests/test_save_scan_history_ocsf.sh
+++ b/scanner/tests/test_save_scan_history_ocsf.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2034
 # Unit tests for scanner/lib/output.sh: save_scan_history prowler OCSF
 # compliance python block (L414-445). Exercises:
 #   L414-416  prowler-*.ocsf.json detection loop


### PR DESCRIPTION
## Summary

Repo-wide cleanup + npm publish prep. The repo was already healthy (151 CI guards + 1317 pytest green); these are the concrete remaining items found by an evidence-based sweep.

### Cleanup
- **shellcheck (10 → 0 warnings).** CI `shell-lint` runs at `severity:error`, so these never failed CI — clearing the residual noise:
  - 8 `scanner/tests/*.sh`: add `# shellcheck disable=SC2034` on line 2 (matches existing convention; vars are test stubs consumed via sourced `scanner/lib` code).
  - `scanner/checks/saas/api-checks.sh`: replace 5× `$(<f 2>/dev/null || echo …)` with `$(cat f …)` to clear **SC2188** (also POSIX-safe — no behavior change).
  - `hooks/security-lint.sh`: SC2034 disable for `FILE="${1:-}"`, documenting the hook arg contract (only `CONTENT` is scanned).
- **Version sync:** `.claude-plugin/marketplace.json` `0.5.1` → `0.7.1` (drifted from `package.json`).
- **MEMORY.md:** mark the Dependabot auto-merge backlog item DONE (#249/#250/#251 merged).

### npm publish prep
- **Slim the published tarball: 43.1 MB → 582 kB** (536 → 220 files).
  - Removed `docs/` from `files[]` — not read at runtime (scanner only *writes* to `$SCAN_DIR/docs/architecture` in the user's project). It was shipping two `.pptx` seminar templates totalling ~38 MB.
  - Excluded 6 operator-only scripts (cost-xlsx / license / PC-sheet + Google-Sheets-auth helpers) via negated `files[]` patterns. `.npmignore` could not exclude them because `files[]` takes precedence (confirmed via `npm publish --dry-run`).
- Added `CHANGELOG.md` (Keep a Changelog) and included it in `files[]`.

## Test plan
- [x] `shellcheck -S warning` sweep across scanner/scripts/hooks/bin → **0 warnings** (was 10)
- [x] `pytest scanner/tests/test_ci_*.py` → **151 passed**
- [x] `pytest scanner/tests/` (full) → **1317 passed**
- [x] edited test files still execute (`test_output_functions`, `test_output_coverage` PASS)
- [x] `npm publish --dry-run --access public` → `claudesec@0.7.1`, 582 kB, no `docs/`/pptx, 6 internal scripts excluded, core retained
- [x] JSON validity (`marketplace.json`, `package.json`) + version parity at 0.7.1
- [x] separate-lane code review → APPROVE (no blocking issues)

## Notes
- npm registry is at **0.6.1** while `package.json` is **0.7.1** (no `v0.7.x` tag exists). Publishing 0.7.1 is intentionally **left to the maintainer** — push a `v0.7.1` tag or run the `npm-publish.yml` workflow_dispatch.
- Follow-up (not in this PR): a `test_ci_npm_files.py` guard asserting `docs/` stays out of `files[]` and the 6 exclusions hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)