### PR TITLE
fix(ci): exclude kimchang.com from lychee link-check (flaky timeout)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -728,6 +728,7 @@ jobs:
             --exclude 'krcert.or.kr'
             --exclude 'privacy.kisa.or.kr'
             --exclude 'ecrm.cyber.go.kr'
+            --exclude 'kimchang.com'
             --exclude 'atlas.mitre.org'
             --exclude 'airc.nist.gov'
             --exclude 'media.defense.gov'


### PR DESCRIPTION
## Summary

The 김앤장 (`kimchang.com`) legal-insight URLs in `docs/compliance/isms-p.md:221-222` intermittently exceed lychee's 20s timeout, failing the `link-check` job → `Lint` aggregator → blocking **unrelated** PRs. This currently blocks #286 (a docker size-gate change that has nothing to do with these links, since link-check runs over `**/*.md`).

This adds `--exclude 'kimchang.com'` to the lychee args, matching the established pattern of excluding slow Korean legal/gov domains already in the list (`law.go.kr`, `pipc.go.kr`, `isms.kisa.or.kr`, `ecrm.cyber.go.kr`, ...).

## Verification

- `lychee` on `docs/compliance/isms-p.md` with the new exclude: **0 errors, 6 excluded, 2 OK**.
- Full CI guard suite: `python3 -m pytest scanner/tests/test_ci_*.py` → **195 passed**.
- YAML parse: OK.

## Scope

Single-line addition to `.github/workflows/lint.yml`. No doc content changed — the kimchang links remain in `isms-p.md` as authoritative references; they are simply skipped by the reachability check, exactly like the other slow KR domains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)