### PR TITLE
refactor(scanner): single-source load_scan_results + scan-category list, harden loader

### DIFF
--- a/scanner/claudesec
+++ b/scanner/claudesec
@@ -27,6 +27,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly CHECKS_DIR="$SCRIPT_DIR/checks"
 readonly LIB_DIR="$SCRIPT_DIR/lib"
 
+# Canonical scan-category order — the single source of truth. Both the full-scan
+# and dashboard-scan paths expand this array, and scanner/lib/diagram-gen.py's
+# CATEGORIES must mirror it (guarded by test_ci_diagram_gen_canonical_sync.py).
+readonly -a CLAUDESEC_ALL_CATEGORIES=(
+  infra ai network cloud access-control cicd code macos windows saas prowler
+)
+
 # Source library
 source "$LIB_DIR/output.sh"
 source "$LIB_DIR/checks.sh"
@@ -562,7 +569,7 @@ run_scan() {
   # Determine which categories to scan (dedupe and filter)
   local categories=()
   if [[ "$CATEGORY" == "all" ]]; then
-    categories=(infra ai network cloud access-control cicd code macos windows saas prowler)
+    categories=("${CLAUDESEC_ALL_CATEGORIES[@]}")
   else
     IFS=',' read -ra _raw <<< "$CATEGORY"
     for c in "${_raw[@]}"; do
@@ -1165,7 +1172,7 @@ run_scan_for_dashboard() {
 
   local categories=()
   if [[ "$CATEGORY" == "all" ]]; then
-    categories=(infra ai network cloud access-control cicd code macos windows saas prowler)
+    categories=("${CLAUDESEC_ALL_CATEGORIES[@]}")
   else
     IFS=',' read -ra categories <<< "$CATEGORY"
   fi

--- a/scanner/lib/dashboard_data_loader.py
+++ b/scanner/lib/dashboard_data_loader.py
@@ -46,19 +46,27 @@ from dashboard_api_client import (
 
 
 def load_scan_results(path: str) -> dict[str, Any]:
+    default: dict[str, Any] = {
+        "passed": 0,
+        "failed": 0,
+        "warnings": 0,
+        "skipped": 0,
+        "total": 0,
+        "score": 0,
+        "grade": "F",
+        "duration": 0,
+        "findings": [],
+    }
     if not path or not os.path.isfile(path):
-        return {
-            "passed": 0,
-            "failed": 0,
-            "warnings": 0,
-            "skipped": 0,
-            "total": 0,
-            "score": 0,
-            "grade": "F",
-            "findings": [],
-        }
-    with open(path, encoding="utf-8") as f:
-        return json.load(f)
+        return default
+    # Degrade gracefully on a truncated/corrupt scan-report.json (e.g. from a
+    # killed scan) instead of crashing dashboard/diagram generation — matches
+    # load_scan_history / load_audit_points_detected below.
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return default
 
 
 def _parse_ocsf_json(content: str) -> list[dict[str, Any]]:

--- a/scanner/lib/diagram-gen.py
+++ b/scanner/lib/diagram-gen.py
@@ -20,26 +20,25 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from dashboard_arch import ARCH_DOMAINS  # noqa: E402  (canonical security domains)
 from dashboard_compliance import COMPLIANCE_FRAMEWORKS  # noqa: E402
+# load_scan_results is single-sourced in dashboard_data_loader (with try/except
+# hardening) so the two implementations can't drift.
+from dashboard_data_loader import load_scan_results  # noqa: E402,F401
 
 VERSION = "0.1.0"
 
-# Scanner categories (from claudesec)
+# Scanner categories — order must mirror the `CLAUDESEC_ALL_CATEGORIES` array in
+# scanner/claudesec (the authoritative scan order). CATEGORIES[:8]/[:7] slices
+# feed diagram labels, so order matters. Kept honest by
+# scanner/tests/test_ci_diagram_gen_canonical_sync.py.
 CATEGORIES = [
     "infra", "ai", "network", "cloud", "access-control",
-    "cicd", "code", "macos", "saas", "windows", "prowler",
+    "cicd", "code", "macos", "windows", "saas", "prowler",
 ]
 
 # Security architecture domains and compliance frameworks are single-sourced
 # from dashboard_arch.ARCH_DOMAINS and dashboard_compliance.COMPLIANCE_FRAMEWORKS
 # (imported above) — no inline copies here, so the diagram never drifts from the
 # dashboard. Kept honest by scanner/tests/test_ci_diagram_gen_canonical_sync.py.
-
-
-def load_scan_results(path):
-    if not path or not os.path.isfile(path):
-        return {"passed": 0, "failed": 0, "warnings": 0, "skipped": 0, "total": 0, "score": 0, "grade": "F", "duration": 0, "findings": []}
-    with open(path) as f:
-        return json.load(f)
 
 
 def _parse_ocsf_json(content):

--- a/scanner/tests/test_ci_diagram_gen_canonical_sync.py
+++ b/scanner/tests/test_ci_diagram_gen_canonical_sync.py
@@ -52,6 +52,16 @@ from _ci_guard_util import strip_comment_lines  # noqa: E402
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LIB_DIR = REPO_ROOT / "scanner" / "lib"
 DIAGRAM_GEN = LIB_DIR / "diagram-gen.py"
+CLAUDESEC = REPO_ROOT / "scanner" / "claudesec"
+
+# The canonical bash scan-category array (single source of truth).
+_BASH_ALL_CATEGORIES_RE = re.compile(
+    r"readonly\s+-a\s+CLAUDESEC_ALL_CATEGORIES=\((.*?)\)", re.DOTALL
+)
+# The old inline form we forbid re-introducing: a literal category list on a
+# lowercase `categories=(` assignment instead of expanding the canonical array.
+# Case-sensitive, so it does NOT match the uppercase CLAUDESEC_ALL_CATEGORIES decl.
+_BASH_INLINE_CATEGORIES_RE = re.compile(r"categories=\(\s*infra\s+ai\s+network")
 
 # An inline reassignment of the canonical list (the drift we forbid).
 _INLINE_ARCH_RE = re.compile(r"^\s*ARCH_DOMAINS\s*=\s*\[", re.MULTILINE)
@@ -78,6 +88,12 @@ def _load_diagram_gen():
     mod = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(mod)
     return mod
+
+
+def _bash_all_categories():
+    """Parse CLAUDESEC_ALL_CATEGORIES=( ... ) from scanner/claudesec -> list."""
+    m = _BASH_ALL_CATEGORIES_RE.search(CLAUDESEC.read_text(encoding="utf-8"))
+    return m.group(1).split() if m else None
 
 
 class TestDiagramGenCanonicalSync(unittest.TestCase):
@@ -137,6 +153,36 @@ class TestDiagramGenCanonicalSync(unittest.TestCase):
             _INLINE_ARCH_RE.search(strip_comment_lines(bad)),
             "detector should flag an inline ARCH_DOMAINS reassignment",
         )
+
+    # -- CATEGORIES single-source parity (bash <-> diagram-gen) ---------------
+
+    def test_categories_mirror_bash_canonical_order(self):
+        bash_cats = _bash_all_categories()
+        self.assertIsNotNone(
+            bash_cats,
+            "CLAUDESEC_ALL_CATEGORIES array not found in scanner/claudesec",
+        )
+        mod = _load_diagram_gen()
+        self.assertEqual(
+            mod.CATEGORIES,
+            bash_cats,
+            "diagram-gen CATEGORIES must exactly mirror scanner/claudesec "
+            "CLAUDESEC_ALL_CATEGORIES — same members AND order, since the "
+            "CATEGORIES[:8]/[:7] diagram-label slices depend on order",
+        )
+
+    def test_bash_category_list_is_single_sourced(self):
+        stripped = strip_comment_lines(CLAUDESEC.read_text(encoding="utf-8"))
+        self.assertIsNone(
+            _BASH_INLINE_CATEGORIES_RE.search(stripped),
+            "scanner/claudesec must expand CLAUDESEC_ALL_CATEGORIES, not inline "
+            "the category list on a lowercase categories=(...) assignment",
+        )
+
+    def test_categories_parity_self_test_detects_reorder(self):
+        """Sanity: a reordered copy must not compare equal to the bash source."""
+        bash_cats = _bash_all_categories()
+        self.assertNotEqual(bash_cats, list(reversed(bash_cats)))
 
 
 if __name__ == "__main__":

--- a/scanner/tests/test_dashboard_data_loader_pure.py
+++ b/scanner/tests/test_dashboard_data_loader_pure.py
@@ -58,6 +58,19 @@ class TestLoadScanResults(unittest.TestCase):
         self.assertEqual(result["passed"], 5)
         self.assertEqual(result["grade"], "A")
 
+    def test_corrupt_json_returns_default_shape(self):
+        # A truncated / corrupt scan-report.json (e.g. from a killed scan) must
+        # degrade to the default shape, not crash dashboard/diagram generation.
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "scan.json")
+            with open(p, "w", encoding="utf-8") as f:
+                f.write('{"passed": 5, "failed":')  # truncated JSON
+            result = loader.load_scan_results(p)
+        self.assertEqual(result["total"], 0)
+        self.assertEqual(result["grade"], "F")
+        self.assertEqual(result["duration"], 0)
+        self.assertEqual(result["findings"], [])
+
 
 # ===========================================================================
 # 2. _parse_ocsf_json


### PR DESCRIPTION
## What

Removes two hand-maintained duplicates in `scanner/lib` — the same drift bug-class already fixed for `PROVIDER_LABELS` / `ARCH_DOMAINS` / `COMPLIANCE_FRAMEWORKS` (#305–#307).

### `load_scan_results` — consolidate + harden
- `diagram-gen.py` carried its own copy whose default dict diverged from the loader's (`duration` present in one, absent in the other), and **neither wrapped `json.load` in try/except** — a truncated/corrupt `scan-report.json` (e.g. from a killed scan) raised an unhandled exception and crashed dashboard/diagram generation.
- Consolidate to `dashboard_data_loader.load_scan_results` (imported by diagram-gen, matching `dashboard-gen.py`), add `"duration": 0` to the default (superset), and wrap `open`/`json.load` in `try/except (OSError, json.JSONDecodeError)` — the graceful-degradation pattern already used by `load_scan_history` / `load_audit_points_detected`.
- New corrupt-JSON regression test.

### Scan categories — single-source + parity guard
- The `all` list was inlined in `run_scan` **and** `run_scan_for_dashboard` **and** re-declared as `CATEGORIES` in `diagram-gen.py`, which had **already drifted in order** (`saas`/`windows` swapped). `CATEGORIES[:8]/[:7]` feed diagram labels, so order matters.
- Single-source as a `readonly CLAUDESEC_ALL_CATEGORIES` array in `claudesec`, expanded in both scan paths; fix `diagram-gen` `CATEGORIES` to mirror that order.
- Extend `test_ci_diagram_gen_canonical_sync.py`: parse the bash array and assert `diagram-gen.CATEGORIES` matches it exactly (members **and** order), forbid a lowercase inline `categories=(infra ai network …)` reassignment, plus a reorder self-test.

## Test plan / evidence
- `pytest scanner/` → **1443 passed**, scanner/lib coverage **99.12%** (≥99% gate).
- `shellcheck -S error scanner/claudesec` → clean.
- `CLAUDESEC_ALL_CATEGORIES` expands to the 11 categories in canonical order; `claudesec version` smoke OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)