### PR TITLE
refactor(scanner): split Prowler dashboard summary out of output.sh

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -376,13 +376,13 @@ jobs:
             if [[ "$name" == *_tty ]]; then
               timeout 30 \
                 python3 scanner/tests/pty_run.py \
-                  kcov --include-pattern=checks.sh,output.sh \
+                  kcov --include-pattern=checks.sh,output.sh,output_prowler.sh \
                     --exclude-pattern=api-checks.sh,api_checks.sh \
                     "kcov-out/$name" "$sh" \
                 || rc=$?
             else
               timeout 30 \
-                kcov --include-pattern=checks.sh,output.sh \
+                kcov --include-pattern=checks.sh,output.sh,output_prowler.sh \
                   --exclude-pattern=api-checks.sh,api_checks.sh \
                   "kcov-out/$name" "$sh" \
                 || rc=$?

--- a/scanner/lib/output.sh
+++ b/scanner/lib/output.sh
@@ -504,65 +504,13 @@ compute_trend() {
   export TREND_HAS_PREV="true"
 }
 
-# Map a prowler provider slug (from filename) to a human-readable label.
-# Pure: deterministic string → string mapping, no I/O.
-_prowler_dashboard_summary_provider_label() {
-  case "$1" in
-    aws) echo "AWS" ;;
-    kubernetes) echo "Kubernetes" ;;
-    azure) echo "Azure" ;;
-    gcp) echo "GCP" ;;
-    github) echo "GitHub" ;;
-    googleworkspace) echo "Google Workspace" ;;
-    m365) echo "Microsoft 365" ;;
-    cloudflare) echo "Cloudflare" ;;
-    nhn) echo "NHN Cloud" ;;
-    iac) echo "IaC" ;;
-    llm) echo "LLM" ;;
-    image) echo "Container Image" ;;
-    oraclecloud) echo "Oracle Cloud" ;;
-    alibabacloud) echo "Alibaba Cloud" ;;
-    openstack) echo "OpenStack" ;;
-    mongodbatlas) echo "MongoDB Atlas" ;;
-    *) echo "$1" ;;
-  esac
-}
 
-# Build Prowler report summary HTML from .claudesec-prowler/*.ocsf.json (for dashboard)
-_prowler_dashboard_summary() {
-  local prowler_dir="${SCAN_DIR:-.}/.claudesec-prowler"
-  [[ -d "$prowler_dir" ]] || return 0
-  local files
-  files=$(find "$prowler_dir" -maxdepth 1 -name "prowler-*.ocsf.json" 2>/dev/null | sort)
-  [[ -z "$files" ]] && return 0
+# Prowler dashboard summary (provider-label map + per-provider HTML table) lives
+# in the sibling output_prowler.sh so this file stays focused; sourced by path
+# relative to this script so it resolves however output.sh itself is sourced.
+# shellcheck source=scanner/lib/output_prowler.sh
+source "$(dirname "${BASH_SOURCE[0]}")/output_prowler.sh"
 
-  echo "<div class=\"findings prowler-report\" style=\"margin-bottom:2rem\">"
-  echo "  <h2 style=\"padding:1rem 1.25rem;font-size:1rem;border-bottom:1px solid var(--border)\">☁ Prowler 클라우드 리포트 (프로바이더별 요약)</h2>"
-  echo "  <div style=\"padding:1rem 1.25rem\">"
-  echo "  <table style=\"width:100%;border-collapse:collapse\">"
-  echo "  <thead><tr><th style=\"text-align:left;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">프로바이더</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">전체</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">치명적</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">높음</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">중간</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">낮음</th></tr></thead>"
-  echo "  <tbody>"
-  while IFS= read -r f; do
-    [[ -f "$f" ]] || continue
-    local provider label total c h m l
-    provider=$(basename "$f" .ocsf.json | sed 's/^prowler-//')
-    label="$(_prowler_dashboard_summary_provider_label "$provider")"
-    total=$(grep -c '"status_code": *"FAIL"' "$f" 2>/dev/null || echo 0)
-    read -r c h m l <<< "$(awk '
-      BEGIN { c=0; h=0; m=0; l=0 }
-      /"severity":/ { gsub(/.*"severity": *"/,""); gsub(/".*/, ""); sev=$0 }
-      /"status_code": *"FAIL"/ {
-        if (sev=="Critical") c++; else if (sev=="High") h++; else if (sev=="Medium") m++; else if (sev=="Low") l++
-      }
-      END { print c+0, h+0, m+0, l+0 }
-    ' "$f" 2>/dev/null)"
-    c=${c:-0}; h=${h:-0}; m=${m:-0}; l=${l:-0}
-    echo "  <tr><td style=\"padding:0.5rem 0.75rem;border-bottom:1px solid var(--border)\">$label</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border)\">$total</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:#dc2626\">$c</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:#ef4444\">$h</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:#eab308\">$m</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:var(--muted)\">$l</td></tr>"
-  done <<< "$files"
-  echo "  </tbody></table>"
-  echo "  <p style=\"margin-top:0.75rem;font-size:0.78rem;color:var(--muted)\">원본 리포트 파일: <code>.claudesec-prowler/prowler-*.ocsf.json</code> (JSON-OCSF). 최신 상태로 갱신하려면 <code>claudesec scan -c prowler</code> 또는 <code>claudesec dashboard -c prowler</code>를 다시 실행하세요.</p>"
-  echo "  </div></div>"
-}
 
 _html_findings_rows() {
   local -n arr=$1

--- a/scanner/lib/output_prowler.sh
+++ b/scanner/lib/output_prowler.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ClaudeSec — Prowler dashboard summary (split out of output.sh)
+# ============================================================================
+# Provider-label mapping + the per-provider Prowler HTML summary table used by
+# the dashboard. Sourced by output.sh. The label `case` mirrors PROVIDER_LABELS
+# in scanner/lib/dashboard_providers.py and is kept in sync by
+# scanner/tests/test_ci_provider_labels_sync.py.
+
+# Map a prowler provider slug (from filename) to a human-readable label.
+# Pure: deterministic string → string mapping, no I/O.
+_prowler_dashboard_summary_provider_label() {
+  case "$1" in
+    aws) echo "AWS" ;;
+    kubernetes) echo "Kubernetes" ;;
+    azure) echo "Azure" ;;
+    gcp) echo "GCP" ;;
+    github) echo "GitHub" ;;
+    googleworkspace) echo "Google Workspace" ;;
+    m365) echo "Microsoft 365" ;;
+    cloudflare) echo "Cloudflare" ;;
+    nhn) echo "NHN Cloud" ;;
+    iac) echo "IaC" ;;
+    llm) echo "LLM" ;;
+    image) echo "Container Image" ;;
+    oraclecloud) echo "Oracle Cloud" ;;
+    alibabacloud) echo "Alibaba Cloud" ;;
+    openstack) echo "OpenStack" ;;
+    mongodbatlas) echo "MongoDB Atlas" ;;
+    *) echo "$1" ;;
+  esac
+}
+
+# Build Prowler report summary HTML from .claudesec-prowler/*.ocsf.json (for dashboard)
+_prowler_dashboard_summary() {
+  local prowler_dir="${SCAN_DIR:-.}/.claudesec-prowler"
+  [[ -d "$prowler_dir" ]] || return 0
+  local files
+  files=$(find "$prowler_dir" -maxdepth 1 -name "prowler-*.ocsf.json" 2>/dev/null | sort)
+  [[ -z "$files" ]] && return 0
+
+  echo "<div class=\"findings prowler-report\" style=\"margin-bottom:2rem\">"
+  echo "  <h2 style=\"padding:1rem 1.25rem;font-size:1rem;border-bottom:1px solid var(--border)\">☁ Prowler 클라우드 리포트 (프로바이더별 요약)</h2>"
+  echo "  <div style=\"padding:1rem 1.25rem\">"
+  echo "  <table style=\"width:100%;border-collapse:collapse\">"
+  echo "  <thead><tr><th style=\"text-align:left;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">프로바이더</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">전체</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">치명적</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">높음</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">중간</th><th style=\"text-align:right;padding:0.5rem 0.75rem;font-size:0.7rem;color:var(--muted);border-bottom:1px solid var(--border)\">낮음</th></tr></thead>"
+  echo "  <tbody>"
+  while IFS= read -r f; do
+    [[ -f "$f" ]] || continue
+    local provider label total c h m l
+    provider=$(basename "$f" .ocsf.json | sed 's/^prowler-//')
+    label="$(_prowler_dashboard_summary_provider_label "$provider")"
+    total=$(grep -c '"status_code": *"FAIL"' "$f" 2>/dev/null || echo 0)
+    read -r c h m l <<< "$(awk '
+      BEGIN { c=0; h=0; m=0; l=0 }
+      /"severity":/ { gsub(/.*"severity": *"/,""); gsub(/".*/, ""); sev=$0 }
+      /"status_code": *"FAIL"/ {
+        if (sev=="Critical") c++; else if (sev=="High") h++; else if (sev=="Medium") m++; else if (sev=="Low") l++
+      }
+      END { print c+0, h+0, m+0, l+0 }
+    ' "$f" 2>/dev/null)"
+    c=${c:-0}; h=${h:-0}; m=${m:-0}; l=${l:-0}
+    echo "  <tr><td style=\"padding:0.5rem 0.75rem;border-bottom:1px solid var(--border)\">$label</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border)\">$total</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:#dc2626\">$c</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:#ef4444\">$h</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:#eab308\">$m</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:var(--muted)\">$l</td></tr>"
+  done <<< "$files"
+  echo "  </tbody></table>"
+  echo "  <p style=\"margin-top:0.75rem;font-size:0.78rem;color:var(--muted)\">원본 리포트 파일: <code>.claudesec-prowler/prowler-*.ocsf.json</code> (JSON-OCSF). 최신 상태로 갱신하려면 <code>claudesec scan -c prowler</code> 또는 <code>claudesec dashboard -c prowler</code>를 다시 실행하세요.</p>"
+  echo "  </div></div>"
+}

--- a/scanner/tests/test_ci_provider_labels_sync.py
+++ b/scanner/tests/test_ci_provider_labels_sync.py
@@ -40,7 +40,9 @@ from pathlib import Path
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
-OUTPUT_SH = REPO_ROOT / "scanner" / "lib" / "output.sh"
+# The bash provider-label `case` was split out of output.sh into output_prowler.sh
+# (still sourced by output.sh); the parity guard follows it there.
+OUTPUT_SH = REPO_ROOT / "scanner" / "lib" / "output_prowler.sh"
 
 # Load the canonical Python source (dashboard_providers.py lives in scanner/lib).
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))


### PR DESCRIPTION
## What (refactor backlog — Priority 2, step 3)

`output.sh` (752 lines) carried the Prowler dashboard block — the provider-label `case` (`_prowler_dashboard_summary_provider_label`) and the per-provider HTML summary table (`_prowler_dashboard_summary`, incl. its awk severity counter). Neither is called elsewhere in `output.sh` (only the summary's own label lookup + `test_output_coverage.sh`), so they move to a sibling `scanner/lib/output_prowler.sh`, which `output.sh` `source`s by `BASH_SOURCE`-relative path.

### Kept in lockstep
- **kcov `--include-pattern`** (`lint.yml`, both invocations) now lists `output_prowler.sh`, so the moved lines stay measured — **coverage is neutral by construction** (byte-identical functions, same tests, same merged numerator/denominator across `checks.sh` + `output.sh` + `output_prowler.sh`).
- **`test_ci_provider_labels_sync.py`** `OUTPUT_SH` now points at `output_prowler.sh`, so the `PROVIDER_LABELS` parity guard follows the label `case`.

## Test plan / evidence
- `shellcheck -S error` clean (both files).
- `test_output_functions.sh` **225 passed**, `test_output_coverage.sh` **76 passed** (both `source output.sh` → prowler fns resolve).
- provider-labels guard **11 passed**; full CI-guard suite **258 passed**.
- ⚠️ **kcov could not be run locally** to confirm the 90% floor — kcov is a Linux/ptrace tool and does not function on the macOS arm64 authoring host (merged reported 0%/0 files even after `brew install kcov`). The **CI kcov job (ubuntu) is the authoritative gate**; the change is coverage-neutral by construction (please confirm the `scanner-shell-coverage` check stays green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)