### PR TITLE
feat(scanner): render non-assessable ISMS-P 3.x PII controls as N/A

### DIFF
--- a/scanner/lib/compliance-map.py
+++ b/scanner/lib/compliance-map.py
@@ -322,6 +322,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "개인정보 수집 시 목적 명시, 동의 획득, 최소 수집 원칙",
             "action": "수집 목적 명시; 필수/선택 동의 분리; 최소 수집 원칙 이행; 법적 근거 확인.",
             "checks": ["personal_data", "pii", "consent", "privacy", "collection"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -330,6 +331,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "주민등록번호 수집 원칙적 금지, 법령 근거 시에만 처리",
             "action": "주민번호 수집 최소화; 대체 수단(CI/DI) 활용; 암호화 저장 필수.",
             "checks": ["pii", "ssn", "identification", "encrypt", "masking"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -338,6 +340,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "민감정보 및 고유식별정보 처리 시 별도 동의·보호조치",
             "action": "별도 동의 획득; 암호화 필수; 접근 제한; 처리 현황 관리.",
             "checks": ["sensitive", "biometric", "health", "encrypt", "pii"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -346,6 +349,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "보유 개인정보 현황 관리 및 처리 목적별 분류",
             "action": "개인정보 처리대장; 보유량·목적·보유기간 관리; 주기적 현행화.",
             "checks": ["pii", "inventory", "data_classification", "personal_data"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -354,6 +358,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "가명정보 처리 시 안전조치 및 재식별 금지",
             "action": "가명처리 기준 수립; 결합 전문기관 활용; 재식별 금지 조치.",
             "checks": ["pseudonymization", "anonymization", "masking", "de_identification"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -362,6 +367,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "개인정보 제3자 제공 시 동의 및 계약 관리",
             "action": "제공 동의 획득; 제공 항목·목적 명시; 제공 이력 관리.",
             "checks": ["third_party", "sharing", "consent", "data_transfer"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -370,6 +376,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "개인정보 국외이전 시 정보주체 동의 및 보호조치",
             "action": "국외이전 동의; 수탁자 보호조치 계약; 이전 현황 공개.",
             "checks": ["cross_border", "international", "gdpr"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -378,6 +385,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "보유기간 경과·목적 달성 시 지체 없이 파기",
             "action": "파기 절차; 복구 불가능한 방법(물리적 파괴, 데이터 삭제); 파기 기록 관리.",
             "checks": ["deletion", "retention", "destroy", "purge", "lifecycle"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -386,6 +394,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "개인정보 처리방침 수립 및 공개",
             "action": "처리방침 웹사이트 게시; 필수 기재항목 확인; 변경 시 공지.",
             "checks": ["privacy_policy", "disclosure", "notice", "transparency"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -394,6 +403,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "열람·정정·삭제·처리정지·전송요구·자동화결정 거부 권리 보장",
             "action": "권리 행사 절차; 전송요구권(데이터이동권) 대응; 자동화 결정 거부·설명 요구권 대응; 10일 내 처리.",
             "checks": ["data_subject", "right_to_access", "right_to_delete", "portability", "automated_decision"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -402,6 +412,7 @@ COMPLIANCE_CONTROL_MAP = {
             "desc": "개인정보 이용내역을 정보주체에게 주기적 통지",
             "action": "연 1회 이상 이용내역 통지; 통지 내용(항목, 이용목적, 보유기간); 전자적 통지.",
             "checks": ["notification", "notice", "transparency", "reporting"],
+            "assessable": False,
             "status": "",
         },
     ],
@@ -676,7 +687,10 @@ def map_compliance(all_findings):
                 native_match = _match_prowler_compliance(f, framework)
                 if keyword_match or native_match:
                     matching.append(f)
-            status = "PASS" if len(matching) == 0 else "FAIL"
+            if not ctrl.get("assessable", True):
+                status = "N/A"
+            else:
+                status = "PASS" if len(matching) == 0 else "FAIL"
             mapped.append(
                 {
                     **ctrl,
@@ -690,10 +704,14 @@ def map_compliance(all_findings):
 
 
 def compliance_summary(compliance_map):
-    """Return {framework: {pass, fail, total}} from map_compliance output."""
+    """Return {framework: {pass, fail, na, total}} from map_compliance output.
+
+    N/A controls are excluded from total (total = pass + fail).
+    """
     summary = {}
     for fw, controls in compliance_map.items():
         p = sum(1 for c in controls if c["status"] == "PASS")
         f = sum(1 for c in controls if c["status"] == "FAIL")
-        summary[fw] = {"pass": p, "fail": f, "total": p + f}
+        na = sum(1 for c in controls if c["status"] == "N/A")
+        summary[fw] = {"pass": p, "fail": f, "na": na, "total": p + f}
     return summary

--- a/scanner/lib/dashboard-gen.py
+++ b/scanner/lib/dashboard-gen.py
@@ -50,7 +50,7 @@ from dashboard_mapping import (  # noqa: F401
     CHECK_EN_MAP, DEFAULT_SUMMARY, DEFAULT_ACTION, get_check_en,
     OWASP_2025, OWASP_CHECK_MAP, OWASP_LLM_2025, map_findings_to_owasp,
     COMPLIANCE_FRAMEWORKS, COMPLIANCE_CONTROL_MAP,
-    map_compliance, _match_prowler_compliance,
+    map_compliance, _match_prowler_compliance, compliance_summary as _compliance_summary,
     ARCH_DOMAINS, ARCH_DOMAIN_LINKS, OWASP_TO_ARCH, map_architecture,
     CATEGORY_META,
 )
@@ -177,12 +177,8 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
     total_prowler_fail = sum(v["total_fail"] for v in prov_summary.values())
     total_prowler_pass = sum(v["total_pass"] for v in prov_summary.values())
 
-    # Compliance summary for history tracking
-    compliance_summary = {}
-    for fw, controls in compliance_map.items():
-        fw_pass = sum(1 for c in controls if c["status"] == "PASS")
-        fw_fail = sum(1 for c in controls if c["status"] == "FAIL")
-        compliance_summary[fw] = {"pass": fw_pass, "fail": fw_fail, "total": fw_pass + fw_fail}
+    # Compliance summary for history tracking (canonical source: compliance-map.py)
+    compliance_summary = _compliance_summary(compliance_map)
 
     history_json = json.dumps(
         history

--- a/scanner/lib/dashboard-template.html
+++ b/scanner/lib/dashboard-template.html
@@ -316,13 +316,13 @@ tr.arch-highlight td{animation:archPulseTd 1.2s ease 2}
 .comp-title{padding:.75rem 1.25rem;font-weight:700;font-size:.9rem;cursor:pointer;display:flex;align-items:center;gap:.75rem;transition:background .15s}
 .comp-title:hover{background:rgba(255,255,255,.03)}
 .comp-stat{font-size:.78rem;font-weight:600;margin-left:auto}
-.cs-pass{color:#22c55e}.cs-fail{color:#ef4444}
+.cs-pass{color:#22c55e}.cs-fail{color:#ef4444}.cs-na{color:#94a3b8}
 .comp-arrow{color:var(--muted);font-size:.7rem;transition:transform .2s}
 .comp-section.expanded .comp-arrow{transform:rotate(90deg)}
 .comp-body{display:none;padding:0}
 .comp-section.expanded .comp-body{display:block}
 .comp-arch-links{padding:.5rem 1rem;background:rgba(255,255,255,.02);border-bottom:1px solid var(--border)}
-.comp-pass td{opacity:.7}.comp-fail td{}.comp-st-pass{color:#22c55e;font-weight:700}.comp-st-fail{color:#ef4444;font-weight:700}
+.comp-pass td{opacity:.7}.comp-fail td{}.comp-st-pass{color:#22c55e;font-weight:700}.comp-st-fail{color:#ef4444;font-weight:700}.comp-na td{opacity:.6}.comp-st-na{color:#94a3b8;font-weight:700}
 /* Trend */
 .trend-section{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;margin-bottom:1.5rem}
 .trend-section h2{font-size:.95rem;margin-bottom:.75rem}

--- a/scanner/lib/dashboard_compliance.py
+++ b/scanner/lib/dashboard_compliance.py
@@ -6,7 +6,7 @@ cap (coding-style rule). Re-exported by dashboard_mapping for backward
 compatibility; importers may use either path.
 
 Public names: COMPLIANCE_FRAMEWORKS, COMPLIANCE_CONTROL_MAP,
-_match_prowler_compliance, map_compliance.
+_match_prowler_compliance, map_compliance, compliance_summary.
 
 The compliance control map itself is defined once, in compliance-map.py (the
 single source of truth, also loaded directly by output.sh). This module imports
@@ -102,3 +102,4 @@ except Exception as e:
 COMPLIANCE_CONTROL_MAP = _cm_mod.COMPLIANCE_CONTROL_MAP
 _match_prowler_compliance = _cm_mod._match_prowler_compliance
 map_compliance = _cm_mod.map_compliance
+compliance_summary = _cm_mod.compliance_summary

--- a/scanner/lib/dashboard_html_compliance.py
+++ b/scanner/lib/dashboard_html_compliance.py
@@ -32,9 +32,9 @@ def _build_compliance_html(compliance_map) -> str:
         "PCI-DSS v4.0.1": [0, 1, 2, 3, 4, 5],
     }
     for framework, controls in compliance_map.items():
-        total_c = len(controls)
         pass_c = sum(1 for c in controls if c["status"] == "PASS")
-        fail_c = total_c - pass_c
+        fail_c = sum(1 for c in controls if c["status"] == "FAIL")
+        na_c = sum(1 for c in controls if c["status"] == "N/A")
         comp_id = comp_slug(framework)
         comp_arch_html = ""
         for aidx in COMP_FW_TO_ARCH.get(framework, []):
@@ -46,14 +46,18 @@ def _build_compliance_html(compliance_map) -> str:
             if comp_arch_html
             else ""
         )
-        comp_html += f'<div class="comp-section" id="{comp_id}"><div class="comp-title" onclick="toggleComp(this)">{h(framework)} <span class="comp-stat"><span class="cs-pass">{pass_c} pass</span> / <span class="cs-fail">{fail_c} fail</span></span><span class="comp-arrow">▸</span></div>'
+        na_stat_html = f' / <span class="cs-na">{na_c} n/a</span>' if na_c > 0 else ""
+        comp_html += f'<div class="comp-section" id="{comp_id}"><div class="comp-title" onclick="toggleComp(this)">{h(framework)} <span class="comp-stat"><span class="cs-pass">{pass_c} pass</span> / <span class="cs-fail">{fail_c} fail</span>{na_stat_html}</span><span class="comp-arrow">▸</span></div>'
         if comp_arch_row:
             comp_html += comp_arch_row
         comp_html += '<div class="comp-body"><table><thead><tr><th>Control</th><th>Name</th><th>Status</th><th>Related</th><th>Summary · Remediation</th></tr></thead><tbody>'
         for ctrl in controls:
-            st_cls = "pass" if ctrl["status"] == "PASS" else "fail"
-            st_icon = "✓" if ctrl["status"] == "PASS" else "✗"
-            st_text = "Pass" if ctrl["status"] == "PASS" else "Fail"
+            if ctrl["status"] == "PASS":
+                st_cls, st_icon, st_text = "pass", "✓", "Pass"
+            elif ctrl["status"] == "N/A":
+                st_cls, st_icon, st_text = "na", "—", "N/A"
+            else:
+                st_cls, st_icon, st_text = "fail", "✗", "Fail"
             desc = (ctrl.get("desc") or ctrl.get("name") or "").strip()
             action = (
                 ctrl.get("action")

--- a/scanner/lib/dashboard_mapping.py
+++ b/scanner/lib/dashboard_mapping.py
@@ -531,6 +531,7 @@ from dashboard_compliance import (  # noqa: F401  (re-exported for back-compat)
     COMPLIANCE_CONTROL_MAP,
     _match_prowler_compliance,
     map_compliance,
+    compliance_summary,
 )
 
 
@@ -617,6 +618,7 @@ __all__ = [
     "COMPLIANCE_CONTROL_MAP",
     "_match_prowler_compliance",
     "map_compliance",
+    "compliance_summary",
     "ARCH_DOMAINS",
     "ARCH_DOMAIN_LINKS",
     "OWASP_TO_ARCH",

--- a/scanner/tests/test_compliance_keyword_positive_match.py
+++ b/scanner/tests/test_compliance_keyword_positive_match.py
@@ -90,8 +90,11 @@ class TestShortKeywordsHaveControls(unittest.TestCase):
 
 
 class TestShortKeywordsPositivelyMatch(unittest.TestCase):
-    """Each short acronym keyword must still trigger FAIL on every control
-    that lists it, when a finding's text contains that keyword."""
+    """Each short acronym keyword must still trigger FAIL on every
+    assessable control that lists it, when a finding's text contains that
+    keyword. Non-assessable controls (e.g. the 11 ISMS-P 3.x PII/privacy
+    controls) always report "N/A" regardless of matches — see
+    `map_compliance()` — but the match must still be tracked (count>=1)."""
 
     def test_short_keywords_trigger_fail_on_all_their_controls(self):
         for keyword in SHORT_KEYWORDS:
@@ -109,10 +112,11 @@ class TestShortKeywordsPositivelyMatch(unittest.TestCase):
                     controls_by_id = {c["control"]: c for c in result[framework]}
                     ctrl = controls_by_id[control_id]
                     with self.subTest(framework=framework, control=control_id):
+                        expected_status = "N/A" if not ctrl.get("assessable", True) else "FAIL"
                         self.assertEqual(
                             ctrl["status"],
-                            "FAIL",
-                            f"keyword {keyword!r} did NOT trigger FAIL on "
+                            expected_status,
+                            f"keyword {keyword!r} did NOT trigger {expected_status} on "
                             f"{framework}/{control_id} (checks={ctrl['checks']!r}) "
                             "— this is a false negative: the keyword no longer "
                             "matches its own finding text.",

--- a/scanner/tests/test_compliance_map.py
+++ b/scanner/tests/test_compliance_map.py
@@ -103,11 +103,15 @@ class TestMapCompliance(unittest.TestCase):
     """Test map_compliance with various finding sets."""
 
     def test_empty_findings_all_pass(self):
+        """With no findings, every assessable control is PASS; every
+        non-assessable control (e.g. the 11 ISMS-P 3.x PII controls) is
+        always N/A regardless of findings."""
         result = map_compliance([])
         for fw, controls in result.items():
             for ctrl in controls:
                 with self.subTest(framework=fw, control=ctrl["control"]):
-                    self.assertEqual(ctrl["status"], "PASS")
+                    expected_status = "N/A" if not ctrl.get("assessable", True) else "PASS"
+                    self.assertEqual(ctrl["status"], expected_status)
                     self.assertEqual(ctrl["count"], 0)
                     self.assertEqual(ctrl["findings"], [])
 
@@ -214,12 +218,15 @@ class TestComplianceSummary(unittest.TestCase):
         self.assertTrue(any_fail)
 
     def test_summary_totals_match_controls(self):
+        """total = pass + fail, excluding non-assessable (N/A) controls."""
         cmap = map_compliance([])
         summary = compliance_summary(cmap)
-        for fw in COMPLIANCE_CONTROL_MAP:
-            expected_total = len(COMPLIANCE_CONTROL_MAP[fw])
-            self.assertEqual(summary[fw]["total"], expected_total)
-            self.assertEqual(summary[fw]["pass"] + summary[fw]["fail"], expected_total)
+        for fw, controls in COMPLIANCE_CONTROL_MAP.items():
+            assessable_count = sum(1 for c in controls if c.get("assessable", True))
+            na_count = len(controls) - assessable_count
+            self.assertEqual(summary[fw]["total"], assessable_count)
+            self.assertEqual(summary[fw]["na"], na_count)
+            self.assertEqual(summary[fw]["pass"] + summary[fw]["fail"], assessable_count)
 
     def test_summary_keys_match_frameworks(self):
         cmap = map_compliance([])

--- a/scanner/tests/test_compliance_map_ismsp_na.py
+++ b/scanner/tests/test_compliance_map_ismsp_na.py
@@ -1,0 +1,169 @@
+"""
+Focused tests for the ISMS-P 3.x PII/privacy "N/A" pilot.
+
+Background
+----------
+The 11 ISMS-P 3.x controls (개인정보 처리단계별 요구사항: consent, privacy policy,
+data-subject rights, pseudonymization, cross-border transfer, third-party
+sharing, deletion/retention) are governance/legal controls that a technical
+scanner cannot assess. Rendering them as PASS whenever no keyword/native
+finding happens to match (the pre-existing `count==0 -> PASS` default) is a
+false compliance assurance. They are tagged `"assessable": False` in
+`COMPLIANCE_CONTROL_MAP["KISA ISMS-P"]` and `map_compliance()` always reports
+their status as `"N/A"`, excluded from the pass/fail totals computed by
+`compliance_summary()`.
+
+This is a PILOT scoped to ISMS-P 3.x only — no other framework's controls are
+tagged non-assessable.
+
+stdlib-only (importlib to load the hyphenated `compliance-map.py` module, same
+approach as `test_compliance_map.py`). No network, no on-disk fixtures.
+"""
+
+import importlib.util
+import os
+import unittest
+
+_spec = importlib.util.spec_from_file_location(
+    "compliance_map_ismsp_na",
+    os.path.join(os.path.dirname(__file__), "..", "lib", "compliance-map.py"),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+
+COMPLIANCE_CONTROL_MAP = _mod.COMPLIANCE_CONTROL_MAP
+map_compliance = _mod.map_compliance
+compliance_summary = _mod.compliance_summary
+
+ISMSP_PII_CONTROL_IDS = {
+    "3.1.1", "3.1.3", "3.1.4", "3.2.1", "3.2.5",
+    "3.3.1", "3.3.4", "3.4.1", "3.5.1", "3.5.2", "3.5.3",
+}
+
+
+def _make_finding(check="chk", title="", message=""):
+    return {"check": check, "title": title, "message": message}
+
+
+class TestIsmspPiiControlsTagged(unittest.TestCase):
+    """The 11 ISMS-P 3.x PII controls are tagged assessable=False; no others are."""
+
+    def test_exactly_eleven_controls_are_non_assessable(self):
+        ismsp = COMPLIANCE_CONTROL_MAP["KISA ISMS-P"]
+        non_assessable_ids = {c["control"] for c in ismsp if not c.get("assessable", True)}
+        self.assertEqual(non_assessable_ids, ISMSP_PII_CONTROL_IDS)
+        self.assertEqual(len(non_assessable_ids), 11)
+
+    def test_no_other_framework_has_non_assessable_controls(self):
+        for fw, controls in COMPLIANCE_CONTROL_MAP.items():
+            if fw == "KISA ISMS-P":
+                continue
+            with self.subTest(framework=fw):
+                for ctrl in controls:
+                    self.assertTrue(
+                        ctrl.get("assessable", True),
+                        f"{fw}/{ctrl['control']} unexpectedly tagged non-assessable "
+                        "— this pilot is scoped to ISMS-P 3.x only.",
+                    )
+
+
+class TestMapComplianceNaStatus(unittest.TestCase):
+    """map_compliance() always reports N/A for non-assessable controls."""
+
+    def test_all_eleven_ismsp_pii_controls_are_na_with_no_findings(self):
+        result = map_compliance([])
+        ismsp = {c["control"]: c for c in result["KISA ISMS-P"]}
+        for control_id in ISMSP_PII_CONTROL_IDS:
+            with self.subTest(control=control_id):
+                self.assertEqual(ismsp[control_id]["status"], "N/A")
+
+    def test_assessable_control_never_reports_na(self):
+        result = map_compliance([])
+        for fw, controls in result.items():
+            for ctrl in controls:
+                if ctrl.get("assessable", True):
+                    with self.subTest(framework=fw, control=ctrl["control"]):
+                        self.assertNotEqual(ctrl["status"], "N/A")
+
+    def test_matching_keyword_does_not_flip_na_control_to_fail(self):
+        """A finding whose text contains an N/A control's own keyword must not
+        move it out of N/A — it stays N/A but the match is still recorded
+        (count/findings) as an informational signal for human review."""
+        # "3.1.1" checks include "consent"; craft a finding containing it.
+        finding = _make_finding(
+            check="consent_missing",
+            title="Consent not recorded",
+            message="No consent on file for this user",
+        )
+        result = map_compliance([finding])
+        ismsp = {c["control"]: c for c in result["KISA ISMS-P"]}
+        ctrl = ismsp["3.1.1"]
+        self.assertEqual(ctrl["status"], "N/A")
+        self.assertGreaterEqual(ctrl["count"], 1)
+        self.assertTrue(len(ctrl["findings"]) >= 1)
+
+    def test_all_eleven_ismsp_pii_controls_stay_na_even_with_matching_findings(self):
+        """Cross-check across all 11 controls: each one's own first keyword,
+        when present in a finding's text, still yields N/A (not FAIL)."""
+        ismsp_controls = {c["control"]: c for c in COMPLIANCE_CONTROL_MAP["KISA ISMS-P"]}
+        for control_id in ISMSP_PII_CONTROL_IDS:
+            keyword = ismsp_controls[control_id]["checks"][0]
+            finding = _make_finding(
+                check="test_check",
+                title=f"Finding containing {keyword}",
+                message=f"This mentions {keyword} directly.",
+            )
+            result = map_compliance([finding])
+            ctrl = {c["control"]: c for c in result["KISA ISMS-P"]}[control_id]
+            with self.subTest(control=control_id, keyword=keyword):
+                self.assertEqual(ctrl["status"], "N/A")
+
+
+class TestComplianceSummaryExcludesNa(unittest.TestCase):
+    """compliance_summary() reports na=11 for KISA ISMS-P and excludes N/A
+    controls from total (total = pass + fail)."""
+
+    def test_ismsp_na_count_is_eleven(self):
+        cmap = map_compliance([])
+        summary = compliance_summary(cmap)
+        self.assertEqual(summary["KISA ISMS-P"]["na"], 11)
+
+    def test_ismsp_total_excludes_na_controls(self):
+        cmap = map_compliance([])
+        summary = compliance_summary(cmap)
+        stats = summary["KISA ISMS-P"]
+        self.assertEqual(stats["total"], stats["pass"] + stats["fail"])
+        total_controls = len(COMPLIANCE_CONTROL_MAP["KISA ISMS-P"])
+        self.assertEqual(stats["total"], total_controls - stats["na"])
+        self.assertEqual(total_controls, 42)
+        self.assertEqual(stats["total"], 31)
+
+    def test_frameworks_without_na_controls_have_na_zero(self):
+        cmap = map_compliance([])
+        summary = compliance_summary(cmap)
+        for fw in COMPLIANCE_CONTROL_MAP:
+            if fw == "KISA ISMS-P":
+                continue
+            with self.subTest(framework=fw):
+                self.assertEqual(summary[fw]["na"], 0)
+                self.assertEqual(summary[fw]["total"], len(COMPLIANCE_CONTROL_MAP[fw]))
+
+
+class TestAssessableControlRegression(unittest.TestCase):
+    """Regression: an assessable control still behaves PASS/FAIL as before."""
+
+    def test_assessable_control_with_match_is_fail(self):
+        finding = _make_finding(check="mfa_disabled", title="MFA not enabled", message="User lacks MFA")
+        result = map_compliance([finding])
+        iso = {c["control"]: c for c in result["ISO 27001:2022"]}
+        self.assertEqual(iso["A.8.5"]["status"], "FAIL")
+
+    def test_assessable_control_without_match_is_pass(self):
+        finding = _make_finding(check="random_check", title="Unrelated", message="Nothing special")
+        result = map_compliance([finding])
+        iso = {c["control"]: c for c in result["ISO 27001:2022"]}
+        self.assertEqual(iso["A.5.1"]["status"], "PASS")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_dashboard_mapping_pure.py
+++ b/scanner/tests/test_dashboard_mapping_pure.py
@@ -312,11 +312,14 @@ class TestMapCompliance(unittest.TestCase):
         return d
 
     def test_empty_findings_every_control_passes(self):
+        """Assessable controls PASS with no findings; non-assessable controls
+        (the 11 ISMS-P 3.x PII controls) are always N/A."""
         result = dm.map_compliance([])
         for framework, controls in result.items():
             assert framework in dm.COMPLIANCE_CONTROL_MAP
             for ctrl in controls:
-                assert ctrl["status"] == "PASS"
+                expected_status = "N/A" if not ctrl.get("assessable", True) else "PASS"
+                assert ctrl["status"] == expected_status
                 assert ctrl["count"] == 0
                 assert ctrl["findings"] == []
 


### PR DESCRIPTION
## Summary

The 11 **ISMS-P 3.x** PII/privacy controls (`3.1.1, 3.1.3, 3.1.4, 3.2.1, 3.2.5, 3.3.1, 3.3.4, 3.4.1, 3.5.1, 3.5.2, 3.5.3`) are governance/legal controls a technical scanner (GitHub config + Prowler cloud findings) **cannot assess** — consent, privacy-policy disclosure, data-subject rights, pseudonymization, cross-border transfer, third-party sharing, deletion/retention.

Previously `map_compliance()` returned `PASS` whenever no finding matched (`count==0`), so all 11 rendered **green** — implying 개인정보보호법 compliance that was never actually checked (false assurance in an audit context).

This PR renders them as **N/A (미평가 / manual review required)**, **excluded** from PASS/FAIL counts. Product decision confirmed with the maintainer; **pilot scoped to ISMS-P 3.x only** — other frameworks are unchanged (a framework-wide extension is a possible follow-up).

## Changes
- **`compliance-map.py`**: tag the 11 controls `assessable: false`; `map_compliance()` forces status `N/A` for non-assessable controls (matching findings still recorded as informational — a keyword/native match never flips them to FAIL); `compliance_summary()` adds an `na` count with `total = pass + fail` (N/A excluded).
- **`dashboard-gen.py`**: replace the *duplicated* inline pass/fail/total loop with the canonical `compliance_summary()` (threaded via the `dashboard_compliance → dashboard_mapping` re-export chain) so N/A cannot drift.
- **`dashboard_html_compliance.py`**: 3-way pass/fail/na badge + stat header (`cs-na` shown only when `na_c>0`; `comp-na`/`comp-st-na` row classes).
- **`dashboard-template.html`**: `.cs-na` / `.comp-na` / `.comp-st-na` styles.

`scan-report.json`'s `compliance` field gains an additive `na` key; the dashboard JS reads only `pass`/`fail`, so it's inert there.

## Behavior
ISMS-P summary on empty findings: `pass:31, fail:0, na:11, total:31` (was `pass:42 … total:42`).

## Test plan
- [x] New `test_compliance_map_ismsp_na.py`: tagging exactness (exactly 11, all ISMS-P 3.x, no other framework), N/A invariants (keyword match on an N/A control stays N/A), summary math (`na==11`, `total==pass+fail==31`), assessable-control regression (still FAIL on match / PASS on none).
- [x] Updated `test_compliance_map.py` / `test_dashboard_mapping_pure.py` / `test_compliance_keyword_positive_match.py` to the new intended behavior (strengthened, not loosened).
- [x] `CLAUDESEC_DASHBOARD_OFFLINE=1 pytest scanner/ -q` → **1435 passed**; scanner/lib coverage **99%**.
- [x] Shell tests green: `test_prowler_dashboard_summary.sh` (19), `test_output_functions.sh` (225), `test_output_coverage.sh` (76).
- [x] Independent sec-reviewer pass: clean, no CRITICAL/HIGH/MEDIUM.
- [x] gitleaks clean; no PII/secrets/real paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)