### PR TITLE
refactor(scanner): extract load_datadog_logs nested helpers to module level

### DIFF
--- a/scanner/lib/dashboard_data_loader.py
+++ b/scanner/lib/dashboard_data_loader.py
@@ -392,6 +392,96 @@ def load_network_tool_results(network_dir: str) -> NetworkToolResult:
     return out
 
 
+def _dd_normalize_log_severity(raw: Any) -> str:
+    """Map a raw log status/level to the log-summary bucket (error/warning/info)."""
+    val = (raw or "").strip().lower()
+    if val in ("critical", "crit", "error", "err", "fatal"):
+        return "error"
+    if val in ("warn", "warning"):
+        return "warning"
+    if val in ("info", "notice", "ok", "pass"):
+        return "info"
+    return "unknown"
+
+
+def _dd_normalize_log(item: dict[str, Any]) -> DatadogLogEntry:
+    """Normalize one raw Datadog log record into a DatadogLogEntry."""
+    attrs = item.get("attributes", {}) if isinstance(item, dict) else {}
+    nested = attrs.get("attributes", {}) if isinstance(attrs, dict) else {}
+    status = (
+        attrs.get("status")
+        or nested.get("status")
+        or attrs.get("level")
+        or nested.get("level")
+    )
+    severity = _dd_normalize_log_severity(status)
+    message = (
+        attrs.get("message")
+        or nested.get("message")
+        or item.get("message", "")
+        or ""
+    )
+    source = (
+        attrs.get("service")
+        or nested.get("service")
+        or attrs.get("source")
+        or nested.get("source")
+        or "-"
+    )
+    timestamp = (
+        attrs.get("timestamp")
+        or nested.get("timestamp")
+        or item.get("timestamp", "")
+    )
+    return {
+        "severity": severity,
+        "message": str(message),
+        "source": str(source),
+        "timestamp": str(timestamp),
+    }
+
+
+def _dd_normalize_signal_severity(raw: Any) -> str:
+    """Map a raw signal/case severity/priority to the standard severity bucket."""
+    val = str(raw or "").strip().lower()
+    if val in ("critical", "sev-1", "p1"):
+        return "critical"
+    if val in ("high", "sev-2", "p2"):
+        return "high"
+    if val in ("medium", "med", "sev-3", "p3"):
+        return "medium"
+    if val in ("low", "sev-4", "p4"):
+        return "low"
+    if val in ("info", "informational"):
+        return "info"
+    return "unknown"
+
+
+def _dd_inc_severity(counter: DatadogSeveritySummary, sev: str) -> None:
+    """Increment the matching severity bucket in a DatadogSeveritySummary counter."""
+    if sev == "critical":
+        counter["critical"] += 1
+    elif sev == "high":
+        counter["high"] += 1
+    elif sev == "medium":
+        counter["medium"] += 1
+    elif sev == "low":
+        counter["low"] += 1
+    elif sev == "info":
+        counter["info"] += 1
+    else:
+        counter["unknown"] += 1
+
+
+def _dd_extract_items(data: Any) -> list[dict[str, Any]]:
+    """Pull the list of dict records from a Datadog `{data: [...]}` or bare-list payload."""
+    if isinstance(data, dict) and isinstance(data.get("data"), list):
+        return [x for x in data["data"] if isinstance(x, dict)]
+    if isinstance(data, list):
+        return [x for x in data if isinstance(x, dict)]
+    return []
+
+
 def load_datadog_logs(datadog_dir: str) -> DatadogLogsData:
     logs: list[DatadogLogEntry] = []
     summary: DatadogSummary = {
@@ -430,86 +520,6 @@ def load_datadog_logs(datadog_dir: str) -> DatadogLogsData:
     if not datadog_dir or not os.path.isdir(datadog_dir):
         return out
 
-    def _normalize_severity(raw):
-        val = (raw or "").strip().lower()
-        if val in ("critical", "crit", "error", "err", "fatal"):
-            return "error"
-        if val in ("warn", "warning"):
-            return "warning"
-        if val in ("info", "notice", "ok", "pass"):
-            return "info"
-        return "unknown"
-
-    def _normalize_log(item: dict[str, Any]) -> DatadogLogEntry:
-        attrs = item.get("attributes", {}) if isinstance(item, dict) else {}
-        nested = attrs.get("attributes", {}) if isinstance(attrs, dict) else {}
-        status = (
-            attrs.get("status")
-            or nested.get("status")
-            or attrs.get("level")
-            or nested.get("level")
-        )
-        severity = _normalize_severity(status)
-        message = (
-            attrs.get("message")
-            or nested.get("message")
-            or item.get("message", "")
-            or ""
-        )
-        source = (
-            attrs.get("service")
-            or nested.get("service")
-            or attrs.get("source")
-            or nested.get("source")
-            or "-"
-        )
-        timestamp = (
-            attrs.get("timestamp")
-            or nested.get("timestamp")
-            or item.get("timestamp", "")
-        )
-        return {
-            "severity": severity,
-            "message": str(message),
-            "source": str(source),
-            "timestamp": str(timestamp),
-        }
-
-    def _normalize_dd_severity(raw: Any) -> str:
-        val = str(raw or "").strip().lower()
-        if val in ("critical", "sev-1", "p1"):
-            return "critical"
-        if val in ("high", "sev-2", "p2"):
-            return "high"
-        if val in ("medium", "med", "sev-3", "p3"):
-            return "medium"
-        if val in ("low", "sev-4", "p4"):
-            return "low"
-        if val in ("info", "informational"):
-            return "info"
-        return "unknown"
-
-    def _inc_sev(counter: DatadogSeveritySummary, sev: str) -> None:
-        if sev == "critical":
-            counter["critical"] += 1
-        elif sev == "high":
-            counter["high"] += 1
-        elif sev == "medium":
-            counter["medium"] += 1
-        elif sev == "low":
-            counter["low"] += 1
-        elif sev == "info":
-            counter["info"] += 1
-        else:
-            counter["unknown"] += 1
-
-    def _extract_items(data: Any) -> list[dict[str, Any]]:
-        if isinstance(data, dict) and isinstance(data.get("data"), list):
-            return [x for x in data["data"] if isinstance(x, dict)]
-        if isinstance(data, list):
-            return [x for x in data if isinstance(x, dict)]
-        return []
-
     candidates = [
         "datadog-logs.json",
         "logs.json",
@@ -531,7 +541,7 @@ def load_datadog_logs(datadog_dir: str) -> DatadogLogsData:
                             obj = json.loads(line)
                         except json.JSONDecodeError:
                             continue
-                        normalized = _normalize_log(obj)
+                        normalized = _dd_normalize_log(obj)
                         logs.append(normalized)
             else:
                 with open(fpath, encoding="utf-8") as f:
@@ -539,11 +549,11 @@ def load_datadog_logs(datadog_dir: str) -> DatadogLogsData:
                 if isinstance(data, dict) and isinstance(data.get("data"), list):
                     for item in data["data"]:
                         if isinstance(item, dict):
-                            logs.append(_normalize_log(item))
+                            logs.append(_dd_normalize_log(item))
                 elif isinstance(data, list):
                     for item in data:
                         if isinstance(item, dict):
-                            logs.append(_normalize_log(item))
+                            logs.append(_dd_normalize_log(item))
         except (OSError, json.JSONDecodeError):
             continue
 
@@ -578,14 +588,14 @@ def load_datadog_logs(datadog_dir: str) -> DatadogLogsData:
         except (OSError, json.JSONDecodeError):
             continue
         parsed_signals: list[dict[str, str]] = []
-        for item in _extract_items(data):
+        for item in _dd_extract_items(data):
             attrs = (
                 item.get("attributes", {})
                 if isinstance(item.get("attributes"), dict)
                 else {}
             )
-            sev = _normalize_dd_severity(attrs.get("severity"))
-            _inc_sev(signal_summary, sev)
+            sev = _dd_normalize_signal_severity(attrs.get("severity"))
+            _dd_inc_severity(signal_summary, sev)
             parsed_signals.append(
                 {
                     "severity": sev,
@@ -644,18 +654,18 @@ def load_datadog_logs(datadog_dir: str) -> DatadogLogsData:
         except (OSError, json.JSONDecodeError):
             continue
         parsed_cases: list[dict[str, str]] = []
-        for item in _extract_items(data):
+        for item in _dd_extract_items(data):
             attrs = (
                 item.get("attributes", {})
                 if isinstance(item.get("attributes"), dict)
                 else {}
             )
-            sev = _normalize_dd_severity(
+            sev = _dd_normalize_signal_severity(
                 attrs.get("severity")
                 or attrs.get("priority")
                 or attrs.get("case_priority")
             )
-            _inc_sev(case_summary, sev)
+            _dd_inc_severity(case_summary, sev)
             parsed_cases.append(
                 {
                     "severity": sev,


### PR DESCRIPTION
## What (refactor backlog — priority 2, safest first)

`load_datadog_logs` was a **308-line** function with five nested closures mixing log normalization, severity mapping, and record extraction. All five are **pure** (they close over no loop-local state — everything is passed as args), so they're hoisted to module level:

| New module helper | Role |
|-------------------|------|
| `_dd_normalize_log_severity` | log status/level → error/warning/info bucket |
| `_dd_normalize_log` | one raw log record → `DatadogLogEntry` |
| `_dd_normalize_signal_severity` | signal/case severity/priority → standard bucket |
| `_dd_inc_severity` | increment a `DatadogSeveritySummary` counter |
| `_dd_extract_items` | pull dict records from `{data:[...]}` / bare list |

`load_datadog_logs` now just orchestrates the three section loops (logs / signals / cases) and calls the shared, **independently unit-testable** helpers.

## Test plan / evidence

- Pure hoist, no logic change → behavior-preserving & coverage-neutral.
- `pytest scanner/` → **1443 passed**, scanner/lib coverage **99.12%** (≥99% gate).
- Datadog loader suites (`test_dashboard_data_loader_pure` / `_coverage`) → **106 passed**.
- `ast.parse` OK; no new lint (pre-existing F401 unused-imports in this file are unrelated and left untouched; ruff is not a CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)