### PR TITLE
fix(ci): gate npm-publish dry-run to skip already-published versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -133,9 +133,18 @@ jobs:
         # redirect; `npm@'>=11.5.1'` resolves to the highest matching (= latest).
         run: npm install -g npm@'>=11.5.1'
 
+      # Dry-run only when the version is NOT already on npm: `npm publish
+      # --dry-run` still performs the registry pre-check and ERRORS with "cannot
+      # publish over the previously published versions" for an existing version,
+      # so a dry_run dispatch on an unbumped version would fail. The
+      # already-published case is handled by the informational skip below.
       - name: Publish (dry run)
-        if: needs.detect.outputs.dry_run == 'true' || needs.detect.outputs.already_published == 'true'
+        if: needs.detect.outputs.dry_run == 'true' && needs.detect.outputs.already_published == 'false'
         run: npm publish --access public --provenance --dry-run
+
+      - name: Already published (skip)
+        if: needs.detect.outputs.already_published == 'true'
+        run: echo "::notice::claudesec@${{ needs.detect.outputs.version }} already on npm — nothing to publish (skipping dry-run/publish)."
 
       - name: Publish
         if: needs.detect.outputs.dry_run == 'false' && needs.detect.outputs.already_published == 'false'


### PR DESCRIPTION
## Summary

Latent bug found via a `dry_run` dispatch (2026-06-24): the **"Publish (dry run)"** step ran `npm publish --provenance --dry-run` whenever `dry_run==true OR already_published==true`, but `npm publish --dry-run` **still performs the registry pre-check** and errors:
```
npm error You cannot publish over the previously published versions: 0.7.2.
```
So a `workflow_dispatch` with `dry_run=true` on an **unbumped (already-published)** version FAILED — and the file's own header claim *"a version already present on npm is skipped (the job runs a --dry-run instead)"* was broken.

**Impact: LOW** — normal auto-release pushes skip the publish *job* entirely when already-published (`should_publish=false && dry_run=false`); only the manual dry-run-dispatch path broke.

## Fix
- **"Publish (dry run)"** now runs only when `dry_run==true && already_published==false` (dry-run a version not yet on npm → never errors).
- **New "Already published (skip)"** step emits an informational `::notice::` (no `npm publish`) when `already_published==true`, covering both push and dry-run-dispatch cases without hitting the registry pre-check.
- Real **"Publish"** step unchanged. Both `npm publish` invocations still carry `--provenance`.

## Test plan
- [x] `actionlint` clean
- [x] `test_ci_npm_publish.py` (every `npm publish` has `--provenance`) + `test_ci_injection_surface.py` pass (20) — the new step is an `echo`; its `${{ needs.detect.outputs.version }}` is trusted semver, not a `github.event.*` injection surface
- [x] run history confirms the hardened detect step + npm upgrade already succeed; this removes the only remaining dry-run-dispatch failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)