### PR TITLE
docs(ci): link-hygiene follow-ups from redirect sweep

### DIFF
--- a/docs/guides/compliance-scan-integration-priority.md
+++ b/docs/guides/compliance-scan-integration-priority.md
@@ -30,7 +30,7 @@ ISMS-P, ISO 27001, SOC2, PCI-DSS 등 컴플라이언스에 준수하는 보안 �
 | **Prowler** | [prowler-cloud/prowler](https://github.com/prowler-cloud/prowler) | CIS, NIST 800-53/CSF, FedRAMP, **PCI-DSS**, **ISO 27001**, **SOC2**, **KISA ISMS-P**, GDPR, HIPAA 등 25+ | **이미 ClaudeSec 통합**. 멀티클라우드·GitHub. |
 | **Lynis** | [CISOfy/lynis](https://github.com/CISOfy/lynis) | HIPAA, ISO 27001, PCI-DSS (호스트 하드닝) | 호스트/OS 감사. 에이전트리스. |
 | **CloudAudit** | [xtawb/cloudaudit](https://github.com/xtawb/cloudaudit) | CIS, NIST, SOC2, ISO 27001, PCI-DSS | AWS/GCP/Azure, AI 기반. |
-| **Security Controls Mapping** | [counteractive/security-controls](https://github.com/counteractive/security-controls) | NIST CSF, CIS CSC, NIST 800-53, NIST 800-171, OWASP Top 10 Proactive/ASVS | 프레임워크 간 컨트롤 매핑 데이터셋(머신리더블). 스캐너 아님. |
+| **Security Controls Mapping** | [center-for-threat-informed-defense/mappings-explorer](https://github.com/center-for-threat-informed-defense/mappings-explorer) · [usnistgov/oscal-content](https://github.com/usnistgov/oscal-content) | NIST 800-53 Rev4/5 ↔ MITRE ATT&CK, CSF 2.0, NIST 800-171 Rev3 (머신리더블 JSON/YAML/CSV) | 프레임워크 간 컨트롤 매핑 데이터셋. 스캐너 아님. counteractive/security-controls는 2020년 이후 미유지(NIST CSF 1.1 기준)라 MITRE CTID + NIST OSCAL로 교체. |
 | **AuditKit** | (Community Edition) | SOC2, PCI-DSS, CMMC 등 | 오픈소스 컴플라이언스 스캐너. |
 
 **Best practice**: 단일 스캐너(Prowler)로 최대한 커버하고, 호스트/OS 레벨이 필요할 때만 Lynis 등 보조 도구를 검토.
@@ -126,7 +126,7 @@ ISMS-P, ISO 27001, SOC2, PCI-DSS 등 컴플라이언스에 준수하는 보안 �
 ## 7. 참고 자료
 
 - [QueryPie Audit Points](https://github.com/querypie/audit-points) — SaaS/DevSecOps 감사 포인트 공유 저장소
-- [Prowler Compliance (공식 문서)](https://docs.prowler.com/introduction)
+- [Prowler Compliance (공식 문서)](https://docs.prowler.com/user-guide/compliance/tutorials/compliance)
 - [Prowler Hub — Compliance](https://hub.prowler.com/compliance)
 - [KISA ISMS-P 소개](https://isms.kisa.or.kr/main/ispims/intro/)
 - [PCI-DSS 문서](https://www.pcisecuritystandards.org/document_library/?category=pcidss)

--- a/lychee.toml
+++ b/lychee.toml
@@ -77,4 +77,10 @@ exclude = [
 ]
 
 # Directories never walked for links.
-exclude_path = ["node_modules"]
+#   * node_modules: vendored deps, never our docs.
+#   * .claudesec-sources: gitignored local cache of fetched upstream sources.
+#     Absent in CI (not committed), but present on developer machines, where a
+#     local sweep (`lychee --config lychee.toml ... '**/*.md'`) would otherwise
+#     walk it and report rot in third-party docs we do not own. Excluded so the
+#     local verify command matches CI's committed-file-only view.
+exclude_path = ["node_modules", ".claudesec-sources"]

--- a/scanner/tests/test_ci_lychee_config.py
+++ b/scanner/tests/test_ci_lychee_config.py
@@ -287,6 +287,19 @@ class TestCiLycheeConfig(unittest.TestCase):
             "the inline `--exclude-path node_modules`).",
         )
 
+    def test_toml_excludes_claudesec_sources_path(self):
+        # `.claudesec-sources` is a gitignored local cache of fetched upstream
+        # docs. It is absent in CI (never committed) but present on dev machines,
+        # where a local sweep would otherwise walk it and report rot in
+        # third-party docs we do not own. Keep it in `exclude_path` so the local
+        # verify command matches CI's committed-file-only view.
+        self.assertRegex(
+            strip_comment_lines(self.toml_text),
+            r"exclude_path\s*=\s*\[[^\]]*\.claudesec-sources",
+            "lychee.toml must keep `.claudesec-sources` in `exclude_path` so a "
+            "local sweep does not scan the gitignored upstream-source cache.",
+        )
+
     def test_lychee_toml_is_change_detected(self):
         # The `changes` job path-gates link-check on the `markdown` bucket and
         # scanner-unit-tests (this guard) on the `scanner` bucket. If lychee.toml


### PR DESCRIPTION
Three follow-ups surfaced by the monthly lychee redirect sweep work (#298–#301).

## Changes

### 1. `lychee.toml` — exclude the gitignored source cache
Add `.claudesec-sources` to `exclude_path` (alongside `node_modules`). It is a gitignored local cache of fetched upstream docs — absent in CI (never committed) but present on developer machines, where a local strict sweep would otherwise walk it and report rot in third-party docs we don't own. This makes the local verify command match CI's committed-file-only view. Guarded by a new `test_toml_excludes_claudesec_sources_path` in `test_ci_lychee_config.py`.

### 2. Prowler compliance link precision
`docs/guides/compliance-scan-integration-priority.md`: the link labelled **"Prowler Compliance (공식 문서)"** now points at the canonical compliance page `docs.prowler.com/user-guide/compliance/tutorials/compliance` instead of the generic `/introduction`. The generic **"Prowler Documentation"** link in `cloud-security-posture.md` stays at `/introduction` by design (its label is generic).

### 3. Replace abandoned control-mapping dataset
`counteractive/security-controls` is unmaintained (last commit 2020, still NIST CSF 1.1, 49 stars). Replaced with two actively-maintained authoritative sources:
- **MITRE CTID Mappings Explorer** — NIST 800-53 Rev4/5 ↔ ATT&CK (v1.1.0, Apr 2025)
- **NIST `usnistgov/oscal-content`** — SP 800-53 Rev5, CSF 2.0, SP 800-171 Rev3 (machine-readable)

## Verification
- All replacement URLs confirmed **clean 2xx, no redirect** under the strict sweep (`--max-redirects 0 --accept '200..=299'`).
- `markdownlint` OK; `lychee` on changed doc: 10 OK / 0 errors.
- `pytest scanner/tests/test_ci_lychee_config.py test_ci_lychee_redirect_sweep.py` → 24 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)