### PR TITLE
fix(ci): normalize actions/checkout version comments to v7.0.0 + record guard decision

### DIFF
--- a/.github/workflows/cross-os-checks.yml
+++ b/.github/workflows/cross-os-checks.yml
@@ -48,7 +48,7 @@ jobs:
             name: Windows KISA live checks (structural)
             test: scanner/tests/test_check_windows_kisa_security_live.sh
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Run OS-specific structural integration test
         shell: bash
         run: bash ${{ matrix.test }}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Run Lighthouse CI
         uses: treosh/lighthouse-ci-action@3e7e23fb74242897f95c0ba9cabad3d0227b9b18  # v12.6.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -35,7 +35,7 @@ jobs:
       shell: ${{ steps.detect.outputs.shell }}
       markdown: ${{ steps.detect.outputs.markdown }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
       - id: detect
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Dependency Review
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0 (node24)
         with:
@@ -97,7 +97,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.npm_deps == 'true' || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: '22'
@@ -110,7 +110,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.python_deps == 'true' || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: '3.11'
@@ -130,7 +130,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.shell == 'true' || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Run ShellCheck (pinned action + pinned engine version)
         # ludeeus/action-shellcheck@00cae500 is a composite action (no node runtime),
         # so it is unaffected by the 2026-06-02 node20 deprecation.
@@ -158,7 +158,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.scanner == 'true' || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
@@ -289,7 +289,7 @@ jobs:
       # written) so measured bash coverage is unchanged; local: 120s+ -> 3.7s.
       CLAUDESEC_DASHBOARD_OFFLINE: "1"
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Cache kcov v42 binary
         id: kcov-cache
         uses: actions/cache@2c8a9bd7457de244a408f35966fab2fb45fda9c8  # v6.0.0
@@ -458,7 +458,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.docker == 'true' || needs.changes.outputs.scanner == 'true' || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
       - name: Build claudesec runtime image (cache enabled)
@@ -549,7 +549,7 @@ jobs:
   pii-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Check for PII and personal information
         run: |
           find . -type f \( -name '*.py' -o -name '*.sh' -o -name '*.md' -o -name '*.yml' -o -name '*.yaml' -o -name '*.json' -o -name '*.html' -o -name '*.svg' \) \
@@ -563,7 +563,7 @@ jobs:
     # The audit script exits 1 on any unguarded job.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.1.0
         with:
           python-version: "3.13"
@@ -580,7 +580,7 @@ jobs:
       # dir --help` confirms it takes "[path]" and walks files. The history-
       # scanning subcommand `gitleaks git` is intentionally not used here;
       # full history checkout was a leftover from the gitleaks-action era.
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       # gitleaks/gitleaks-action v2.3.9 (latest) still runs on node20, and the
       # upstream node24 migration (gitleaks/gitleaks-action#215) was still open
       # as of 2026-05-19. To stay clear of the 2026-06-02 node20 deprecation we
@@ -615,7 +615,7 @@ jobs:
   frontmatter-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Check YAML frontmatter in docs
         # Uses find -print0 + while-read with process substitution to avoid
         # the shellcheck SC2044 fragile-for-loop pattern. Process substitution
@@ -646,7 +646,7 @@ jobs:
       && (needs.changes.outputs.docker == 'true' || needs.changes.outputs.scanner == 'true')
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Create placeholder dashboard files
         run: |
@@ -696,7 +696,7 @@ jobs:
   markdown-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Lint Markdown
         uses: DavidAnson/markdownlint-cli2-action@ded1f9488f68a970bc66ea5619e13e9b52e601cd  # v23
         with:
@@ -713,7 +713,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.markdown == 'true' || github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Check links
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:

--- a/.github/workflows/og-meta-verify.yml
+++ b/.github/workflows/og-meta-verify.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Run og-meta-verify and sticky-comment
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/protection-drift-watch.yml
+++ b/.github/workflows/protection-drift-watch.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Verify admin token is configured
         id: token_check

--- a/.github/workflows/prowler-python-watch.yml
+++ b/.github/workflows/prowler-python-watch.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
 
       - name: Check prowler Python ceiling
         id: ceiling

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -42,7 +42,7 @@ jobs:
     outputs:
       code: ${{ steps.detect.outputs.code }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           fetch-depth: 0
       - id: detect

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -147,6 +147,22 @@ Both former Tier-2 candidates landed in #258 and are now in the Catalog above:
   `dast-full-scan.yml` (`schedule:`) triggers are already asserted by
   `test_ci_security_gate.py`; no separate guard needed.
 
+- **`uses:` version-comment correctness vs the pinned SHA.**
+
+  **Decision (2026-06-24): no version-comment guard.** A guard asserting the
+  `# vX.Y.Z` comment matches the pinned SHA's actual tag would need to resolve
+  SHA → tag via the GitHub API — a **network call**, which violates the
+  stdlib-only / offline / no-subprocess constraint every guard here holds.
+  A weaker *presence* check (every `uses:` has *some* version comment) is
+  offline-feasible but would NOT have caught the real incident (a Dependabot bump
+  that updated the SHA but left a STALE `# v4.2.2` comment on a `v7.0.0` SHA,
+  normalized in the checkout-v7 cleanup) — it only catches a *missing* comment,
+  not a wrong one. Crucially, the comment is **cosmetic**: `test_ci_gate_topology.py`
+  already pins the 40-hex SHA (the actual supply-chain control), so a wrong
+  comment is a readability/doc-accuracy wart, not a security regression — below
+  the incident bar. Mitigation is a one-time normalization on each major action
+  bump, not a guard.
+
 ### Verified already-guarded during this review (not backlog)
 
 lychee `v0.23.0` pin (`test_ci_gate_topology.py`), the `Security Scan Gate`


### PR DESCRIPTION
## Summary

Cleanup after the #274 Dependabot actions-group bump (checkout v6→v7), which updated the SHA everywhere but left **inconsistent version comments**: 2 lines kept a stale `# v4.2.2`, 19 had none, 8 were correct.

- **Normalized all 29 `actions/checkout@9c091bb...` refs to `# v7.0.0`.** Verified the SHA `9c091bb...` is tagged **v7 / v7.0.0** via the GitHub API (commit "update error wording #2467") *before* relabeling. The diff is **comment-only** — no SHA/logic change; gate-topology SHA pins intact.
- **Recorded the ralplan decision** (Task 3) in the guard catalog backlog: **no version-comment guard.** Checking comment↔SHA *correctness* needs a network SHA→tag lookup (violates the stdlib-only/offline guard constraint); a *presence*-only check wouldn't catch a stale comment anyway; and the comment is cosmetic since `test_ci_gate_topology.py` already pins the 40-hex SHA (the real supply-chain control). Below the incident bar — mitigate by one-time normalization on each major bump.

## Test plan
- [x] `git diff` confirmed **comment-only** (every changed line is a `checkout@9c091bb` ref)
- [x] `actionlint` no errors
- [x] `test_ci_gate_topology.py` (SHA pins) + full `test_ci_*.py` + util → **202 passed**
- [x] `markdownlint` + catalog meta-guards green

## Session task status
- **#1**: this PR (comment normalization).
- **#2**: checkout-v7 monitor — lint.yml runs all green post-v7; fork-PR-blocking is unobservable without a fork PR (single-owner repo) — recorded for the next external PR.
- **#3**: this PR (decision recorded in the catalog backlog — ralplan conclusion: don't guard it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)