### PR TITLE
fix(docker): bump bundled trivy 0.69.3 → 0.72.0 (clears 1 CRITICAL + 45 HIGH CVEs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,7 +94,7 @@ RUN apk add --no-cache \
     py3-pip \
     kubectl
 
-ARG TRIVY_VERSION=0.69.3
+ARG TRIVY_VERSION=0.72.0
 # Trivy vulnerability scanner (used by ClaudeSec network checks)
 # Install by downloading the prebuilt Linux binary asset with checksum verification.
 RUN set -eux; \


### PR DESCRIPTION
## What

A trivy scan of the `claudesec:ci` runtime image surfaced **92 vulnerabilities**, but **89 of them were inside the bundled `usr/local/bin/trivy` v0.69.3 binary itself** — trivy flagging its own vendored Go deps (grpc, containerd, docker, buildkit, go stdlib, …). trivy is `curl`-downloaded via a build ARG, so Dependabot cannot track it and it silently drifted **3 releases** behind, letting a **CRITICAL** (grpc `CVE-2026-33186`) accumulate.

This bumps `ARG TRIVY_VERSION` `0.69.3 → 0.72.0` (latest). The install step verifies the release `checksums.txt` (no hardcoded hash to update), and the pin stays version-shaped so `test_ci_trivy_version_pinned.py` stays green.

## Scan delta (fresh rebuild, trivy 0.72.0 DB)

| Severity | Before | After | Δ |
|----------|--------|-------|---|
| CRITICAL | 1 | **0** | grpc eliminated |
| HIGH | 48 | **3** | −45 (−94%) |
| MEDIUM | 34 | 3 | −31 |
| **TOTAL** | **92** | **10** | **−89%** |

**`libexpat` fixed for free**: `2.7.5-r0 → 2.8.1-r0` (`CVE-2026-45186`). The fresh build pulls the patched package now published on the `alpine:3.20` branch — base **digest unchanged** (it is already the latest 3.20). OS-package vulns: **2 → 0**.

## Remaining 3 HIGH (not directly actionable here)

- `cryptography 46.0.7` (prowler 5.30.1 transitive pin — bump with the prowler upgrade, tracked separately)
- 2× `oras-go/v2` inside the trivy binary (clears in a future trivy release; `CVE-2026-50163` has no fix yet)

## Test plan — verified locally

- Image rebuilt from the changed Dockerfile
- Smoke (mirrors `lint.yml` docker checks): `trivy --version` = 0.72.0, `kubectl version` = v1.30.9, `prowler -v` = 5.30.1
- **Non-root**: uid=1000 ✓
- **Size**: 149 MB (< 513 MB gate #286) ✓
- CI guards pass: `test_ci_trivy_version_pinned.py`, `test_ci_dockerfile_base_pinned.py`, `test_ci_prowler_version_pinned.py` (39 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)