### PR TITLE
refactor(ci): consolidate _top_level_jobs parser into _ci_guard_util

### DIFF
--- a/scanner/tests/_ci_guard_util.py
+++ b/scanner/tests/_ci_guard_util.py
@@ -61,6 +61,25 @@ def strip_inline_comment(line: str) -> str:
     return re.sub(r"\s+#.*$", "", line)
 
 
+def top_level_jobs(text: str) -> list:
+    """The job keys under a workflow's top-level `jobs:` map (2-space-indented
+    `name:` lines), in document order. Stops at the dedent to the next top-level
+    key, and strips trailing inline comments so `build:  # x` still matches.
+    Returns a list; callers wrap in `set()` where set semantics are needed."""
+    jobs, in_jobs = [], False
+    for raw in text.splitlines():
+        if re.match(r"^jobs:\s*$", raw):
+            in_jobs = True
+            continue
+        if in_jobs:
+            if re.match(r"^\S", raw):  # dedent back to a top-level key
+                break
+            m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", strip_inline_comment(raw))
+            if m:
+                jobs.append(m.group(1))
+    return jobs
+
+
 def join_continuations(text: str) -> str:
     """Join backslash-newline line continuations onto one line, so a shell/Docker
     instruction that wraps an argument onto the next line is seen as one command

--- a/scanner/tests/test_ci_gate_topology.py
+++ b/scanner/tests/test_ci_gate_topology.py
@@ -28,7 +28,10 @@ from glob import glob
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import strip_inline_comment as _strip_comment  # noqa: E402
+from _ci_guard_util import (  # noqa: E402
+    strip_inline_comment as _strip_comment,
+    top_level_jobs,
+)
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -81,20 +84,6 @@ class TestLintGateNeedsCompleteness(unittest.TestCase):
     def setUpClass(cls):
         cls.text = LINT_YML.read_text(encoding="utf-8") if LINT_YML.is_file() else ""
 
-    def _top_level_jobs(self):
-        jobs, in_jobs = [], False
-        for raw in self.text.splitlines():
-            if re.match(r"^jobs:\s*$", raw):
-                in_jobs = True
-                continue
-            if in_jobs:
-                if re.match(r"^\S", raw):  # dedent back to a top-level key
-                    break
-                m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", _strip_comment(raw))
-                if m:
-                    jobs.append(m.group(1))
-        return jobs
-
     def _lint_gate_needs(self):
         needs, in_gate, in_needs = [], False, False
         for raw in self.text.splitlines():
@@ -122,7 +111,7 @@ class TestLintGateNeedsCompleteness(unittest.TestCase):
         self.assertTrue(LINT_YML.is_file(), f"{LINT_YML} not found")
 
     def test_every_job_is_gated_or_allowlisted(self):
-        jobs = set(self._top_level_jobs())
+        jobs = set(top_level_jobs(self.text))
         needs = set(self._lint_gate_needs())
         self.assertIn("changes", jobs, "job parsing broke — 'changes' not found")
         self.assertTrue(needs, "lint-gate.needs parsing broke — empty needs list")
@@ -141,7 +130,7 @@ class TestLintGateNeedsCompleteness(unittest.TestCase):
     def test_allowlist_has_no_stale_entries(self):
         # An allowlist entry that no longer names a real job (or that has since
         # been added to needs) is dead config — fail so it gets cleaned up.
-        jobs = set(self._top_level_jobs())
+        jobs = set(top_level_jobs(self.text))
         needs = set(self._lint_gate_needs())
         stale = {
             j

--- a/scanner/tests/test_ci_required_jobs_exist.py
+++ b/scanner/tests/test_ci_required_jobs_exist.py
@@ -33,13 +33,12 @@ No network, no subprocess. Passes under pytest (the CI runner) and
 measured coverage gate.
 """
 
-import re
 import sys
 import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import strip_inline_comment as _strip_comment  # noqa: E402
+from _ci_guard_util import top_level_jobs  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -65,21 +64,6 @@ class TestRequiredLintJobsExist(unittest.TestCase):
     def setUpClass(cls):
         cls.text = LINT_YML.read_text(encoding="utf-8") if LINT_YML.is_file() else ""
 
-    def _top_level_jobs(self):
-        """Return the set of 2-space-indented job keys under `jobs:`."""
-        jobs, in_jobs = [], False
-        for raw in self.text.splitlines():
-            if re.match(r"^jobs:\s*$", raw):
-                in_jobs = True
-                continue
-            if in_jobs:
-                if re.match(r"^\S", raw):  # dedent back to a top-level key
-                    break
-                m = re.match(r"^  ([A-Za-z0-9_-]+):\s*$", _strip_comment(raw))
-                if m:
-                    jobs.append(m.group(1))
-        return set(jobs)
-
     def test_lint_yml_exists(self):
         self.assertTrue(
             LINT_YML.is_file(),
@@ -89,13 +73,13 @@ class TestRequiredLintJobsExist(unittest.TestCase):
     def test_parser_canary(self):
         # If the job parser breaks, fail loudly here rather than vacuously
         # "finding" the required jobs missing (or present).
-        jobs = self._top_level_jobs()
+        jobs = set(top_level_jobs(self.text))
         self.assertIn(
             "lint-gate", jobs, "job parsing broke — 'lint-gate' aggregator not found"
         )
 
     def test_required_security_jobs_present(self):
-        jobs = self._top_level_jobs()
+        jobs = set(top_level_jobs(self.text))
         missing = REQUIRED_LINT_JOBS - jobs
         self.assertEqual(
             missing,


### PR DESCRIPTION
## Summary

DRY follow-up to #267. Two guards (`gate_topology`, `required_jobs_exist`) carried a near-identical `_top_level_jobs` method parsing the `jobs:` map. They had **already drifted** (one returned a list, the other a `set`) — exactly the divergence single-sourcing prevents.

- **Add `top_level_jobs(text) -> list`** to `_ci_guard_util.py` (uses the shared `strip_inline_comment`). Returns a list; callers wrap in `set()` as needed.
- **gate_topology**: drop the local method, import `top_level_jobs`; the two call sites already did `set(...)`. `_strip_comment`/`re` stay (used elsewhere — SHA-pin + needs parsing).
- **required_jobs_exist**: drop the local method; its only `re` and `_strip_comment` uses lived inside it → both removed as **orphan imports**; call sites now `set(top_level_jobs(self.text))` (the `frozenset` difference needs a set).

Behavior identical. Continues the #259/#267 helper-extraction line.

## Test plan
- [x] `pytest scanner/tests/test_ci_*.py` → **168 passed**
- [x] `python3 -m unittest discover` → **168 OK** (dual-runner)
- [x] no local `_top_level_jobs` defs remain
- [x] required_jobs has no orphaned `re`/`_strip_comment` import (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)