### PR TITLE
docs(p2): unify scanner category/check counts, add reports+plans layout, backfill CHANGELOG

### DIFF
--- a/.cursor/rules/claudesec-project.mdc
+++ b/.cursor/rules/claudesec-project.mdc
@@ -15,6 +15,8 @@ ClaudeSec is a **DevSecOps toolkit** for AI-assisted secure development. Documen
 - `docs/guides/` — Step-by-step tutorials
 - `docs/compliance/` — NIST, ISO, ISMS-P compliance guides
 - `docs/architecture/` — Draw.io architecture/flow/security-domains diagrams (generated from scan data)
+- `docs/reports/` — Session reports, retrospectives, and generated scan/seminar collateral
+- `docs/plans/` — Strategy and planning documents
 - `assets/` — Logo and branding assets
 - `templates/` — Reusable config templates
 - `scanner/` — Security scanner CLI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,48 @@ per-commit history, see the git log and `MEMORY.md` (delta log).
 
 ### Added
 
-- **Two new marketplace plugin slash commands** (issue #20). `npx claudesec
+- **Two new marketplace plugin slash commands** (issue #20, #289). `npx claudesec
   prowler` runs a Prowler multi-cloud scan (thin alias for `scan -c prowler`),
   and `npx claudesec compliance [framework]` runs a compliance gap scan that
   maps findings to a framework (`scan --compliance`, default `isms-p`). Both are
   registered in `.claude-plugin/marketplace.json` so they surface as `/prowler`
   and `/compliance` once the plugin is installed. Marketplace↔CLI parity is
   guarded by `scanner/tests/test_ci_plugin_skills_cli_parity.py`.
+- **Monthly lychee redirect / link-rot sweep** (#298) — a notifier-only workflow
+  that opens a self-healing issue when links redirect or rot, plus a
+  `lychee-redirect-triage` playbook skill (#299).
+- **CI quality gates**: Lighthouse Performance/SEO/Accessibility ≥ 90 on the live
+  Pages site (#288); a Docker scanner-image size gate pinned at ~513 MB (#286);
+  a script-injection regression guard (#270).
+- **CI-guard discipline**: ADR-001 (CI guard hardening + periodic adversarial
+  audit) with an ADR index and operationalized audit cadence (#278, #279).
+- **Docs**: NIST OLIR mapping of the OWASP LLM Top 10 to CSF 2.0 (#303).
+
+### Changed
+
+- **ISMS-P non-assessable controls** now render as N/A (미평가): the 3.x PII
+  controls (#309) and, framework-wide, the governance controls that lack a native
+  Prowler evidence path (#311), with the policy documented (#310).
+- **Single-sourced scanner constants** to kill drift: Prowler provider labels +
+  parity guard (#305), diagram-gen security domains & compliance frameworks from
+  the canonical modules (#306), and Prowler display order (#308).
+- **Dashboard modularization**: split `dashboard_mapping` into compliance + arch
+  modules (#284) and extracted `dashboard_data_loader` (#285).
+- `dashboard_compliance` now hard-fails on a load error instead of silently using
+  a stale inline fallback map (#304).
+- Externalized the lychee exclude allowlist to `lychee.toml` with a guard (#290);
+  added a post-publish provenance-verify cadence and explicit OIDC npm floor (#264).
+
+### Fixed
+
+- Removed substring-false-positive keywords from the compliance keyword map (#307).
+- Deduplicated DAST alerts and gated the nightly scan to a real target (#283).
+- Resolved lychee-detected redirects/link-rot to canonical URLs and excluded
+  flaky bot-blocked / gov-CERT domains (#291, #301, #302, #287, #268).
+- Closed comment-evasion false-negatives across several CI guards (#271, #275,
+  #277) and gated the npm-publish dry-run so it does not run on an already
+  published version (#276).
+- Routine dependency bumps (GitHub Actions, nginx image, pytest).
 
 ## [0.7.2]
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,8 @@ All documentation is in Markdown. No build system required.
 - docs/guides/ — Step-by-step tutorials
 - docs/compliance/ — NIST, ISO, ISMS-P compliance guides
 - docs/architecture/ — Architecture and flow diagrams
+- docs/reports/ — Session reports, retrospectives, and generated scan/seminar collateral
+- docs/plans/ — Strategy and planning documents
 - assets/ — Logo and branding assets
 - templates/ — Reusable config templates
 - scanner/ — Security scanner CLI

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ claudesec/
 
 ## Scanner CLI
 
-ClaudeSec includes a zero-dependency bash scanner that checks your project for security best practices across 10 categories (~120+ checks). Optionally integrates with [Prowler](https://github.com/prowler-cloud/prowler) for deep multi-cloud scanning.
+ClaudeSec includes a zero-dependency bash scanner that checks your project for security best practices across 11 categories (~120+ checks). The `prowler` category integrates with [Prowler](https://github.com/prowler-cloud/prowler) for deep multi-cloud scanning.
 
 **Scanner anchors**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ npx claudesec dashboard       # Full scan + dashboard
 
 ## Features
 
-- 40+ security checks across code, CI/CD, IAM, infrastructure, cloud, AI/LLM, SaaS
+- 120+ security checks across code, CI/CD, IAM, infrastructure, cloud, network, AI/LLM, SaaS, macOS & Windows
 - Prowler CSPM: AWS, Kubernetes, GitHub, IaC
 - ISMS asset management dashboard (9 tabs)
 - Claude Code slash commands: `/scan`, `/dashboard`, `/audit`


### PR DESCRIPTION
## What (P2 documentation consistency)

Verified against the scanner (not guessed):

| Fix | Before | After | Evidence |
|-----|--------|-------|----------|
| Scanner categories | README blurb "10 categories" | "11 categories" | `CLAUDESEC_ALL_CATEGORIES` has 11; README table + AGENTS.md already say 11 |
| Check count | `docs/index.md` "40+ checks" | "120+ checks" | `grep` → 126 unique check IDs; README/AGENTS say "~120+" |
| Directory layout | `docs/reports/`, `docs/plans/` undocumented | added rows | both dirs actively maintained |
| CHANGELOG `[Unreleased]` | only #289 listed | backfilled 44 commits | `git log v0.7.2..HEAD` |

Files: `README.md`, `docs/index.md`, `CLAUDE.md`, `.cursor/rules/claudesec-project.mdc`, `CHANGELOG.md`.

The `prowler` category is framed as the multi-cloud one. The remaining "10 categories" strings in `README.md` (lines 493/643) are **left as-is** — they refer to the **OWASP Top 10**, a different set.

## Test plan
- `markdownlint` clean on all changed docs.
- No stale scanner-category / check-count numbers remain (`grep` confirms remaining "10 categories" hits are OWASP Top 10).

> Out of scope (deferred): `AGENTS.md` architect/test-engineer role clarification and the stale `scripts/AGENTS.md` table — flagged for a separate pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)