### PR TITLE
fix(docs): resolve lychee redirect-sweep #300 link rot + bot-block excludes

### DIFF
--- a/docs/guides/compliance-scan-integration-priority.md
+++ b/docs/guides/compliance-scan-integration-priority.md
@@ -30,7 +30,7 @@ ISMS-P, ISO 27001, SOC2, PCI-DSS 등 컴플라이언스에 준수하는 보안 �
 | **Prowler** | [prowler-cloud/prowler](https://github.com/prowler-cloud/prowler) | CIS, NIST 800-53/CSF, FedRAMP, **PCI-DSS**, **ISO 27001**, **SOC2**, **KISA ISMS-P**, GDPR, HIPAA 등 25+ | **이미 ClaudeSec 통합**. 멀티클라우드·GitHub. |
 | **Lynis** | [CISOfy/lynis](https://github.com/CISOfy/lynis) | HIPAA, ISO 27001, PCI-DSS (호스트 하드닝) | 호스트/OS 감사. 에이전트리스. |
 | **CloudAudit** | [xtawb/cloudaudit](https://github.com/xtawb/cloudaudit) | CIS, NIST, SOC2, ISO 27001, PCI-DSS | AWS/GCP/Azure, AI 기반. |
-| **Gestalt Security Framework** | [GestaltSecurity/Gestalt-Security-Framework](https://github.com/GestaltSecurity/Gestalt-Security-Framework) | NIST 800-53, ISO 27000, PCI-DSS, COBIT, CIS, SOC2 등 | 컨트롤 매핑·네비게이션용. 스캐너 아님. |
+| **Security Controls Mapping** | [counteractive/security-controls](https://github.com/counteractive/security-controls) | NIST CSF, CIS CSC, NIST 800-53, NIST 800-171, OWASP Top 10 Proactive/ASVS | 프레임워크 간 컨트롤 매핑 데이터셋(머신리더블). 스캐너 아님. |
 | **AuditKit** | (Community Edition) | SOC2, PCI-DSS, CMMC 등 | 오픈소스 컴플라이언스 스캐너. |
 
 **Best practice**: 단일 스캐너(Prowler)로 최대한 커버하고, 호스트/OS 레벨이 필요할 때만 Lynis 등 보조 도구를 검토.
@@ -126,7 +126,7 @@ ISMS-P, ISO 27001, SOC2, PCI-DSS 등 컴플라이언스에 준수하는 보안 �
 ## 7. 참고 자료
 
 - [QueryPie Audit Points](https://github.com/querypie/audit-points) — SaaS/DevSecOps 감사 포인트 공유 저장소
-- [Prowler Compliance (공식 문서)](https://docs.prowler.com/introduction/user-guide/compliance/tutorials/compliance)
+- [Prowler Compliance (공식 문서)](https://docs.prowler.com/introduction)
 - [Prowler Hub — Compliance](https://hub.prowler.com/compliance)
 - [KISA ISMS-P 소개](https://isms.kisa.or.kr/main/ispims/intro/)
 - [PCI-DSS 문서](https://www.pcisecuritystandards.org/document_library/?category=pcidss)

--- a/docs/guides/incident-response.md
+++ b/docs/guides/incident-response.md
@@ -13,7 +13,7 @@ tags: [incident-response, nist, iso27035, security-operations, playbook]
 - [NIST SP 800-61r2](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf) — Computer Security Incident Handling Guide
 - [NIST CSF 2.0](https://www.nist.gov/cyberframework) — Cybersecurity Framework, Respond (RS) Function
 - [ISO/IEC 27035](https://www.iso.org/standard/78973.html) — Information Security Incident Management
-- [SANS Incident Handler's Handbook](https://www.sans.org/white-papers/33901/) — Incident Handling Step-by-Step
+- [SANS Incident Handler's Handbook](https://www.sans.org/white-papers/33901) — Incident Handling Step-by-Step
 
 ---
 
@@ -440,11 +440,11 @@ behavior:
 | NIST SP 800-61r2 | <https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-61r2.pdf> |
 | NIST CSF 2.0 Respond Function | <https://www.nist.gov/cyberframework> |
 | ISO/IEC 27035 | <https://www.iso.org/standard/78973.html> |
-| SANS Incident Handler's Handbook | <https://www.sans.org/white-papers/33901/> |
+| SANS Incident Handler's Handbook | <https://www.sans.org/white-papers/33901> |
 | MITRE ATT&CK | <https://attack.mitre.org> |
 | KrCERT/CC 침해사고 신고 | <https://www.krcert.or.kr> |
 | 개인정보보호위원회 | <https://www.pipc.go.kr> |
-| OWASP Incident Response | <https://owasp.org/www-community/Incident_Response> |
+| OWASP SAMM Incident Management | <https://owaspsamm.org/model/operations/incident-management/> |
 
 ## 관련 문서
 

--- a/docs/guides/zscaler-zia-datadog.md
+++ b/docs/guides/zscaler-zia-datadog.md
@@ -109,5 +109,5 @@ After configuration, run the ClaudeSec scanner:
 ## References
 
 - [Zscaler NSS Deployment Guide](https://help.zscaler.com/zia/about-nanolog-streaming-service)
-- [Datadog Zscaler Integration](https://docs.datadoghq.com/integrations/zscaler_internet_access/)
+- [Datadog Zscaler Integration](https://docs.datadoghq.com/integrations/z-scaler/)
 - [ZIA API Documentation](https://help.zscaler.com/zia/api)

--- a/lychee.toml
+++ b/lychee.toml
@@ -36,6 +36,16 @@ exclude = [
   "in-toto.io",
   "sigstore.dev",
   "public.cyber.mil",
+  #   * ISO standard pages 403 to crawlers (Akamai) but load in a browser;
+  #     path-specific so non-/standard iso.org links stay checked.
+  "www.iso.org/standard/",
+  #   * npm package page 403s to bots but is the canonical package URL.
+  "www.npmjs.com/package/claudesec",
+  #   * SK Shieldus security blog 403s to CI crawlers, fine in a browser.
+  "www.skshieldus.com/blog-security/",
+  # --- Template placeholders: intentionally non-real URLs in templates/ that
+  #     404 by design (users substitute their own org/repo).
+  "github.com/YOUR_ORG/YOUR_REPO",
   # --- Upstream URL structure changed / varies (false-positive 404s)
   "atlas.mitre.org",
   "airc.nist.gov",


### PR DESCRIPTION
## Why

The monthly `Lychee Redirect Sweep` opened **#300** with 16 findings (redirects + link rot the PR-time `link-check` accepts by design via `--accept '100..=599'`). This resolves all of them following the [`lychee-redirect-triage`](.claude/skills/lychee-redirect-triage/SKILL.md) playbook.

## What

**Dead links (404) → canonical URL**
- Prowler compliance docs → `docs.prowler.com/introduction` (old deep path 404s)
- OWASP `www-community/Incident_Response` (404) → **OWASP SAMM Incident Management** (`owaspsamm.org`, authoritative + live 200)
- Datadog `zscaler_internet_access/` (404) → canonical `/integrations/z-scaler/` (200)

**Fabricated reference → real, verified tool**
- `GestaltSecurity/Gestalt-Security-Framework` **does not exist** (the org has only a `site` repo; no such project anywhere on the web). Replaced with the real [`counteractive/security-controls`](https://github.com/counteractive/security-controls), listing its **actual** framework coverage (NIST CSF, CIS CSC, NIST 800-53/800-171, OWASP Top 10 Proactive/ASVS) — not the roadmap-only SOC2/PCI/ISO/COBIT the repo doesn't yet implement.

**Redirect (3xx) → rewritten to canonical (not excluded)**
- SANS `white-papers/33901/` 308-normalized to the no-slash `/33901` on the CI runner → rewrote to canonical (playbook case 2). **Not** added as an exclude: the local 403 seen during triage was a `Server: Zscaler/6.2` proxy artifact, not a real SANS bot-block.

**Bot-block excludes (403 to CI crawlers, browser-accessible)** — added to the *"blocks bots"* section of `lychee.toml`, path-specific so sibling links stay checked. The exact-count-guarded `# --- Intentional redirects` section is **untouched** (stays at 3):
- `www.iso.org/standard/` (Akamai bot-challenge)
- `www.npmjs.com/package/claudesec`
- `www.skshieldus.com/blog-security/`
- `github.com/YOUR_ORG/YOUR_REPO` (template placeholder, 404 by design)

## Verification

- Strict sweep on the **tracked** repo: `lychee --config lychee.toml --max-redirects 0 --accept '200..=299' '**/*.md'` → **0 errors** (215 OK, 173 excluded). The 5 errors under `.claudesec-sources/` are a **gitignored** vendored clone CI never checks out (absent from #300).
- Guard `test_ci_lychee_config.py` → **12/12** (intentional-redirect section unchanged at 3).
- `markdownlint` on the 3 changed docs → clean.
- **SANS caveat:** cannot be verified locally (Zscaler proxy 403s it). The post-merge sweep re-run is the definitive check — if `/33901` is clean, #300 auto-closes; if SANS still fails there, it will be the only remaining item and gets re-triaged with clean-runner evidence.

Refs #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)