### PR TITLE
fix(scanner): silence bash "unterminated here-document" warning in scan-tools

### DIFF
--- a/scanner/checks/network/scan-tools.sh
+++ b/scanner/checks/network/scan-tools.sh
@@ -41,8 +41,12 @@ _trivy_run() {
 
   # Parse Trivy JSON and push critical/high into findings for Overview
   if [[ -f "$out_fs" ]] && has_command python3; then
-    local crit=0 high=0 med=0
-    read -r crit high med <<< "$(python3 - "$out_fs" <<'PYTRIVY' 2>/dev/null)" || true
+    local crit=0 high=0 med=0 _trivy_counts
+    # Feed the heredoc into a plain command substitution (assigned to a var),
+    # then read from that var — do NOT nest the heredoc inside the `read <<<`
+    # here-string. The nested `read <<< "$(python3 <<'EOF' ...)"` form makes bash
+    # warn "command substitution: 1 unterminated here-document" at source time.
+    _trivy_counts="$(python3 - "$out_fs" 2>/dev/null <<'PYTRIVY' || true
 import json, sys
 try:
     with open(sys.argv[1]) as f:
@@ -63,6 +67,8 @@ try:
 except Exception:
     print(0, 0, 0)
 PYTRIVY
+)"
+    read -r crit high med <<< "$_trivy_counts"
     [[ "$crit" -gt 0 ]] && fail "TRIVY-CRIT" "Trivy: $crit CRITICAL vulnerability(ies)" "critical" \
       "Review .claudesec-network/trivy-fs.json and fix or suppress" "Run 'trivy fs $scan_path' for details"
     [[ "$high" -gt 0 ]] && fail "TRIVY-HIGH" "Trivy: $high HIGH vulnerability(ies)" "high" \


### PR DESCRIPTION
## Problem

Sourcing `scanner/checks/network/scan-tools.sh` printed:

```
scan-tools.sh: line 45: warning: command substitution: 1 unterminated here-document
```

**Root cause**: the Trivy-count parse nested a heredoc inside a command substitution inside a `read <<<` here-string — `read -r crit high med <<< "$(python3 - <<'PYTRIVY' ... )"`. Two heredoc operators (`<<<` and `<<`) on one logical line confuse bash's parser at source/parse time; it warns even though the runtime output is correct.

## Fix

Feed the heredoc into a plain command substitution assigned to a `local` var, then `read` from that var — the heredoc no longer nests inside the here-string. Behavior unchanged.

## Test plan / evidence

- Reproduced both forms in isolation: broken → warning; fixed → no warning, identical output.
- Sourcing the file no longer emits the warning.
- `shellcheck -S error` clean.
- Parse still yields correct counts (fixture 1 CRITICAL / 2 HIGH / 1 MEDIUM → `crit=1 high=2 med=1`).

> Complements #317, which adds `test_check_network_scan_tools.sh` covering this function's TRIVY-* outputs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)