### PR TITLE
fix(ci): close comment-evasion false-negatives in 4 guards (CRITICAL+3 HIGH)

### DIFF
--- a/scanner/tests/test_ci_coverage_thresholds.py
+++ b/scanner/tests/test_ci_coverage_thresholds.py
@@ -21,8 +21,12 @@ No network, no subprocess.
 """
 
 import re
+import sys
 import unittest
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_comment_lines, strip_inline_comment  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -34,10 +38,20 @@ MIN_PYTHON_COV_FAIL_UNDER = 99
 MIN_BASH_COVERAGE_THRESHOLD = 90.0
 
 
+def active_text(text):
+    """`text` with whole-line AND trailing-inline `#` comments removed, so a
+    floor value surviving only in a comment cannot satisfy the gate check
+    (comment-evasion false-negative class — F-2)."""
+    return "\n".join(
+        strip_inline_comment(ln) for ln in strip_comment_lines(text).splitlines()
+    )
+
+
 class TestCiCoverageThresholds(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.text = LINT_YML.read_text(encoding="utf-8") if LINT_YML.is_file() else ""
+        raw = LINT_YML.read_text(encoding="utf-8") if LINT_YML.is_file() else ""
+        cls.text = active_text(raw)
 
     def test_lint_yml_exists(self):
         self.assertTrue(
@@ -78,6 +92,24 @@ class TestCiCoverageThresholds(unittest.TestCase):
             f"{MIN_BASH_COVERAGE_THRESHOLD}%). If intentional, update "
             f"MIN_BASH_COVERAGE_THRESHOLD in this test and justify in the PR.",
         )
+
+
+class TestCoverageCommentEvasion(unittest.TestCase):
+    """F-2: a floor surviving only in a comment must not satisfy the gate."""
+
+    def test_commented_floor_is_not_counted(self):
+        mutant = "# pytest --cov-fail-under=99\nrun: pytest  # was --cov-fail-under=99"
+        scan = active_text(mutant)
+        self.assertEqual(
+            re.findall(r"--cov-fail-under=(\d+)", scan),
+            [],
+            "comment-evasion: a `--cov-fail-under` surviving only in a whole-line "
+            "or trailing comment must NOT count as an active coverage gate.",
+        )
+
+    def test_active_floor_is_counted(self):
+        scan = active_text("run: pytest --cov-fail-under=99")
+        self.assertEqual(re.findall(r"--cov-fail-under=(\d+)", scan), ["99"])
 
 
 if __name__ == "__main__":

--- a/scanner/tests/test_ci_dependabot_automerge.py
+++ b/scanner/tests/test_ci_dependabot_automerge.py
@@ -49,8 +49,12 @@ No `scanner/lib` import (does not touch the 99% coverage gate). No network, no
 subprocess. Runs under pytest (the CI runner) and `python3 -m unittest`.
 """
 
+import sys
 import unittest
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_comment_lines  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -95,13 +99,21 @@ FORBIDDEN_TOKENS = {
 
 
 def _violations(text: str) -> list:
-    """Return a list of problem descriptions for REQUIRED/FORBIDDEN violations."""
+    """Return a list of problem descriptions for REQUIRED/FORBIDDEN violations.
+
+    Whole-line `#` comments are stripped first (F-3): a fork-guard token surviving
+    only in a comment must NOT satisfy a REQUIRED check (the real `if:` could be
+    neutered to `true`), and a `--admin` quoted in a comment must NOT false-trip a
+    FORBIDDEN check. The case-arm strings live in the active `case` block, never
+    in commentary, so stripping is safe for them too.
+    """
+    scan = strip_comment_lines(text)
     problems = []
     for name, tok in sorted(REQUIRED_TOKENS.items()):
-        if tok not in text:
+        if tok not in scan:
             problems.append(f"MISSING required invariant [{name}]: {tok!r}")
     for name, tok in sorted(FORBIDDEN_TOKENS.items()):
-        if tok in text:
+        if tok in scan:
             problems.append(f"FORBIDDEN token present [{name}]: {tok!r}")
     return problems
 
@@ -223,6 +235,19 @@ class TestDependabotAutoMergeGuardMutation(unittest.TestCase):
         self.assertTrue(
             any("fork_guard_same_repo" in p for p in _violations(mutant)),
             "Mutation FAILED: removing the same-repo fork guard was NOT detected.",
+        )
+
+    def test_fork_guard_surviving_only_in_comment_is_detected(self):
+        # F-3 (comment-evasion): neuter the real same-repo fork guard but leave
+        # the token alive in a `#` comment — the guard must still fire.
+        mutant = self._GOOD.replace(
+            "  github.event.pull_request.head.repo.full_name == github.repository",
+            "  # github.event.pull_request.head.repo.full_name == github.repository",
+        )
+        self.assertTrue(
+            any("fork_guard_same_repo" in p for p in _violations(mutant)),
+            "Mutation FAILED (F-3): the same-repo fork guard surviving only in a "
+            "comment satisfied the REQUIRED check — comment-evasion not defended.",
         )
 
     def test_dropping_a_hard_exclude_path_is_detected(self):

--- a/scanner/tests/test_ci_dependabot_automerge.py
+++ b/scanner/tests/test_ci_dependabot_automerge.py
@@ -54,7 +54,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import strip_comment_lines  # noqa: E402
+from _ci_guard_util import strip_comment_lines, strip_inline_comment  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -101,13 +101,17 @@ FORBIDDEN_TOKENS = {
 def _violations(text: str) -> list:
     """Return a list of problem descriptions for REQUIRED/FORBIDDEN violations.
 
-    Whole-line `#` comments are stripped first (F-3): a fork-guard token surviving
-    only in a comment must NOT satisfy a REQUIRED check (the real `if:` could be
-    neutered to `true`), and a `--admin` quoted in a comment must NOT false-trip a
-    FORBIDDEN check. The case-arm strings live in the active `case` block, never
-    in commentary, so stripping is safe for them too.
+    Whole-line AND trailing-inline `#` comments are stripped first (F-3 + 2nd-review
+    Finding 2): a fork-guard token surviving only in a comment must NOT satisfy a
+    REQUIRED check (the real `if:` could be neutered to `true`), and a `--admin`
+    in a trailing comment must NOT false-trip a FORBIDDEN check. The case-arm /
+    fork-guard strings carry no inline `#`, so stripping is safe for them. (A
+    `--admin` in non-comment prose, e.g. an `echo`, is an accepted residual
+    false-positive — substring matching can't tell prose from a command.)
     """
-    scan = strip_comment_lines(text)
+    scan = "\n".join(
+        strip_inline_comment(ln) for ln in strip_comment_lines(text).splitlines()
+    )
     problems = []
     for name, tok in sorted(REQUIRED_TOKENS.items()):
         if tok not in scan:

--- a/scanner/tests/test_ci_dockerfile_base_pinned.py
+++ b/scanner/tests/test_ci_dockerfile_base_pinned.py
@@ -56,7 +56,7 @@ DOCKERFILE_NGINX = REPO_ROOT / "Dockerfile.nginx"
 # Shared guard primitive (comment-stripping). Import as a top-level module so it
 # resolves under both pytest and `python3 -m unittest`.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import strip_comment_lines  # noqa: E402
+from _ci_guard_util import strip_comment_lines, strip_inline_comment  # noqa: E402
 
 # A `FROM [--flag=...]... <image>[ AS stage]` line. Group 1 = the image ref.
 # The `(?:--\S+\s+)*` prefix skips build flags like `--platform=$BUILDPLATFORM`
@@ -72,7 +72,14 @@ HARDCODED_PY_PATH_RE = re.compile(r"python3\.\d+/site-packages")
 
 
 def from_refs(text: str) -> list:
-    return FROM_RE.findall(strip_comment_lines(text))
+    # Strip whole-line AND trailing-inline `#` comments before matching. FROM_RE
+    # anchors the image ref at line-end (`\s*$`), so a `FROM img@sha256:x # note`
+    # line would otherwise fail to match and be SILENTLY DROPPED from both the
+    # digest and alpine-freeze checks (comment-evasion false-negative — F-4).
+    active = "\n".join(
+        strip_inline_comment(ln) for ln in strip_comment_lines(text).splitlines()
+    )
+    return FROM_RE.findall(active)
 
 
 def digest_violations(text: str, label: str) -> list:
@@ -195,6 +202,30 @@ class TestDockerfileBasePinnedMutation(unittest.TestCase):
         self.assertTrue(
             any("3.20" in p for p in alpine_freeze_violations(mutant)),
             "Mutation FAILED: an alpine minor bump (3.20 -> 3.24) was NOT detected.",
+        )
+
+    def test_alpine_bump_on_commented_from_line_is_detected(self):
+        # F-4 (comment-evasion): a trailing inline comment on a FROM line must not
+        # make it slip past the freeze check (FROM_RE anchors the ref at line-end).
+        mutant = self._GOOD.replace(
+            "alpine:3.20@sha256:deadbeef AS builder",
+            "alpine:3.24@sha256:deadbeef AS builder  # interim bump",
+        )
+        self.assertTrue(
+            any("3.20" in p for p in alpine_freeze_violations(mutant)),
+            "Mutation FAILED (F-4): an alpine bump on a FROM line with a trailing "
+            "inline comment was silently dropped (not inspected).",
+        )
+
+    def test_undigested_from_with_trailing_comment_is_detected(self):
+        mutant = self._GOOD.replace(
+            "alpine:3.20@sha256:deadbeef AS builder",
+            "alpine:3.20 AS builder  # no digest",
+        )
+        self.assertTrue(
+            any("not digest-pinned" in p for p in digest_violations(mutant, "df")),
+            "Mutation FAILED (F-4): an un-digested FROM with a trailing comment "
+            "was silently dropped.",
         )
 
     def test_hardcoded_python_path_is_detected(self):

--- a/scanner/tests/test_ci_security_gate.py
+++ b/scanner/tests/test_ci_security_gate.py
@@ -24,8 +24,27 @@ Does not import scanner/lib, so it does not affect the measured coverage gate.
 """
 
 import re
+import sys
 import unittest
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_inline_comment  # noqa: E402
+
+
+def conditional_body_from(text, var):
+    """The body of `if [ "$<var>" -gt 0 ]; then ... fi` with trailing inline `#`
+    comments stripped per line, so a commented-out `# exit 1` can neither satisfy
+    nor falsely trip the severity-block checks (comment-evasion class, F-1)."""
+    m = re.search(
+        r'\[\s*"\$' + re.escape(var) + r'"\s+-gt\s+0\s*\]\s*;\s*then(.*?)\bfi\b',
+        text,
+        re.DOTALL,
+    )
+    if not m:
+        return None
+    return "\n".join(strip_inline_comment(ln) for ln in m.group(1).splitlines())
+
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -196,13 +215,7 @@ class TestScanCriticalSeverityBlock(unittest.TestCase):
         )
 
     def _conditional_body(self, var):
-        # Capture the body of `if [ "$<var>" -gt 0 ]; then ... fi`.
-        m = re.search(
-            r'\[\s*"\$' + re.escape(var) + r'"\s+-gt\s+0\s*\]\s*;\s*then(.*?)\bfi\b',
-            self.text,
-            re.DOTALL,
-        )
-        return m.group(1) if m else None
+        return conditional_body_from(self.text, var)
 
     def test_critical_block_exits_nonzero(self):
         body = self._conditional_body("CRITS")
@@ -226,6 +239,24 @@ class TestScanCriticalSeverityBlock(unittest.TestCase):
                 "HIGH findings must remain non-blocking (warning only); only "
                 "CRITICAL blocks the merge.",
             )
+
+
+class TestSeverityBlockCommentEvasion(unittest.TestCase):
+    """F-1 (CRITICAL): a commented-out `exit 1` must not satisfy the merge block."""
+
+    def test_commented_exit_one_does_not_satisfy(self):
+        mutant = 'if [ "$CRITS" -gt 0 ]; then\n  echo warn  # exit 1\nfi'
+        body = conditional_body_from(mutant, "CRITS") or ""
+        self.assertNotRegex(
+            body,
+            r"\bexit\s+1\b",
+            "comment-evasion: a `# exit 1` surviving only in a comment must NOT "
+            "satisfy the CRITICAL merge-block check.",
+        )
+
+    def test_real_exit_one_satisfies(self):
+        good = 'if [ "$CRITS" -gt 0 ]; then\n  exit 1\nfi'
+        self.assertRegex(conditional_body_from(good, "CRITS"), r"\bexit\s+1\b")
 
 
 if __name__ == "__main__":

--- a/scanner/tests/test_ci_security_gate.py
+++ b/scanner/tests/test_ci_security_gate.py
@@ -33,17 +33,32 @@ from _ci_guard_util import strip_inline_comment  # noqa: E402
 
 
 def conditional_body_from(text, var):
-    """The body of `if [ "$<var>" -gt 0 ]; then ... fi` with trailing inline `#`
-    comments stripped per line, so a commented-out `# exit 1` can neither satisfy
-    nor falsely trip the severity-block checks (comment-evasion class, F-1)."""
+    """The body of `if [ "$<var>" -gt 0 ]; then ... fi`.
+
+    Trailing inline `#` comments are stripped per line first, so a commented-out
+    `# exit 1` can neither satisfy nor falsely trip the severity-block checks
+    (comment-evasion class, F-1). The closing `fi` is found by a BALANCED if/fi
+    depth count — NOT the first `fi` — so a nested `if … fi` inside the block (or
+    a heredoc) cannot terminate the capture early and hide a trailing `exit 1`
+    (2nd-review Finding 1). `elif`/`else`/`then` are not `\\bfi\\b`/`\\bif\\b`
+    tokens, so they don't perturb the count.
+    """
     m = re.search(
-        r'\[\s*"\$' + re.escape(var) + r'"\s+-gt\s+0\s*\]\s*;\s*then(.*?)\bfi\b',
+        r'\[\s*"\$' + re.escape(var) + r'"\s+-gt\s+0\s*\]\s*;\s*then',
         text,
-        re.DOTALL,
     )
     if not m:
         return None
-    return "\n".join(strip_inline_comment(ln) for ln in m.group(1).splitlines())
+    # Comment-stripped remainder after the CRITS `then` (so a `# fi`/`# if` in a
+    # comment cannot skew the depth count).
+    rest = "\n".join(strip_inline_comment(ln) for ln in text[m.end():].splitlines())
+    depth, end = 1, len(rest)
+    for tk in re.finditer(r"\bif\b|\bfi\b", rest):
+        depth += 1 if tk.group(0) == "if" else -1
+        if depth == 0:
+            end = tk.start()
+            break
+    return rest[:end]
 
 
 # scanner/tests/this_file -> parents[2] == repo root
@@ -257,6 +272,22 @@ class TestSeverityBlockCommentEvasion(unittest.TestCase):
     def test_real_exit_one_satisfies(self):
         good = 'if [ "$CRITS" -gt 0 ]; then\n  exit 1\nfi'
         self.assertRegex(conditional_body_from(good, "CRITS"), r"\bexit\s+1\b")
+
+    def test_exit_one_after_nested_fi_is_captured(self):
+        # 2nd-review Finding 1: a nested `if … fi` must not terminate the capture
+        # before the outer `exit 1` (balanced fi-counter, not first-fi).
+        nested = (
+            'if [ "$CRITS" -gt 0 ]; then\n'
+            '  if [ "$X" -ge 1 ]; then\n    echo inner\n  fi\n'
+            "  exit 1\n"
+            "fi"
+        )
+        self.assertRegex(
+            conditional_body_from(nested, "CRITS"),
+            r"\bexit\s+1\b",
+            "Balanced-fi FAILED: `exit 1` after a nested `fi` was not captured — "
+            "a nested-if restructuring could silently disable the merge block.",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

A full adversarial audit of all 22 `test_ci_*.py` guards found a **systemic comment-evasion false-negative class** in guards that predate the shared comment-stripping primitives: a protected token surviving only in a `#` comment satisfies a presence/regex check while the real control is removed → guard stays green. Uniform fix: route the checks through the existing `_ci_guard_util` strippers + add a comment-evasion mutation self-test each.

| Sev | Guard | Hole → fix |
|-----|-------|-----------|
| **CRITICAL** | `test_ci_security_gate.py` | the `[ "$CRITS" -gt 0 ]; then … exit 1` block matched without comment-strip → `# exit 1` kept it green while the **only merge-blocking severity gate** was silently disabled. Now strips inline comments from the captured body (refactored to a testable `conditional_body_from`). |
| **HIGH** | `test_ci_coverage_thresholds.py` | 99%/90% floors found via `findall` over raw text → a commented-out floor still matched. Now scans whole-line + inline-stripped text. |
| **HIGH** | `test_ci_dependabot_automerge.py` | fork-guard token check over raw text → the same-repo guard surviving only in a comment satisfied it while the real `if:` could be neutered (pwn-request foot-gun on this write-token `pull_request_target` workflow). Now strips comments first. |
| **HIGH** | `test_ci_dockerfile_base_pinned.py` | `FROM_RE` anchors the ref at line-end → `FROM img@sha256:x  # note` silently dropped from digest + alpine-freeze checks. `from_refs` now strips inline comments too. |

The well-hardened recent guards (branch-protection, injection, npm-oidc, dependabot-config, prowler-version, no-ere-pipe) already defended this and were **unchanged**.

## Test plan
- [x] `pytest scanner/tests/test_ci_*.py` → **189 passed** (+7 mutation self-tests; + `unittest` dual-runner)
- [x] each fix proven **non-vacuous** (old code accepted the commented token; new rejects it)
- [x] the 4 affected guards: 48 tests green

> Per repo discipline (substring guards historically need 2 adversarial passes), a **second adversarial review** of these fixes is running before merge.

Remaining audit items (not in this PR, lower severity): MEDIUM F-5 (security-gate `needs:`/pass-set scoping), F-6 (npm-publish scoping), F-7 (`extract_on_block` inline-comment), LOW F-8/F-9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)