### PR TITLE
refactor(ci): consolidate duplicated _strip_comment into _ci_guard_util

### DIFF
--- a/scanner/tests/_ci_guard_util.py
+++ b/scanner/tests/_ci_guard_util.py
@@ -37,6 +37,8 @@ root):
     from _ci_guard_util import strip_comment_lines, extract_on_block
 """
 
+import re
+
 
 def non_comment_lines(text: str) -> list:
     """The lines of `text` with whole-line `#` comments dropped."""
@@ -47,6 +49,16 @@ def strip_comment_lines(text: str) -> str:
     """`text` with whole-line `#` comments removed, so a token living only in a
     comment cannot satisfy a presence check."""
     return "\n".join(non_comment_lines(text))
+
+
+def strip_inline_comment(line: str) -> str:
+    """A SINGLE line with a trailing inline `# ...` comment removed
+    (e.g. `uses: foo@<sha>  # v1.2.3` -> `uses: foo@<sha>`). Requires whitespace
+    before the `#` so a `#` inside a token (a URL fragment, a quoted value) is
+    not stripped. Per-line and distinct from strip_comment_lines/non_comment_lines,
+    which drop WHOLE comment lines from a multi-line text — several guards need
+    the trailing-comment form when scanning one `run:`/`uses:` line at a time."""
+    return re.sub(r"\s+#.*$", "", line)
 
 
 def join_continuations(text: str) -> str:

--- a/scanner/tests/test_ci_codeql_single_model.py
+++ b/scanner/tests/test_ci_codeql_single_model.py
@@ -26,9 +26,13 @@ No network, no subprocess. Passes under pytest (the CI runner) and
 """
 
 import re
+import sys
 import unittest
 from glob import glob
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_inline_comment as _strip_comment  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -39,10 +43,6 @@ WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 ANALYSIS_ACTION_RE = re.compile(
     r"uses:\s*github/codeql-action/(init|analyze)(?:[/@]|\s|$)"
 )
-
-
-def _strip_comment(line: str) -> str:
-    return re.sub(r"\s+#.*$", "", line)
 
 
 class TestCodeqlSingleModel(unittest.TestCase):

--- a/scanner/tests/test_ci_gate_topology.py
+++ b/scanner/tests/test_ci_gate_topology.py
@@ -22,9 +22,13 @@ runner) and `python3 -m unittest`.
 """
 
 import re
+import sys
 import unittest
 from glob import glob
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_inline_comment as _strip_comment  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -41,11 +45,6 @@ LINT_YML = WORKFLOW_DIR / "lint.yml"
 # lint-gate.needs so its OWASP A08 fork-guard audit is merge-blocking — it is
 # therefore correctly NO LONGER allowlisted.)
 UNGATED_JOBS_ALLOWLIST = {"lint-gate"}
-
-
-def _strip_comment(line: str) -> str:
-    # Drop an inline "  # ..." comment without tripping on '#' inside a token.
-    return re.sub(r"\s+#.*$", "", line)
 
 
 class TestActionShaPinning(unittest.TestCase):

--- a/scanner/tests/test_ci_npm_publish.py
+++ b/scanner/tests/test_ci_npm_publish.py
@@ -41,16 +41,16 @@ The npm package payload (files[]) is guarded by test_ci_npm_files.py.
 """
 
 import re
+import sys
 import unittest
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_inline_comment as _strip_comment  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 NPM_PUBLISH = REPO_ROOT / ".github" / "workflows" / "npm-publish.yml"
-
-
-def _strip_comment(line: str) -> str:
-    return re.sub(r"\s+#.*$", "", line)
 
 
 class TestNpmPublishProvenance(unittest.TestCase):

--- a/scanner/tests/test_ci_provenance_verify.py
+++ b/scanner/tests/test_ci_provenance_verify.py
@@ -36,15 +36,14 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import extract_on_block  # noqa: E402
+from _ci_guard_util import (  # noqa: E402
+    extract_on_block,
+    strip_inline_comment as _strip_comment,
+)
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "provenance-verify.yml"
-
-
-def _strip_comment(line: str) -> str:
-    return re.sub(r"\s+#.*$", "", line)
 
 
 class TestProvenanceVerifyWorkflow(unittest.TestCase):

--- a/scanner/tests/test_ci_required_jobs_exist.py
+++ b/scanner/tests/test_ci_required_jobs_exist.py
@@ -34,8 +34,12 @@ measured coverage gate.
 """
 
 import re
+import sys
 import unittest
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_inline_comment as _strip_comment  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -54,10 +58,6 @@ REQUIRED_LINT_JOBS = frozenset(
         "scanner-shell-coverage",
     }
 )
-
-
-def _strip_comment(line: str) -> str:
-    return re.sub(r"\s+#.*$", "", line)
 
 
 class TestRequiredLintJobsExist(unittest.TestCase):


### PR DESCRIPTION
## Summary

Audit follow-up (catalog-integrity audit, #266). Five CI guards each defined an **identical** local `_strip_comment(line) = re.sub(r"\s+#.*$", "", line)` — a per-line *trailing/inline* comment stripper.

The trap: the shared `_ci_guard_util` only offered **whole-line** strippers (`strip_comment_lines`/`non_comment_lines`), which have **different semantics** — so the copies could *not* simply switch to those (that would have changed behavior). Instead:

- **Add `strip_inline_comment(line)`** to `_ci_guard_util.py` — the trailing-comment form, documented as distinct from the whole-line strippers.
- **Migrate all five guards** (`codeql_single_model`, `gate_topology`, `npm_publish`, `required_jobs_exist`, `provenance_verify`) to `from _ci_guard_util import strip_inline_comment as _strip_comment`, removing the local copies. Call sites unchanged (aliased) → minimal diff.

Behavior is **byte-identical** (same regex), now single-sourced. Continues the #259 helper-extraction.

## Test plan
- [x] `pytest scanner/tests/test_ci_*.py` → **168 passed**
- [x] `python3 -m unittest discover` → **168 OK** (dual-runner)
- [x] no local `_strip_comment` defs remain (`grep` clean)
- [x] `re` stays used in all five (regex elsewhere) → no orphaned imports
- [x] `_ci_guard_util.py` stays out of pytest collection + catalog glob (leading `_`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)