### PR TITLE
fix(ci): harden audit-backlog F-8/F-9 (LOW) — clears the #271 audit backlog

### DIFF
--- a/scanner/tests/test_ci_prowler_provider_guard_ordering.py
+++ b/scanner/tests/test_ci_prowler_provider_guard_ordering.py
@@ -52,9 +52,13 @@ stdlib-only: no PyYAML, no third-party deps. Runs under pytest (CI) and
 """
 
 import re
+import sys
 import unittest
 from pathlib import Path
 from typing import Dict, List, Tuple
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_inline_comment  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -129,6 +133,11 @@ def _parse_provider_sections(
         raw = lines[idx]
         lineno = idx + 1  # 1-based
 
+        # Section headers ARE comments (`# ── AWS ──`), so detect them on the RAW
+        # line. For guard/report CALL detection, ignore comment content (F-8):
+        # skip whole-line comments and strip trailing inline comments, so a guard
+        # surviving only in a comment cannot mask a real guard that is now after
+        # the report (which would skew the min(guard)<min(report) ordering check).
         if _SECTION_HEADER_RE.match(raw):
             _flush(current_label, current_guards, current_reports)
             current_label = raw.strip()
@@ -136,11 +145,13 @@ def _parse_provider_sections(
             current_reports = []
             continue
 
-        m = _GUARD_CALL_RE.search(raw)
+        active = "" if raw.lstrip().startswith("#") else strip_inline_comment(raw)
+
+        m = _GUARD_CALL_RE.search(active)
         if m:
             current_guards.append((m.group(1), lineno))
 
-        if _REPORT_CALL_RE.search(raw):
+        if _REPORT_CALL_RE.search(active):
             current_reports.append(lineno)
 
     _flush(current_label, current_guards, current_reports)
@@ -302,6 +313,29 @@ fi
             [],
             "Detector raised a false positive on correctly-ordered content: "
             + str(violations),
+        )
+
+    # F-8: a guard COMMENTED OUT above the report must not mask a real guard that
+    # now sits AFTER the report. Without comment-stripping, the commented guard's
+    # earlier line number satisfies min(guard)<min(report) and the bug hides.
+    _COMMENTED_GUARD_MASKS_BAD_ORDER = """\
+#!/usr/bin/env bash
+# ── Provider Scans ──────────────────────────────────────────────────────────
+
+# ── Fake Provider ────────────────────────────────────────────────────────────
+
+# _prowler_provider_available "fakeprovider"   # decoy: guard only in a comment
+_fake_json=$(_prowler_scan "fakeprovider")
+_prowler_report "FakeProvider" "$_fake_json" "PROWLER-FAKE"
+_prowler_provider_available "fakeprovider"
+"""
+
+    def test_commented_guard_does_not_mask_bad_ordering(self) -> None:
+        violations = self._check_ordering(self._COMMENTED_GUARD_MASKS_BAD_ORDER)
+        self.assertTrue(
+            violations,
+            "F-8: a guard surviving only in a comment masked a real guard placed "
+            "AFTER the report — the ordering check was evaded.",
         )
 
 

--- a/scanner/tests/test_ci_security_gate.py
+++ b/scanner/tests/test_ci_security_gate.py
@@ -29,7 +29,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import strip_inline_comment  # noqa: E402
+from _ci_guard_util import extract_on_block, strip_inline_comment  # noqa: E402
 
 
 def conditional_body_from(text, var):
@@ -177,28 +177,19 @@ class TestDastBaselinePrTrigger(unittest.TestCase):
             DAST_BASELINE.read_text(encoding="utf-8") if DAST_BASELINE.is_file() else ""
         )
 
-    def _on_block(self):
-        # The `on:` region: from `^on:` to the next top-level key (`jobs:` etc.).
-        out, in_on = [], False
-        for raw in self.text.splitlines():
-            if re.match(r"^on:\s*$", raw):
-                in_on = True
-                continue
-            if in_on:
-                if re.match(r"^[A-Za-z]", raw):  # next top-level key (jobs:, etc.)
-                    break
-                out.append(raw)
-        return "\n".join(out)
-
     def test_dast_baseline_yml_exists(self):
         self.assertTrue(DAST_BASELINE.is_file(), f"{DAST_BASELINE} not found")
 
     def test_triggers_on_pull_request(self):
-        on_block = self._on_block()
+        # F-9: use the shared extract_on_block (handles flow-style `on: [..]`,
+        # quoted `'on':`, and strips comments) instead of a block-only `^on:$`
+        # parser that missed those forms. `pull_request` present in the on: block
+        # (block or flow) satisfies the trigger; comments are already stripped.
+        on_block = extract_on_block(self.text)
         self.assertTrue(on_block, "dast-baseline.yml `on:` block not found")
-        self.assertRegex(
+        self.assertIn(
+            "pull_request",
             on_block,
-            r"^\s*pull_request:",
             "dast-baseline.yml must keep its `pull_request` trigger — losing it "
             "would silently demote the DAST scan to schedule/dispatch-only, "
             "removing per-PR signal.",
@@ -214,28 +205,16 @@ class TestDastFullScanSchedule(unittest.TestCase):
             else ""
         )
 
-    def _on_block(self):
-        # The `on:` region: from `^on:` to the next top-level key (`jobs:` etc.).
-        out, in_on = [], False
-        for raw in self.text.splitlines():
-            if re.match(r"^on:\s*$", raw):
-                in_on = True
-                continue
-            if in_on:
-                if re.match(r"^[A-Za-z]", raw):  # next top-level key (jobs:, etc.)
-                    break
-                out.append(raw)
-        return "\n".join(out)
-
     def test_dast_full_scan_yml_exists(self):
         self.assertTrue(DAST_FULL_SCAN.is_file(), f"{DAST_FULL_SCAN} not found")
 
     def test_triggers_on_schedule(self):
-        on_block = self._on_block()
+        # F-9: shared extract_on_block (flow/quoted/comment-aware) — see baseline.
+        on_block = extract_on_block(self.text)
         self.assertTrue(on_block, "dast-full-scan.yml `on:` block not found")
-        self.assertRegex(
+        self.assertIn(
+            "schedule",
             on_block,
-            r"^\s*schedule:",
             "dast-full-scan.yml must keep its `schedule:` trigger — removing it "
             "would silently stop the nightly full DAST scan with no visible "
             "failure (parallels the dast-baseline pull_request guard).",


### PR DESCRIPTION
## Summary

The final LOW items from the #271 full-audit backlog — **backlog now cleared (F-1..F-9 all addressed)**.

- **F-8** (`test_ci_prowler_provider_guard_ordering.py`): the section parser matched `_prowler_provider_available` / `_prowler_report` on RAW lines, so a guard surviving only in a comment (placed above the report) could mask a real guard now *after* it — `min(guard)<min(report)` held via the comment and the bad ordering hid. Now strips inline comments + skips whole-line comments for **call** detection (section headers `# ── X ──` are still matched raw). +1 non-vacuous mutation test.
- **F-9** (`test_ci_security_gate.py`): the two DAST `_on_block` parsers used a block-only `^on:$` scan (baseline also used `assertRegex(^\s*pull_request:)`), missing flow-style (`on: [pull_request]`) and quoted (`'on':`) triggers. Both now use the shared `extract_on_block` (flow/quoted/comment-aware) with `assertIn`. Its flow/quoted handling is covered by `test__ci_guard_util.py::TestExtractOnBlockF7`.

## Test plan
- [x] `test_ci_*.py` + `test__ci_guard_util.py` → **202 passed** under pytest AND `python3 -m unittest`
- [x] F-8 proven non-vacuous (old raw-match passes the comment-masked mutant; new code flags it)
- [x] F-9 relies on `extract_on_block`, already covered by the util tests

Closes the audit backlog opened by the #271 comprehensive guard review (verifier confirmed all #271–#276 work green on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)