### PR TITLE
docs(ai): cite NIST OLIR OWASP LLM Top 10 ↔ CSF 2.0 mapping

### DIFF
--- a/docs/ai/llm-top10-2025.md
+++ b/docs/ai/llm-top10-2025.md
@@ -351,3 +351,4 @@ async function queryLLM(prompt: string, user: User): Promise<string> {
 - [OWASP GenAI Resources](https://genai.owasp.org/)
 - [MITRE ATLAS](https://atlas.mitre.org/)
 - [NIST AI RMF](https://www.nist.gov/artificial-intelligence)
+- [NIST OLIR Informative Reference Catalog](https://csrc.nist.gov/projects/olir/informative-reference-catalog) — NIST 공식 카탈로그에 `OWASP-LLM-Top10v2.0-to-CSFv2.0` 매핑이 Final 상태(2026-05-08)로 등재. OWASP LLM Top 10 항목을 NIST CSF 2.0 컨트롤로 크로스워크하는 머신리더블 참조 (NIST IR 8278r1 기반)


### PR DESCRIPTION
Adds the NIST OLIR Informative Reference Catalog to `docs/ai/llm-top10-2025.md` references.

## Why
NIST published the `OWASP-LLM-Top10v2.0-to-CSFv2.0` Online Informative Reference at **Final** status on **2026-05-08** (draft 2026-04-08, 30-day public comment per NIST IR 8278r1). It is a machine-readable crosswalk from OWASP LLM Top 10 items to NIST CSF 2.0 controls — directly relevant to this doc and satisfies the NIST authoritative-citation rule.

## Link choice
Points at the catalog root `csrc.nist.gov/projects/olir/informative-reference-catalog` (stable, HTTP 200, no redirect) rather than a version-pinned `?referenceId=` details URL that would rot.

## Verification
- Mapping existence + Final date confirmed via NIST CSRC / nist.gov.
- Catalog URL: `curl -L` → 200, no redirect.
- `markdownlint docs/ai/llm-top10-2025.md` → OK.
- `lychee --config lychee.toml --max-redirects 0 --accept '200..=299' docs/ai/llm-top10-2025.md` → 5 OK / 0 errors.

Follow-up to the link-hygiene sweep (#302).

🤖 Generated with [Claude Code](https://claude.com/claude-code)