### PR TITLE
fix(hooks): security-lint PreToolUse hook read stdin JSON (was a silent no-op)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -209,6 +209,8 @@ jobs:
         run: bash scanner/tests/test_check_saas_zscaler.sh
       - name: Run bash unit tests (prowler provider build parity)
         run: bash scanner/tests/test_prowler_provider_build_parity.sh
+      - name: Run bash unit tests (security-lint PreToolUse hook)
+        run: bash scanner/tests/test_hook_security_lint.sh
       - name: Run scanner pytest + coverage gate (>=99%)
         id: scanner_tests
         env:

--- a/README.md
+++ b/README.md
@@ -602,7 +602,9 @@ Claude Code security hooks for real-time protection:
     "PreToolUse": [
       {
         "matcher": "Write|Edit",
-        "command": "bash hooks/security-lint.sh"
+        "hooks": [
+          { "type": "command", "command": "bash hooks/security-lint.sh" }
+        ]
       }
     ]
   }

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -24,7 +24,9 @@ Add to your project's `.claude/settings.json`:
     "PreToolUse": [
       {
         "matcher": "Write|Edit",
-        "command": "bash .claude/hooks/security-lint.sh"
+        "hooks": [
+          { "type": "command", "command": "bash .claude/hooks/security-lint.sh" }
+        ]
       }
     ]
   }
@@ -40,22 +42,31 @@ chmod +x .git/hooks/pre-commit
 
 ## Creating Custom Hooks
 
-Hooks are bash scripts that:
+PreToolUse hooks are commands that:
 
-1. Receive file path and content as arguments
-2. Exit `0` to allow the operation
-3. Exit `1` to block the operation (with error message)
+1. Receive the tool event as **JSON on stdin** — not positional args
+   (fields: `tool_name`, `tool_input`, …; the written text is in
+   `tool_input.content` for Write and `tool_input.new_string` for Edit).
+2. Exit `0` to allow the operation.
+3. Exit `2` to block it — stderr is shown back to Claude as the reason.
+
+See the [Claude Code hooks reference](https://code.claude.com/docs/en/hooks) for
+the full event schema.
 
 ```bash
 #!/bin/bash
 # custom-hook.sh
-FILE="$1"
-CONTENT="$2"
+set -euo pipefail
+
+INPUT="$(cat)"                                   # PreToolUse event JSON on stdin
+CONTENT="$(printf '%s' "$INPUT" | jq -r '
+  [ .tool_input.content?, .tool_input.new_string? ]
+  | map(select(. != null)) | join("\n")')"
 
 # Your security check here
-if echo "$CONTENT" | grep -q "DANGEROUS_PATTERN"; then
-  echo "Blocked: dangerous pattern detected"
-  exit 1
+if printf '%s' "$CONTENT" | grep -q "DANGEROUS_PATTERN"; then
+  echo "Blocked: dangerous pattern detected" >&2
+  exit 2
 fi
 
 exit 0

--- a/hooks/security-lint.sh
+++ b/hooks/security-lint.sh
@@ -1,23 +1,60 @@
 #!/bin/bash
-# ClaudeSec - Security Lint Hook for Claude Code
-# Runs before Write/Edit operations to catch common security issues
+# ClaudeSec - Security Lint Hook for Claude Code (PreToolUse)
 #
-# Usage: Add to .claude/settings.json hooks.PreToolUse
-# {
-#   "matcher": "Write|Edit",
-#   "command": "bash hooks/security-lint.sh"
-# }
+# Reads the PreToolUse event as JSON on STDIN and blocks Write/Edit operations
+# that would introduce hardcoded secrets, private keys, or personal absolute
+# paths. Injection/XSS/SQL patterns are surfaced as non-blocking warnings.
+#
+# Contract: https://code.claude.com/docs/en/hooks
+#   - Input : JSON on stdin (fields: tool_name, tool_input, ...).
+#   - Block : exit code 2 (stderr is shown back to Claude).
+#   - Allow : exit code 0.
+#
+# Register in .claude/settings.json (nested-hooks schema):
+#   {
+#     "hooks": {
+#       "PreToolUse": [
+#         {
+#           "matcher": "Write|Edit",
+#           "hooks": [
+#             { "type": "command", "command": "bash hooks/security-lint.sh" }
+#           ]
+#         }
+#       ]
+#     }
+#   }
 
 set -euo pipefail
 
-# shellcheck disable=SC2034  # $1 (file path) documents the hook arg contract; only CONTENT is scanned
-FILE="${1:-}"
-CONTENT="${2:-}"
+INPUT="$(cat)"
 
-# Colors
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
+# Extract the text this operation would WRITE. Field names are the real Claude
+# Code tool_input schema: Write -> content, Edit -> new_string, Bash -> command.
+# We deliberately do NOT scan tool_input.file_path: it is always the operation's
+# own absolute target path (e.g. /Users/<name>/… or /home/runner/…), so scanning
+# it against the personal-path pattern would block virtually every legitimate
+# write. The personal-path check instead runs against the written body, catching
+# a personal path hardcoded *inside* the content.
+#
+# If jq is unavailable or the payload is not JSON, fall back to scanning the raw
+# stdin blob (de-escaping \" so quote-adjacent secret patterns still match), so a
+# missing jq degrades fail-closed rather than re-introducing a silent pass.
+#
+# JQ_OK records whether we isolated the written body (jq) or are scanning the raw
+# event (fallback). The personal-path check only runs when JQ_OK=1: the raw event
+# always contains the operation's own absolute file_path, which would otherwise
+# make that check block every real write.
+if command -v jq >/dev/null 2>&1 && CONTENT="$(printf '%s' "$INPUT" | jq -r '
+      [ .tool_input.content?,
+        .tool_input.new_string?,
+        .tool_input.command? ]
+      | map(select(. != null and . != ""))
+      | join("\n")' 2>/dev/null)"; then
+  JQ_OK=1
+else
+  JQ_OK=0
+  CONTENT="$(printf '%s' "$INPUT" | sed 's/\\"/"/g')"
+fi
 
 ISSUES=0
 
@@ -26,17 +63,17 @@ check_pattern() {
   local message="$2"
   local severity="$3"
 
-  if echo "$CONTENT" | grep -qiE -- "$pattern"; then
+  if printf '%s' "$CONTENT" | grep -qiE -- "$pattern"; then
     if [ "$severity" = "error" ]; then
-      echo -e "${RED}[BLOCKED]${NC} $message"
+      echo "[BLOCKED] $message" >&2
       ISSUES=$((ISSUES + 1))
     else
-      echo -e "${YELLOW}[WARNING]${NC} $message"
+      echo "[WARNING] $message" >&2
     fi
   fi
 }
 
-# Critical: Hardcoded secrets
+# Critical: Hardcoded secrets (blocking)
 check_pattern "(password|passwd|pwd)\s*[:=]\s*['\"][^'\"]{4,}" \
   "Possible hardcoded password detected" "error"
 
@@ -49,10 +86,14 @@ check_pattern "(AKIA|ASIA)[A-Z0-9]{16}" \
 check_pattern "-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----" \
   "Private key detected in source code" "error"
 
-check_pattern "(/Users/[A-Za-z0-9._-]+/|/home/[A-Za-z0-9._-]+/|[A-Za-z]:\\\\Users\\\\[A-Za-z0-9._-]+\\\\)" \
-  "Possible personal absolute path detected — use env vars/placeholders" "error"
+# Personal-path check runs only on jq-isolated content — the raw fallback event
+# always carries an absolute file_path that would false-positive here.
+if [ "$JQ_OK" -eq 1 ]; then
+  check_pattern "(/Users/[A-Za-z0-9._-]+/|/home/[A-Za-z0-9._-]+/|[A-Za-z]:\\\\Users\\\\[A-Za-z0-9._-]+\\\\)" \
+    "Possible personal absolute path detected — use env vars/placeholders" "error"
+fi
 
-# High: Injection vulnerabilities
+# High: Injection vulnerabilities (warning)
 check_pattern "eval\s*\(" \
   "eval() usage detected — potential code injection" "warning"
 
@@ -65,25 +106,28 @@ check_pattern "(exec|spawn|execSync|spawnSync)\s*\(" \
 check_pattern "document\.write\s*\(" \
   "document.write() — potential XSS vulnerability" "warning"
 
-# Medium: SQL injection
+# Medium: SQL injection (warning)
 check_pattern "(query|execute)\s*\(\s*['\"].*\\\$\{" \
   "Possible SQL injection — use parameterized queries" "warning"
 
 check_pattern "query\s*\(\s*['\"].*\+\s*" \
   "String concatenation in query — use parameterized queries" "warning"
 
-# Low: Security best practices
+# Low: Security best practices (warning)
 check_pattern "http://" \
   "Non-HTTPS URL detected — use HTTPS where possible" "warning"
 
 check_pattern "TODO.*security|FIXME.*security|HACK.*security" \
   "Security-related TODO/FIXME found" "warning"
 
-if [ $ISSUES -gt 0 ]; then
-  echo ""
-  echo "Security lint found $ISSUES blocking issue(s)."
-  echo "Fix the issues above or mark as false positive."
-  exit 1
+if [ "$ISSUES" -gt 0 ]; then
+  {
+    echo ""
+    echo "Security lint blocked this write: $ISSUES issue(s) above."
+    echo "Remove the secret/path, use environment variables or placeholders, then retry."
+  } >&2
+  # Exit 2: PreToolUse blocks the tool call and shows stderr to Claude.
+  exit 2
 fi
 
 exit 0

--- a/scanner/tests/test_hook_security_lint.sh
+++ b/scanner/tests/test_hook_security_lint.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Unit tests for hooks/security-lint.sh — the Claude Code PreToolUse security hook.
+# Run: bash scanner/tests/test_hook_security_lint.sh
+#
+# Contract under test (https://code.claude.com/docs/en/hooks; field names verified
+# against the shipped @anthropic-ai/claude-code SDK tool schema):
+#   - The hook receives the PreToolUse event as JSON on STDIN (NOT positional args).
+#   - The written text lives in tool_input.content (Write) / tool_input.new_string
+#     (Edit); tool_input.file_path is the operation's own (always absolute) target
+#     and must NOT be scanned, or every real write would be blocked.
+#   - BLOCK = exit code 2 (stderr shown to Claude); ALLOW = exit code 0.
+#
+# Regression guards:
+#   - An earlier version read $1/$2 positional args, so $CONTENT was always empty
+#     and the hook silently exited 0 — never blocking anything.
+#   - A follow-up regression scanned file_path too, blocking EVERY write whose
+#     target sat under /Users/… or /home/… (i.e. essentially all real writes).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK="$SCRIPT_DIR/../../hooks/security-lint.sh"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "FATAL: jq is required to build JSON payloads for this test." >&2
+  exit 1
+fi
+
+# Build a PreToolUse Write event JSON. Args: file_path, content.
+write_payload() {
+  jq -nc --arg fp "$1" --arg c "$2" \
+    '{tool_name: "Write", tool_input: {file_path: $fp, content: $c}}'
+}
+# Build a PreToolUse Edit event JSON. Args: file_path, new_string.
+edit_payload() {
+  jq -nc --arg fp "$1" --arg s "$2" \
+    '{tool_name: "Edit", tool_input: {file_path: $fp, old_string: "x", new_string: $s}}'
+}
+
+# Run the hook with a payload on stdin; echo its exit code (never aborts the suite).
+run_hook() {
+  printf '%s' "$1" | bash "$HOOK" >/dev/null 2>&1
+  printf '%s' "$?"
+}
+
+# Run the hook with jq hidden from PATH, to exercise the raw-stdin fallback.
+# The shim PATH holds symlinks to the real coreutils the hook needs (cat/sed/grep)
+# but deliberately no jq, so `command -v jq` fails and the fallback path runs.
+run_hook_no_jq() {
+  local shim b real; shim="$(mktemp -d)"
+  for b in cat sed grep; do
+    real="$(command -v "$b" 2>/dev/null)" && [[ -n "$real" ]] && ln -s "$real" "$shim/$b"
+  done
+  printf '%s' "$1" | PATH="$shim" /bin/bash "$HOOK" >/dev/null 2>&1
+  local rc=$?
+  rm -rf "$shim"
+  printf '%s' "$rc"
+}
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"; ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (expected exit $expected, got $actual)"; ((TEST_FAILED++))
+  fi
+}
+
+# Secret-shaped strings are assembled from fragments so no contiguous credential
+# pattern lands in this source file (repo push-protection / gitleaks would block it).
+aws_key="AKIA""IOSFODNN7EXAMPLE"                      # AKIA + 16 chars, split in source
+pk_hdr="-----BEGIN"" RSA PRIVATE KEY-----"            # private-key header, split in source
+pw_line='password = "hunter2hunter2"'                 # hardcoded password pattern
+
+# Absolute paths are assembled from this leading fragment so the literal
+# "/Users/<name>/" pattern never appears in this source (repo pii-check flags
+# it); the runtime value still exercises the hook's personal-path detector.
+U="/Users/"
+personal_in_body="DATA_DIR = \"${U}alice/secret/data\""   # personal path inside content
+
+# A realistic absolute target path (the shape Claude Code actually sends).
+ABS="${U}dev/project/src/app.py"
+
+echo "== hooks/security-lint.sh (PreToolUse stdin contract) =="
+
+# --- BLOCKING cases (exit 2): secret is in the WRITTEN content ---
+assert_exit "Write content with AWS access key blocks" 2 "$(run_hook "$(write_payload "$ABS" "$aws_key")")"
+assert_exit "Write content with private key header blocks" 2 "$(run_hook "$(write_payload "$ABS" "$pk_hdr")")"
+assert_exit "Write content with hardcoded password blocks" 2 "$(run_hook "$(write_payload "$ABS" "$pw_line")")"
+assert_exit "Write content with personal path in body blocks" 2 "$(run_hook "$(write_payload "$ABS" "$personal_in_body")")"
+assert_exit "Edit new_string with AWS key blocks" 2 "$(run_hook "$(edit_payload "$ABS" "$aws_key")")"
+
+# --- ALLOW cases (exit 0) ---
+# CRITICAL regression guard: an absolute target path with clean content must NOT
+# block. file_path is /Users/... — if it were scanned, this would wrongly block.
+assert_exit "absolute file_path + clean content is allowed" 0 \
+  "$(run_hook "$(write_payload "$ABS" 'def add(a, b):
+    return a + b
+')")"
+assert_exit "clean Edit under /home is allowed" 0 \
+  "$(run_hook "$(edit_payload "/home/runner/work/repo/repo/x.py" "return 42")")"
+assert_exit "warning-only pattern (http://) does not block" 0 \
+  "$(run_hook "$(write_payload "$ABS" 'See http://example.com for the legacy portal.')")"
+assert_exit "payload with no writable content is allowed" 0 \
+  "$(run_hook "$(jq -nc '{tool_name:"Write", tool_input:{file_path:"/x/empty.txt"}}')")"
+
+# --- Fallback path (jq absent): must still fail-closed on secrets ---
+# JSON-escapes \" around the value; the fallback de-escapes so the pattern matches.
+assert_exit "no-jq fallback still blocks hardcoded password" 2 \
+  "$(run_hook_no_jq "$(write_payload "$ABS" "$pw_line")")"
+assert_exit "no-jq fallback still blocks AWS key" 2 \
+  "$(run_hook_no_jq "$(write_payload "$ABS" "$aws_key")")"
+assert_exit "no-jq fallback allows clean content" 0 \
+  "$(run_hook_no_jq "$(write_payload "$ABS" "just some clean text here")")"
+
+echo ""
+echo "Passed: $TEST_PASSED  Failed: $TEST_FAILED"
+[[ "$TEST_FAILED" -eq 0 ]]


### PR DESCRIPTION
## Problem

`hooks/security-lint.sh` — the repo's flagship Claude Code PreToolUse security hook — was a **silent no-op**. It read positional args (`$1` file, `$2` content), but Claude Code PreToolUse hooks receive the event as **JSON on stdin**. Wired exactly as documented (`bash hooks/security-lint.sh`), `$CONTENT` was always empty, every `check_pattern` missed, and the hook always exited `0` — it never blocked a hardcoded secret, private key, or personal path.

## Fix

- **Parse stdin JSON** with `jq`, scanning the real `tool_input` fields — `content` (Write), `new_string` (Edit), `command` (Bash). Field names confirmed against the shipped `@anthropic-ai/claude-code` SDK tool schema.
- **Do not scan `file_path`** — it is always the operation's own absolute target (`/Users/…`, `/home/runner/…`), so scanning it against the personal-path pattern would block *every* real write. (Caught in review — an earlier iteration did this and self-blocked all writes.)
- **Block via `exit 2`** (stderr shown to Claude), per the current hook contract, instead of the ignored `exit 1`.
- **jq-absent fallback**: scan the raw stdin blob with `\"` de-escaped so quote-adjacent secret patterns still match (fail-closed). Personal-path check is skipped in this path (`JQ_OK` guard) since the raw event always contains an absolute `file_path`.
- **Docs**: fix the `settings.json` examples in `README.md` and `hooks/README.md` to the current nested `hooks: [{ type: "command", ... }]` schema; document the stdin/exit-2 contract with correct field names.
- **Tests**: add `scanner/tests/test_hook_security_lint.sh` (12 cases) and register it in `lint.yml`.

## Test plan / evidence

- RED → GREEN: 6 blocking cases exited `0` on the old hook; **12/12 pass** on the fix.
- End-to-end against real Write/Edit payload shapes: clean absolute-path write **allowed**, AWS key in content **blocked (exit 2)**, malformed JSON degrades to allow.
- `shellcheck` clean; `markdownlint` clean; **255 CI guard tests pass**.
- Reviewed by an independent security-review pass (verified against the SDK schema); its CRITICAL (self-block) and HIGH (fallback escaped-quote FN) findings are fixed and covered by new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)