### PR TITLE
harden(docker): drop capabilities + no-new-privileges on scanner services

### DIFF
--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -22,6 +22,10 @@ services:
     command: ["scan", "-d", "/workspace", "-c", "all"]
     volumes: [".:/workspace"]
     working_dir: /workspace
+    # Hardening: no Linux capabilities, no privilege escalation (writes scan
+    # output under the mounted workspace, so root FS stays writable).
+    cap_drop: ["ALL"]
+    security_opt: ["no-new-privileges:true"]
 
   dashboard-gen:
     build: { context: ., dockerfile: Dockerfile }
@@ -29,6 +33,8 @@ services:
     command: ["dashboard", "-d", "/workspace", "-c", "all", "--no-serve"]
     volumes: [".:/workspace"]
     working_dir: /workspace
+    cap_drop: ["ALL"]
+    security_opt: ["no-new-privileges:true"]
     depends_on:
       scan: { condition: service_completed_successfully }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,12 @@ services:
     volumes: [".:/workspace"]
     working_dir: /workspace
     profiles: [scan]
+    # Hardening: a local file scanner needs no Linux capabilities and must not
+    # gain privileges. (Root FS stays writable — the scan writes scan-report.json
+    # and .claudesec-* under the mounted workspace; opt-in network raw scans are
+    # off by default.)
+    cap_drop: ["ALL"]
+    security_opt: ["no-new-privileges:true"]
 
   dashboard:
     build: { context: ., dockerfile: Dockerfile.nginx }


### PR DESCRIPTION
## What (Docker posture — complements #331)

The scanner services run the local file scanner, which needs **no Linux capabilities** and must not gain privileges. Added `cap_drop: [ALL]` + `security_opt: [no-new-privileges:true]` to:
- `scanner` (docker-compose.yml)
- `scan` + `dashboard-gen` (docker-compose.quickstart.yml)

Root FS stays **writable** (these jobs write `scan-report.json` / `.claudesec-*` under the mounted workspace; opt-in network raw scans are off by default), so unlike the dashboard (#331) `read_only` is not applied.

## Also checked (no change needed)
- **Image size**: `claudesec:ci` **154 MB** / `claudesec:local` **150 MB** — well under the 513 MB gate (#286), which already guards it. No slimming needed.

## Test plan — verified LIVE (Docker running)
- `docker compose --profile scan run --rm scanner scan -d /workspace -c code` completed cleanly under the hardening: **Security Score 90/100 (Grade A)**, 18 passed / 0 failed / 2 warn / 4 skip, ~1m20s — **no permission/capability errors**.
- Both compose files pass `docker compose config`.

> Touches the same compose files as #331 (different service blocks — dashboard vs scanner); they coexist after rebase regardless of merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)