### PR TITLE
chore(repo): route *.pptx through Git LFS (phase a — stop the bleed)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Git LFS routing for large binary collateral.
+#
+# PowerPoint decks under docs/reports/ (seminar / work-improvement templates) are
+# ~37 MB — 96% of everything tracked under docs/reports/. Routing *.pptx through
+# Git LFS keeps future updates out of the packed git history.
+#
+# SCOPE / LIMITATION (see docs/plans/refactoring-backlog.md, Priority 3):
+#   - This declaration only routes NEW or subsequently-modified *.pptx through
+#     LFS. Contributors committing a .pptx need `git lfs` installed.
+#   - The EXISTING committed .pptx blobs are NOT converted by this file. Actually
+#     reclaiming their ~37 MB from history requires `git lfs migrate import
+#     --include='*.pptx'` (a history rewrite / force-push) run in a coordinated
+#     maintenance window (phase b) — it invalidates open PRs, so it is deferred.
+*.pptx filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## What (refactor backlog — Priority 3, phase a)

`docs/reports/` carries two PowerPoint decks (~**37 MB**, 96% of everything tracked under `docs/reports/`). Adds a `.gitattributes` rule so **future** `*.pptx` are stored via Git LFS instead of bloating packed history.

## Scope & honesty (see `docs/plans/refactoring-backlog.md`, Priority 3)

- This is the low-risk **"stop the bleed"** phase — it only routes **new/modified** `.pptx` through LFS. This commit does **not** touch the existing `.pptx` blobs (`git diff --cached --name-only` shows only `.gitattributes`).
- Reclaiming the existing ~37 MB from history needs `git lfs migrate import` (a history rewrite / force-push that invalidates open PRs) in a **coordinated maintenance window (phase b)** — deferred.
- **`git-lfs` is not installed in the authoring environment**, so the LFS clean/smudge round-trip was **not exercised locally**; the rule is a standard, reversible forward declaration validated by inspection. Please confirm LFS is enabled on the repo before merging.

## Test plan
- Only `.gitattributes` added; existing `.pptx` untouched; `pii-check` / `gitleaks` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)