### PR TITLE
chore(dev): local docker-based kcov shell-coverage verification harness

### DIFF
--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -50,6 +50,7 @@ Automation scripts for scan execution, dashboard building, asset collection, and
 | `generate_ai_devsecops_ppt.py` | Python | Generate the AI-DevSecOps PPTX deck |
 | `generate_ai_devsecops_from_template.py` | Python | Build the AI-DevSecOps deck from a template |
 | `generate_security_seminar_template_ppt.py` | Python | Generate the 30-min security-seminar PPTX template |
+| `verify-shell-coverage-docker.sh` | bash | Run the CI `scanner-shell-coverage` kcov flow locally in an ubuntu+kcov container (kcov does not work on macOS); pre-verify the 90% bash floor |
 
 ## For AI Agents
 

--- a/scripts/docker/kcov_report.py
+++ b/scripts/docker/kcov_report.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Print merged kcov bash-coverage summary and enforce a floor.
+
+Usage: kcov_report.py <coverage.json> <floor_percent>
+Exit 0 if merged percent_covered >= floor, else 2. Kept as a standalone file
+(not an inline heredoc) so the docker `bash -c` wrapper in
+verify-shell-coverage-docker.sh has no nested-quoting hazards.
+"""
+import json
+import sys
+
+
+def main() -> int:
+    cov_path, floor = sys.argv[1], float(sys.argv[2])
+    with open(cov_path, encoding="utf-8") as f:
+        data = json.load(f)
+    pct = float(data.get("percent_covered", 0) or 0)
+    print(f"MERGED bash coverage: {pct:.2f}% (floor {floor}%)")
+    for entry in sorted(data.get("files", []), key=lambda x: x.get("file", "")):
+        name = entry.get("file", "?").split("/")[-1]
+        fpct = float(entry.get("percent_covered", 0) or 0)
+        print(f"  {name:24} {fpct:.2f}%")
+    return 0 if pct >= floor else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/docker/shell-coverage.Dockerfile
+++ b/scripts/docker/shell-coverage.Dockerfile
@@ -1,0 +1,36 @@
+# Local kcov shell-coverage verification image.
+#
+# Mirrors the `scanner-shell-coverage` CI job (lint.yml): ubuntu + kcov v42 built
+# from source (jammy/noble apt kcov is v38, which reports 0% for sourced bash).
+# Lets macOS developers pre-verify the bash coverage floor locally — kcov is a
+# Linux/ptrace tool and does not function on macOS hosts.
+#
+# Build once (kcov compile is cached as a layer):
+#   docker build -f scripts/docker/shell-coverage.Dockerfile -t claudesec-kcov .
+# Then run via scripts/verify-shell-coverage-docker.sh
+FROM ubuntu:24.04
+
+ARG KCOV_VERSION=42
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime + build deps for kcov, plus python3/jq/shellcheck/git for the tests.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl \
+      libdw1 libcurl4 libssl3 zlib1g binutils \
+      binutils-dev libcurl4-openssl-dev libdw-dev libiberty-dev \
+      libssl-dev zlib1g-dev cmake build-essential pkg-config \
+      python3 python3-pip jq shellcheck git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build kcov v42 from source (matches the CI pin).
+RUN set -eux; \
+    TMP="$(mktemp -d)"; cd "$TMP"; \
+    curl -fsSL "https://github.com/SimonKagstrom/kcov/archive/refs/tags/v${KCOV_VERSION}.tar.gz" | tar xz; \
+    cd "kcov-${KCOV_VERSION}"; mkdir build && cd build; \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..; \
+    make -j"$(nproc)"; \
+    make install; \
+    cd /; rm -rf "$TMP"; \
+    kcov --version
+
+WORKDIR /repo

--- a/scripts/verify-shell-coverage-docker.sh
+++ b/scripts/verify-shell-coverage-docker.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# ============================================================================
+# verify-shell-coverage-docker.sh — local mirror of the CI scanner-shell-coverage
+# job, run inside an ubuntu+kcov container.
+# ============================================================================
+# kcov is a Linux/ptrace tool and does not work on macOS, so this reproduces the
+# CI bash-coverage gate locally via Docker. Use it to pre-verify the 90% floor
+# before pushing a scanner/lib/*.sh change (e.g. splitting output.sh / checks.sh).
+#
+# Usage:
+#   ./scripts/verify-shell-coverage-docker.sh            # build image if needed, run
+#   ./scripts/verify-shell-coverage-docker.sh --rebuild  # force image rebuild
+#
+# Mirrors lint.yml: --include-pattern=checks.sh,output.sh,output_prowler.sh
+# --exclude-pattern=api-checks.sh,api_checks.sh, direct-script invocation (never
+# `bash script.sh`, which would instrument the bash binary and report 0 lines),
+# CLAUDESEC_DASHBOARD_OFFLINE=1, and a 90.0% floor.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="claudesec-kcov"
+DOCKERFILE="scripts/docker/shell-coverage.Dockerfile"
+FLOOR="90.0"
+INCLUDE="checks.sh,output.sh,output_prowler.sh"
+EXCLUDE="api-checks.sh,api_checks.sh"
+
+cd "$REPO_ROOT"
+
+if ! docker info >/dev/null 2>&1; then
+  echo "ERROR: Docker daemon is not running. Start Docker Desktop and retry." >&2
+  exit 1
+fi
+
+if [[ "${1:-}" == "--rebuild" ]] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "==> Building $IMAGE (kcov v42 compile is cached after the first build)…"
+  docker build -f "$DOCKERFILE" -t "$IMAGE" .
+fi
+
+echo "==> Running scanner shell tests under kcov in container…"
+# Mount the repo read-only; all writes (kcov-out, test tmpdirs) go to container /tmp.
+docker run --rm -v "$REPO_ROOT":/repo:ro -w /repo \
+  -e CLAUDESEC_DASHBOARD_OFFLINE=1 -e FLOOR="$FLOOR" \
+  -e INCLUDE="$INCLUDE" -e EXCLUDE="$EXCLUDE" \
+  "$IMAGE" bash -euo pipefail -c '
+    out=/tmp/kcov-out; mkdir -p "$out"
+    for sh in scanner/tests/test_*.sh; do
+      name=$(basename "$sh" .sh); rc=0
+      # Direct-script invocation (NOT `bash "$sh"`), matching CI, so kcov measures
+      # the script bash lines rather than the bash binary. _tty tests need a pty.
+      if [[ "$name" == *_tty ]]; then
+        timeout 60 python3 scanner/tests/pty_run.py \
+          kcov --include-pattern="$INCLUDE" --exclude-pattern="$EXCLUDE" "$out/$name" "$sh" \
+          >/dev/null 2>&1 || rc=$?
+      else
+        timeout 60 kcov --include-pattern="$INCLUDE" --exclude-pattern="$EXCLUDE" "$out/$name" "$sh" \
+          >/dev/null 2>&1 || rc=$?
+      fi
+      [ "$rc" -ne 0 ] && echo "  (rc=$rc $name)"
+    done
+    kcov --merge "$out/merged" "$out"/*/ >/dev/null 2>&1
+    cov=$(find "$out/merged" -name coverage.json -print -quit 2>/dev/null || true)
+    [ -z "$cov" ] && cov=$(find "$out" -name coverage.json -print -quit 2>/dev/null || true)
+    if [ -z "$cov" ]; then echo "ERROR: no coverage.json produced" >&2; exit 1; fi
+    python3 scripts/docker/kcov_report.py "$cov" "$FLOOR"
+  '
+rc=$?
+if [ "$rc" -eq 0 ]; then
+  echo "==> PASS: bash coverage floor ($FLOOR%) satisfied."
+else
+  echo "==> FAIL: bash coverage below floor ($FLOOR%)." >&2
+fi
+exit "$rc"


### PR DESCRIPTION
## What (refactor backlog — item 3 enabler)

kcov is a Linux/ptrace tool and **does not work on macOS** (a local run reports 0% / 0 files), so the `scanner-shell-coverage` floor could only be checked in CI. This adds a **containerized mirror** of that CI job so `scanner/lib/*.sh` splits can be pre-verified locally before pushing.

- `scripts/docker/shell-coverage.Dockerfile` — `ubuntu:24.04` + **kcov v42 built from source** (matches the CI pin; apt kcov is the broken v38) + python3/jq/shellcheck/git.
- `scripts/docker/kcov_report.py` — standalone merged-coverage reporter + floor gate.
- `scripts/verify-shell-coverage-docker.sh` — builds the image (cached) and runs the CI-equivalent flow (same `--include-pattern` / `--exclude-pattern`, direct-script invocation, pty for `*_tty`, `CLAUDESEC_DASHBOARD_OFFLINE=1`, 90.0% floor).

## Test plan / evidence

- **Verified working**: `MERGED bash coverage: 91.75%` (≥90% floor) — `checks.sh 91.89%`, `output.sh 91.86%`, `output_prowler.sh 89.36%`.
- This **independently confirms locally** that the #329 output.sh split holds the floor (matching its CI `scanner-shell-coverage` PASS).
- `shellcheck -S error` clean; `markdownlint` clean; `kcov_report.py` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)