### PR TITLE
ops(ci): operationalize ADR-001 audit cadence + ADR index

### DIFF
--- a/.github/workflows/guard-audit-reminder.yml
+++ b/.github/workflows/guard-audit-reminder.yml
@@ -1,0 +1,74 @@
+# Quarterly CI-Guard Adversarial Audit Reminder
+#
+# Operationalizes the periodic-audit cadence from ADR-001
+# (docs/devsecops/adr-001-ci-guard-hardening-and-audit-cadence.md): every quarter,
+# open a single idempotent reminder issue to run a comprehensive adversarial
+# audit of all scanner/tests/test_ci_*.py guards — catching older guards that
+# predate a hardening primitive (the comment-evasion false-negative class).
+#
+# This is a SCHEDULED NOTIFIER, not a gate: it must never run on pull_request /
+# pull_request_target and must never become a required status check (mirrors
+# provenance-verify.yml / protection-drift-watch.yml). It opens an issue; a human
+# runs the audit. Idempotent: if an open `guard-audit-due` issue already exists,
+# it does nothing (no duplicate spam).
+
+name: Guard Audit Reminder
+
+on:
+  schedule:
+    # 09:00 UTC on the 1st of Jan / Apr / Jul / Oct (quarterly).
+    - cron: '0 9 1 1,4,7,10 *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  remind:
+    name: Open quarterly guard-audit reminder
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Open reminder issue (idempotent)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # Ensure the label exists (no-op if it already does).
+          gh label list --repo "${GITHUB_REPOSITORY}" --json name \
+            | python3 -c "import sys,json; sys.exit(0 if 'guard-audit-due' in [l['name'] for l in json.load(sys.stdin)] else 1)" 2>/dev/null \
+            || gh label create guard-audit-due --repo "${GITHUB_REPOSITORY}" \
+                 --description "Quarterly ADR-001 CI-guard adversarial audit due" --color "1d76db"
+
+          # Idempotent: skip if an open reminder already exists.
+          existing="$(gh issue list --repo "${GITHUB_REPOSITORY}" \
+            --label guard-audit-due --state open --json number --limit 5)"
+          if [ "$(echo "$existing" | python3 -c 'import sys,json; print(len(json.load(sys.stdin)))')" -gt 0 ]; then
+            echo "An open guard-audit-due issue already exists — skipping duplicate."
+            exit 0
+          fi
+
+          {
+            echo "## Quarterly CI-guard adversarial audit due (ADR-001)"
+            echo ""
+            echo "Run a comprehensive adversarial audit of every"
+            echo "\`scanner/tests/test_ci_*.py\` guard, per the cadence in ADR-001"
+            echo "(\`docs/devsecops/adr-001-ci-guard-hardening-and-audit-cadence.md\`)."
+            echo ""
+            echo "### Checklist"
+            echo "- [ ] Confirm baseline: \`pytest scanner/tests/test_ci_*.py scanner/tests/test__ci_guard_util.py -q\` is green."
+            echo "- [ ] Adversarially review each guard for the comment-evasion false-negative class (token surviving only in a \`#\` comment, unhandled YAML form)."
+            echo "- [ ] Confirm every presence/regex check routes through the \`_ci_guard_util\` comment-stripping primitives."
+            echo "- [ ] Confirm every detector has a non-vacuous mutation self-test."
+            echo "- [ ] Update the 'Unguarded invariants backlog' review date in \`docs/devsecops/ci-config-regression-guards.md\`."
+            echo "- [ ] File follow-up PRs for any finding; close this issue when the backlog is triaged."
+            echo ""
+            echo "Reference: OWASP CICD-SEC-1 (Insufficient Flow Control); NIST SSDF (SP 800-218) PO.3/PW.4."
+          } > /tmp/body.md
+
+          gh issue create --repo "${GITHUB_REPOSITORY}" \
+            --title "chore(ci): quarterly ADR-001 guard adversarial audit due" \
+            --label guard-audit-due \
+            --body-file /tmp/body.md

--- a/docs/devsecops/adr-index.md
+++ b/docs/devsecops/adr-index.md
@@ -1,0 +1,45 @@
+---
+title: Architecture Decision Records (ADR) Index
+description: Convention and index for ClaudeSec Architecture Decision Records under docs/devsecops/adr-*.md
+tags: [adr, devsecops, process, documentation]
+---
+
+# Architecture Decision Records (ADR) Index
+
+An **Architecture Decision Record** captures a significant decision, the context
+that forced it, and its consequences — so the *why* outlives the PR that made it.
+ClaudeSec records decisions that shape its DevSecOps process (CI gates, guard
+discipline, release flow) as ADRs here.
+
+## Convention
+
+- **Location & name**: `docs/devsecops/adr-NNN-<kebab-slug>.md`, where `NNN` is a
+  zero-padded sequential number (`001`, `002`, …). This index is `adr-index.md`
+  (not numbered).
+- **Frontmatter**: every ADR needs `title`, `description`, `tags` (include `adr`).
+- **Body sections**: `Status`, `Date`, then `## Context`, `## Decision`,
+  `## Consequences`, `## References` (cite OWASP / NIST / CIS / vendor docs where
+  a security claim is made — repo rule).
+- **Status values**: `Proposed` → `Accepted` → (`Superseded by ADR-NNN` |
+  `Deprecated`). Never edit an Accepted ADR's decision in place; supersede it with
+  a new ADR and update its status.
+- **Immutable intent**: ADRs are a log. Fix typos freely; record changed
+  decisions as new ADRs.
+
+## Index
+
+| ADR | Title | Status | Date |
+|-----|-------|--------|------|
+| [ADR-001](./adr-001-ci-guard-hardening-and-audit-cadence.md) | CI Guard Hardening Discipline & Periodic Adversarial Audit | Accepted | 2026-06-24 |
+
+## Operationalization
+
+The periodic-audit cadence in ADR-001 is reminded automatically by the
+`Guard Audit Reminder` scheduled workflow
+(`.github/workflows/guard-audit-reminder.yml`), which opens a quarterly idempotent
+`guard-audit-due` issue. It is a scheduled notifier — never a required PR check.
+
+## References
+
+- ADR concept (Michael Nygard): <https://github.com/joelparkerhenderson/architecture-decision-record>
+- In-repo: [CI Config Regression Guards](./ci-config-regression-guards.md)


### PR DESCRIPTION
## Summary

Follow-ups to ADR-001 (#278) — make the periodic-audit cadence durable and establish the ADR convention.

- **`guard-audit-reminder.yml`** — a quarterly **scheduled notifier** (cron 1st of Jan/Apr/Jul/Oct + `workflow_dispatch`) that opens a single **idempotent** `guard-audit-due` issue reminding a human to run the comprehensive adversarial audit of all `test_ci_*.py` guards. Mirrors the `provenance-verify.yml` / `protection-drift-watch.yml` pattern: never runs on `pull_request(_target)`, never a required check, **no `uses:`** (pure `gh` run → no SHA-pin surface), least-privilege (`contents: read`, `issues: write`), skips if an open reminder exists. Operationalizes ADR-001 decision #5.
- **`adr-index.md`** — establishes the ADR convention (naming `adr-NNN-<slug>.md`, required sections, status lifecycle, supersede-don't-edit) and indexes ADR-001; links the reminder workflow.

Per the catalog's Tier-3 decision this aux scheduled notifier needs **no dedicated guard** (not enforcement-bearing, no write-token PR trigger) — consistent with `prowler-python-watch` / `dashboard-refresh`.

## Test plan
- [x] `actionlint` clean (new workflow)
- [x] `test_ci_gate_topology.py` green (new workflow has no `uses:` to SHA-pin)
- [x] `markdownlint` 0 errors (ADR index)
- [x] full `test_ci_*.py` + util suite → **202 passed**

## Session task status
- **#1**: #273 merged; **#274** (checkout v6→v7) armed/landing async — checkout-v7 fork-PR-blocking is a *future* observation (single-owner repo, no fork PR yet); monitoring plan recorded in memory.
- **#2**: this PR (scheduled reminder) — re-running the audit now would be redundant (just completed #271/#275/#277 + verifier PASS).
- **#3**: this PR (ADR index).

🤖 Generated with [Claude Code](https://claude.com/claude-code)