### PR TITLE
docs: fix agent-role references + document the 15 missing scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,12 @@ Multi-agent workflows:
 - **Scanner feature**: architect → implementer → test-engineer → ci-pipeline
 - **Hotfix**: researcher → implementer → reviewer
 
+The `sec-*` and `ci-pipeline` roles are project agents in `.claude/agents/`. The
+`architect`, `writer`, and `test-engineer` steps above are generic roles sourced
+from the global oh-my-claudecode agent catalog (there is no project-scoped
+`.claude/agents/` file for them) — substitute your own equivalents if you are not
+running OMC.
+
 ### Testing
 
 ```bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ All documentation is in Markdown. No build system required.
 
 ## Agents & Model Routing
 
-Project agents in `.claude/agents/`. Model selection:
+Project agents live in `.claude/agents/` (the `sec-*` and `ci-pipeline` roles).
+`architect`, `test-engineer`, and `explore` below are generic roles from the
+global oh-my-claudecode catalog, not project-scoped files. Model selection:
 
 - **opus**: sec-orchestrator, architect — coordination, architecture, security audit
 - **sonnet**: sec-implementer, sec-researcher, sec-reviewer, ci-pipeline, test-engineer — standard work

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md — scripts/
 
 <!-- Parent: ../AGENTS.md -->
-<!-- Generated: 2026-04-08 -->
+<!-- Generated: 2026-07-07 -->
 
 ## Purpose
 
@@ -34,7 +34,22 @@ Automation scripts for scan execution, dashboard building, asset collection, and
 | `quick-start.sh` | bash | Docker-first onboarding |
 | `lint-shell.sh` | bash | ShellCheck wrapper (local + CI) |
 | `gsheet-auth.py` | Python | Google Sheets OAuth helper |
+| `gsheet-auth-setup.py` | Python | gspread OAuth2 auth setup guide/helper |
 | `update-pc-sheet.py` | Python | PC inventory sheet updater |
+| `pre-push.sh` | bash | Git pre-push hook source (blocks direct push to `main`) |
+| `sync-repo-protection.sh` | bash | Sync GitHub branch-protection / ruleset to the codified config (backs `protection-drift-watch.yml`) |
+| `check-pull-request-target-guard.py` | Python | Audit workflows' `pull_request_target` triggers for the fork guard (backs `lint.yml`'s `workflow-fork-guard`) |
+| `check-prowler-python-ceiling.sh` | bash | Watch prowler's PyPI metadata for the Python <3.13 ceiling (backs `prowler-python-watch.yml`) |
+| `dev-machine-hardening.sh` | bash | macOS dev-machine hardening helper |
+| `github-setup-labels.sh` | bash | Create the recommended GitHub labels for this repo |
+| `og-meta-verify.sh` | bash | Fetch the deployed page's OG/Twitter meta + image and verify |
+| `run-prowler-k8s.sh` | bash | Run a Prowler K8s scan as an in-cluster Pod (EKS) |
+| `run-asset-sync.sh` | bash | Run the Google Sheets asset-management sync |
+| `sync-notion-licenses.py` | Python | Sync the Notion software-license DB → `dashboard-data.json` |
+| `update-license-active-accounts.py` | Python | Update the license sheet's `active_accounts` column from real usage |
+| `generate_ai_devsecops_ppt.py` | Python | Generate the AI-DevSecOps PPTX deck |
+| `generate_ai_devsecops_from_template.py` | Python | Build the AI-DevSecOps deck from a template |
+| `generate_security_seminar_template_ppt.py` | Python | Generate the 30-min security-seminar PPTX template |
 
 ## For AI Agents
 


### PR DESCRIPTION
## What (P2 remainder)

Two accuracy fixes flagged in the repo survey:

### `scripts/AGENTS.md` — table was 24/39 scripts
The "Key Scripts" table (dated 2026-04-08) documented only 24 of 39 scripts. Added the **15 undocumented** ones — several CI-critical:
- `sync-repo-protection.sh` → backs `protection-drift-watch.yml`
- `check-pull-request-target-guard.py` → backs the `workflow-fork-guard` job
- `check-prowler-python-ceiling.sh` → backs `prowler-python-watch.yml`
- `pre-push.sh`, the license/asset-sync helpers, and the 3 PPTX generators

Bumped the `Generated` date to 2026-07-07.

### `AGENTS.md` / `CLAUDE.md` — nonexistent "project agents"
The multi-agent workflow steps reference `architect`, `writer`, and `test-engineer`, but only the `sec-*` and `ci-pipeline` roles exist under `.claude/agents/`. Clarified that those three are generic roles from the **global oh-my-claudecode catalog**, not project-scoped agents.

## Test plan
- `markdownlint` clean on all three files.
- All **39** scripts now appear in the table (0 missing, 0 ghosts — verified by diffing the table against `ls scripts/`).
- `pii-check` clean.

> Overlaps `scripts/AGENTS.md` with #317 (which removes the dead `hourly-automation.sh` row); the additions here are appended at the table end, away from that row, so the two merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)