### PR TITLE
fix(ci): harden audit-backlog guards F-5/F-6/F-7 with mutation tests

### DIFF
--- a/scanner/tests/_ci_guard_util.py
+++ b/scanner/tests/_ci_guard_util.py
@@ -108,8 +108,10 @@ def on_key_inline(line: str):
 def extract_on_block(text: str) -> str:
     """Return a workflow's top-level `on:` trigger content: the inline remainder
     of the `on:` line (flow style) PLUS the indented child lines under it, up to
-    the next top-level key. Whole-line comments are dropped so prose mentioning a
-    trigger is never matched, and bare/quoted `on:` keys are both handled."""
+    the next top-level key. Whole-line comments are dropped AND trailing inline
+    `#` comments are stripped per retained line (F-7), so neither a prose line nor
+    a trailing comment mentioning a trigger can satisfy a consumer's presence
+    check; bare/quoted `on:` keys are both handled."""
     body = []
     in_on = False
     for line in text.splitlines():
@@ -119,11 +121,12 @@ def extract_on_block(text: str) -> str:
             inline = on_key_inline(line)
             if inline is not None:
                 in_on = True
+                inline = strip_inline_comment(inline)
                 if inline.strip():
                     body.append(inline)  # flow-style content on the `on:` line
             continue
         # A new top-level key (non-space first char, non-empty) ends the block.
         if line and not line[0].isspace():
             break
-        body.append(line)
+        body.append(strip_inline_comment(line))
     return "\n".join(body)

--- a/scanner/tests/test__ci_guard_util.py
+++ b/scanner/tests/test__ci_guard_util.py
@@ -1,0 +1,67 @@
+"""
+Direct unit tests for the shared `_ci_guard_util` primitives.
+
+The double-underscore name (`test__ci_guard_util.py`) keeps this file OUT of the
+`test_ci_*.py` catalog glob the meta-guards enforce (so it needs no Catalog row —
+it tests a helper, not a CI invariant), while still being collected by pytest
+(`test_*.py`). It gives the shared helpers their first direct coverage and locks
+the F-7 hardening (inline-comment stripping inside `extract_on_block`).
+
+stdlib-only; passes under pytest and `python3 -m unittest`. No network/subprocess.
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import (  # noqa: E402
+    extract_on_block,
+    strip_comment_lines,
+    strip_inline_comment,
+    top_level_jobs,
+)
+
+
+class TestStripInlineComment(unittest.TestCase):
+    def test_strips_trailing_comment(self):
+        self.assertEqual(strip_inline_comment("uses: foo@abc  # v1.2.3"), "uses: foo@abc")
+
+    def test_requires_whitespace_before_hash(self):
+        # `foo#bar` is not a shell comment — a `#` with no preceding space stays.
+        self.assertEqual(strip_inline_comment("image@sha256:dead#beef"), "image@sha256:dead#beef")
+
+
+class TestExtractOnBlockF7(unittest.TestCase):
+    """F-7: extract_on_block strips whole-line AND trailing-inline comments."""
+
+    def test_inline_comment_on_trigger_is_stripped(self):
+        wf = "on:\n  pull_request:  # only on PRs\n    branches: [main]  # gate\njobs:\n  x: {}"
+        block = extract_on_block(wf)
+        self.assertNotIn("#", block, "F-7: inline comments must be stripped from the on: block")
+        self.assertIn("pull_request:", block)
+
+    def test_whole_line_comment_dropped(self):
+        wf = "on:\n  # a prose mention of pull_request\n  push:\n    branches: [main]\njobs: {}"
+        block = extract_on_block(wf)
+        self.assertNotIn("pull_request", block, "whole-line comment must be dropped")
+        self.assertIn("push:", block)
+
+    def test_flow_style_and_quoted_on_key(self):
+        self.assertIn("pull_request", extract_on_block("on: [push, pull_request]  # ci\njobs: {}"))
+        self.assertIn("schedule", extract_on_block("'on':\n  schedule:\n    - cron: '0 0 * * *'\njobs: {}"))
+
+
+class TestTopLevelJobs(unittest.TestCase):
+    def test_parses_block_jobs_and_strips_inline_comment(self):
+        wf = "jobs:\n  build:  # the build\n    runs-on: x\n  test:\n    runs-on: y\non: {}"
+        self.assertEqual(top_level_jobs(wf), ["build", "test"])
+
+
+class TestStripCommentLines(unittest.TestCase):
+    def test_drops_whole_line_comments_only(self):
+        self.assertEqual(strip_comment_lines("a\n# c\n  b"), "a\n  b")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_ci_npm_publish.py
+++ b/scanner/tests/test_ci_npm_publish.py
@@ -144,16 +144,31 @@ class TestNpmPublishAutoRelease(unittest.TestCase):
 
     def test_npm_upgraded_before_publish(self):
         # OIDC trusted publishing needs npm >= 11.5.1; Node 22 bundles npm 10.x.
-        # Accept any global npm self-upgrade: `npm install -g npm...` / `npm i -g npm`.
-        run_lines = [_strip_comment(ln) for ln in self.text.splitlines()]
-        upgraded = any(
-            re.search(r"\bnpm\s+(?:install|i)\s+-g\s+npm\b", ln) for ln in run_lines
+        # F-6: require the upgrade to PRECEDE `npm publish` (an upgrade placed
+        # after the publish, or absent before it, would leave the publish on npm
+        # 10.x and lose OIDC). Lines are comment-stripped so a `# npm install -g
+        # npm` cannot satisfy it.
+        lines = [_strip_comment(ln) for ln in self.text.splitlines()]
+        upgrade_idx = next(
+            (i for i, ln in enumerate(lines)
+             if re.search(r"\bnpm\s+(?:install|i)\s+-g\s+npm\b", ln)),
+            None,
         )
-        self.assertTrue(
-            upgraded,
+        publish_idx = next(
+            (i for i, ln in enumerate(lines) if re.search(r"\bnpm\s+publish\b", ln)),
+            None,
+        )
+        self.assertIsNotNone(
+            upgrade_idx,
             "No `npm install -g npm` step found — Node 22 ships npm 10.x, which "
-            "cannot do OIDC trusted publishing (needs >= 11.5.1). The publish "
-            "would lose provenance / fall back to a missing token and fail.",
+            "cannot do OIDC trusted publishing (needs >= 11.5.1).",
+        )
+        self.assertIsNotNone(publish_idx, "No `npm publish` found in npm-publish.yml.")
+        self.assertLess(
+            upgrade_idx,
+            publish_idx,
+            "`npm install -g npm` must PRECEDE `npm publish` — an upgrade after "
+            "(or absent before) the publish leaves it on npm 10.x and loses OIDC.",
         )
 
     def test_auto_release_push_to_main_trigger(self):
@@ -177,11 +192,41 @@ class TestNpmPublishAutoRelease(unittest.TestCase):
         # The auto-release path pushes the vX.Y.Z tag from the publish job, which
         # needs job-level `contents: write`. Its ABSENCE means tag creation fails
         # (or the workflow-level grant was broadened — caught by the LP guard).
+        # F-6: comment-strip first so a `# contents: write` cannot satisfy it.
+        scan = "\n".join(_strip_comment(ln) for ln in self.text.splitlines())
         self.assertRegex(
-            self.text,
+            scan,
             r"contents:\s*write",
             "No `contents: write` anywhere — the publish job cannot push the "
             "release tag, so auto-tagging on version bump is broken.",
+        )
+
+
+class TestNpmPublishFsixHardening(unittest.TestCase):
+    """F-6 mutation self-tests: upgrade-ordering and comment-evasion."""
+
+    def test_upgrade_after_publish_is_detected(self):
+        # `npm publish` before `npm install -g npm` must trip (ordering invariant).
+        text = "run: npm publish --provenance\nrun: npm install -g npm@latest"
+        lines = [_strip_comment(ln) for ln in text.splitlines()]
+        up = next((i for i, ln in enumerate(lines)
+                   if re.search(r"\bnpm\s+(?:install|i)\s+-g\s+npm\b", ln)), None)
+        pub = next((i for i, ln in enumerate(lines)
+                    if re.search(r"\bnpm\s+publish\b", ln)), None)
+        self.assertFalse(
+            up is not None and pub is not None and up < pub,
+            "F-6: an upgrade placed AFTER publish should not satisfy the ordering.",
+        )
+
+    def test_contents_write_only_in_comment_does_not_satisfy(self):
+        scan = "\n".join(
+            _strip_comment(ln) for ln in "run: echo x  # contents: write".splitlines()
+        )
+        self.assertNotRegex(
+            scan,
+            r"contents:\s*write",
+            "F-6: a `# contents: write` surviving only in a comment must not "
+            "satisfy the tag-permission check.",
         )
 
 

--- a/scanner/tests/test_ci_security_gate.py
+++ b/scanner/tests/test_ci_security_gate.py
@@ -73,6 +73,46 @@ DAST_FULL_SCAN = WORKFLOW_DIR / "dast-full-scan.yml"
 GATE_REQUIRED_NEEDS = {"changes", "scan", "lighthouse"}
 
 
+def gate_block_from(text):
+    """The `security-scan-gate:` job block (its 2-space header to the next
+    2-space top-level key, or EOF), with trailing inline `#` comments stripped
+    per line so a commented token can't satisfy the gate checks (F-5b)."""
+    out, in_gate = [], False
+    for raw in text.splitlines():
+        if re.match(r"^  security-scan-gate:\s*$", raw):
+            in_gate = True
+            out.append(strip_inline_comment(raw))
+            continue
+        if in_gate:
+            if re.match(r"^  [A-Za-z0-9_-]+:", raw):  # next top-level job
+                break
+            out.append(strip_inline_comment(raw))
+    return "\n".join(out)
+
+
+def gate_needs_from(text):
+    """The set of jobs under the gate job's `needs:` key ONLY (block- or
+    flow-style). Scoping to the `needs:` sub-block (not a findall over the whole
+    job block) prevents a `- foo` list item elsewhere — a matrix entry, a step
+    input — from masking a dependency dropped from `needs:` (F-5a)."""
+    needs, in_needs = [], False
+    for raw in gate_block_from(text).splitlines():
+        flow = re.match(r"^    needs:\s*\[(.*)\]\s*$", raw)
+        if flow:
+            needs += re.findall(r"[A-Za-z0-9_-]+", flow.group(1))
+            continue
+        if re.match(r"^    needs:\s*$", raw):
+            in_needs = True
+            continue
+        if in_needs:
+            m = re.match(r"^      -\s*([A-Za-z0-9_-]+)\s*$", raw)
+            if m:
+                needs.append(m.group(1))
+            elif re.match(r"^    [A-Za-z]", raw):  # next 4-space key under the job
+                in_needs = False
+    return set(needs)
+
+
 class TestSecurityScanGate(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -83,20 +123,7 @@ class TestSecurityScanGate(unittest.TestCase):
         )
 
     def _gate_block(self):
-        # Capture the `security-scan-gate:` job block: from its 2-space header to
-        # the next 2-space top-level key (or EOF). 4-space child keys (name:,
-        # needs:, steps:, ...) do not terminate the block.
-        out, in_gate = [], False
-        for raw in self.text.splitlines():
-            if re.match(r"^  security-scan-gate:\s*$", raw):
-                in_gate = True
-                out.append(raw)
-                continue
-            if in_gate:
-                if re.match(r"^  [A-Za-z0-9_-]+:", raw):  # next top-level job
-                    break
-                out.append(raw)
-        return "\n".join(out)
+        return gate_block_from(self.text)
 
     def test_security_scan_yml_exists(self):
         self.assertTrue(SECURITY_SCAN.is_file(), f"{SECURITY_SCAN} not found")
@@ -120,9 +147,9 @@ class TestSecurityScanGate(unittest.TestCase):
         )
 
     def test_gate_aggregates_required_needs(self):
-        block = self._gate_block()
-        # `needs:` block-list items within the gate job
-        needs = set(re.findall(r"^\s*-\s*([A-Za-z0-9_-]+)\s*$", block, re.MULTILINE))
+        # Scoped to the gate job's `needs:` sub-block (F-5a) — not a findall over
+        # the whole job block, which a list item elsewhere could satisfy.
+        needs = gate_needs_from(self.text)
         missing = GATE_REQUIRED_NEEDS - needs
         self.assertEqual(
             missing,
@@ -254,6 +281,48 @@ class TestScanCriticalSeverityBlock(unittest.TestCase):
                 "HIGH findings must remain non-blocking (warning only); only "
                 "CRITICAL blocks the merge.",
             )
+
+
+class TestGateNeedsScopingAndPassset(unittest.TestCase):
+    """F-5: needs aggregation is scoped to the `needs:` sub-block, and the pass-set
+    check ignores comments."""
+
+    def test_needs_scoped_to_needs_block(self):
+        mutant = "\n".join(
+            [
+                "  security-scan-gate:",
+                "    needs:",
+                "      - scan",
+                "      - lighthouse",
+                "    steps:",
+                "      - with:",
+                "          deps:",
+                "            - changes",  # decoy list item — NOT a gate dependency
+                "  next-job:",
+            ]
+        )
+        self.assertNotIn(
+            "changes",
+            gate_needs_from(mutant),
+            "F-5a: a `- changes` list item outside the `needs:` sub-block was "
+            "wrongly counted as a gate dependency.",
+        )
+
+    def test_passset_surviving_only_in_comment_does_not_satisfy(self):
+        mutant = "\n".join(
+            [
+                "  security-scan-gate:",
+                "    steps:",
+                '      - run: echo keep  # not in ("success", "skipped")',
+                "  next-job:",
+            ]
+        )
+        self.assertNotRegex(
+            gate_block_from(mutant),
+            r"""not\s+in\s*\(\s*["']success["']\s*,\s*["']skipped["']\s*\)""",
+            "F-5b: the pass-set surviving only in a `#` comment must not satisfy "
+            "the gate's not-loosened check.",
+        )
 
 
 class TestSeverityBlockCommentEvasion(unittest.TestCase):


### PR DESCRIPTION
## Summary

Follow-up to the #271 full-audit backlog (the MEDIUM findings).

| Finding | Guard | Fix |
|---------|-------|-----|
| **F-5** | `test_ci_security_gate.py` | `needs:` aggregation used a `findall` over the whole job block → a `- foo` list item elsewhere (matrix, step input) could mask a dropped dependency; pass-set check ran un-stripped. Extracted testable `gate_block_from` (comment-stripped) + `gate_needs_from` (scoped to the `needs:` sub-block, block/flow). +2 mutation tests. |
| **F-6** | `test_ci_npm_publish.py` | npm-upgrade check only required `npm install -g npm` *anywhere* → now requires it to **precede** `npm publish` (ordering invariant; an upgrade after leaves npm 10.x / loses OIDC). `contents: write` check now comment-stripped. +2 mutation tests. |
| **F-7** | `_ci_guard_util.extract_on_block` | now strips trailing inline `#` comments per retained line (not just whole-line) → a future consumer can't be evaded by a trailing comment. Added the helper's **first direct tests** in `test__ci_guard_util.py`. |

`test__ci_guard_util.py` uses a double-underscore name so it's **excluded from the `test_ci_*.py` catalog glob** (it tests a helper, not a CI invariant → no Catalog row) while pytest still auto-collects it.

## Test plan
- [x] `test_ci_*.py` + `test__ci_guard_util.py` → **201 passed** under pytest AND `python3 -m unittest`
- [x] each fix has a **non-vacuous** mutation test (needs-scoping, passset comment-evasion, upgrade-ordering, contents:write comment-evasion, extract_on_block inline-strip)
- [x] catalog completeness/no-ghost meta-guards green (new file correctly excluded)
- [x] CI runs `pytest scanner/tests/` (auto-discovers the new file) with `CLAUDESEC_DASHBOARD_OFFLINE=1`

Remaining backlog after this: LOW F-8 (prowler-ordering comment-strip), F-9 (DAST on-block flow/quoted — reuse `extract_on_block`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)