### PR TITLE
test(ci): pin DESIRED_CONTEXTS as exact set + re-triage Tier-3 date

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -104,7 +104,10 @@ complementary gap by asserting the load-bearing security jobs still exist.
 A standing list of CI invariants that are **not yet** protected by a guard,
 triaged by the same bar used to add one (an incident, past or plausible, where
 *silent* weakening disables enforcement — no incident means it likely is not
-worth a guard, to avoid sprawl). Reviewed 2026-06-19.
+worth a guard, to avoid sprawl). Reviewed 2026-06-19; re-triaged 2026-06-22
+(all Tier-3 workflows confirmed KEEP-AS-MONITOR — decision unchanged; the
+`workflow_run` trigger added to `provenance-verify.yml` in #263/#264 is already
+covered by `test_ci_provenance_verify.py`).
 
 ### Tier 2 — incident-backed (now implemented)
 

--- a/scanner/tests/test_ci_branch_protection_codified.py
+++ b/scanner/tests/test_ci_branch_protection_codified.py
@@ -19,10 +19,15 @@ control whose silent removal disables enforcement
 (OWASP CICD-SEC-1 Insufficient Flow Control / CICD-SEC-7 Insecure System
 Configuration; NIST SSDF SP 800-218 PO.3/PW.4):
 
-  1. **Required-status contexts** — `DESIRED_CONTEXTS` must keep BOTH
-     `"Lint"` and `"Security Scan Gate"`. Dropping either un-requires that
-     aggregator, so a PR could merge with that whole gate red. (The "two
-     required checks" contract documented in ci-config-regression-guards.md.)
+  1. **Required-status contexts** — `DESIRED_CONTEXTS` must equal EXACTLY
+     `["Lint","Security Scan Gate"]`. The `desired_contexts` token is the full
+     assignment string up to and including the closing `]'`, so the check is a
+     two-sided pin, not a floor: *dropping* a context un-requires that aggregator
+     (a PR could merge with that whole gate red), and *adding* a third context
+     (appended or prepended) also breaks the exact match — so any change to the
+     required-check set is forced to be deliberate and update this guard. (The
+     "two required checks" contract documented in ci-config-regression-guards.md;
+     both directions are proven by mutation self-tests below.)
   2. **enforce_admins=true** — admins (including the owner) are NOT exempt from
      branch protection. Flipping to false would let an admin force-push to main.
   3. **strict=true** — PRs must be up to date with main before merge.
@@ -295,6 +300,25 @@ class TestBranchProtectionCodifiedMutation(unittest.TestCase):
             "Mutation FAILED: dropping 'Security Scan Gate' from the required "
             "contexts was NOT detected.",
         )
+
+    def test_adding_a_required_context_is_detected(self):
+        # Ceiling direction: the exact-string token (incl. the closing `]'`) must
+        # also catch a SILENTLY ADDED third required context — appended or
+        # prepended — so the required-check set is pinned, not just floored.
+        for label, extra in (
+            ("appended", 'DESIRED_CONTEXTS=\'["Lint","Security Scan Gate","Sneaky"]\''),
+            ("prepended", 'DESIRED_CONTEXTS=\'["Sneaky","Lint","Security Scan Gate"]\''),
+        ):
+            mutant = self._GOOD_SCRIPT.replace(
+                'DESIRED_CONTEXTS=\'["Lint","Security Scan Gate"]\'', extra
+            )
+            with self.subTest(position=label):
+                self.assertTrue(
+                    any("desired_contexts" in p for p in script_violations(mutant)),
+                    f"Mutation FAILED ({label}): adding a third required context "
+                    "was NOT detected — DESIRED_CONTEXTS is not pinned as an exact "
+                    "set.",
+                )
 
     def test_disabling_enforce_admins_is_detected(self):
         mutant = self._GOOD_SCRIPT.replace(


### PR DESCRIPTION
## Summary

Two small follow-ups to #264, both in the CI-guard catalog/guard system (one PR to avoid sprawl).

### 1. Context-ceiling mutation self-test
A re-triage flagged a possible "ceiling gap" in `test_ci_branch_protection_codified.py`: does it catch a *third* required context being silently added to `DESIRED_CONTEXTS`?

**Verified empirically: there is NO gap.** The `desired_contexts` token is the full assignment string up to and including the closing `]'`, so adding a context (appended *or* prepended) breaks the exact match exactly like dropping one. The behavior was already a two-sided pin — but only the *drop* direction had a mutation self-test.

- Add `test_adding_a_required_context_is_detected` (appended + prepended subtests) to lock the ceiling direction in, matching the suite's "every detector has a mutation self-test" discipline.
- Clarify invariant #1 in the docstring: it's a two-sided exact pin, not a floor.
- **No production assertion changed** (none needed — adding a redundant "ceiling" assertion would be dead code).

### 2. Tier-3 re-triage date
`docs/devsecops/ci-config-regression-guards.md`: record the **2026-06-22** re-triage — all three monitor-only workflows (`prowler-python-watch` / `dashboard-refresh` / `og-meta-verify`) confirmed **KEEP-AS-MONITOR**, decision unchanged; the new `provenance-verify` `workflow_run` trigger is already covered by `test_ci_provenance_verify.py`.

## Test plan
- [x] `python3 -m pytest scanner/tests/test_ci_*.py` → **168 passed** (was 167)
- [x] dual-runner (`python3 -m unittest`) green
- [x] new ceiling self-test proven to fire on the mutant (appended + prepended)
- [x] `markdownlint` catalog → 0 errors

## Note
The "ceiling gap" in the re-triage report turned out to be a **false alarm** — the existing exact-string pin already enforced it. This PR adds the *missing regression test* rather than a redundant assertion, and documents the two-sided behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)