### PR TITLE
refactor(scanner): remove dead scanner/lib functions (tested-but-unreachable)

### DIFF
--- a/scanner/lib/checks.sh
+++ b/scanner/lib/checks.sh
@@ -583,28 +583,6 @@ collect_environment_info() {
   fi
 }
 
-# Map check ID to compliance frameworks
-compliance_map() {
-  local id="$1"
-  # Returns compliance mappings for a check ID
-  # Format: "NIST:AC-2|ISO:A.9.2|ISMS-P:2.5.1|SOC2:CC6.1"
-  case "$id" in
-    IAM-*) echo "NIST:AC-2,IA-2|ISO:A.9|ISMS-P:2.5|SOC2:CC6.1" ;;
-    NET-*) echo "NIST:SC-7,SC-8|ISO:A.13|ISMS-P:2.6|SOC2:CC6.6" ;;
-    CLOUD-*) echo "NIST:CM-6,AC-3|ISO:A.12,A.14|ISMS-P:2.10|SOC2:CC6.1" ;;
-    CICD-*) echo "NIST:SA-11,CM-2|ISO:A.14|ISMS-P:2.9|SOC2:CC8.1" ;;
-    AI-*) echo "NIST-AI:MAP,MEASURE|ISO42001:6,7|ISMS-P:2.9" ;;
-    INFRA-*) echo "NIST:CM-6,CM-7|ISO:A.12,A.14|ISMS-P:2.10|SOC2:CC6.6" ;;
-    MAC-*|CIS-*) echo "CIS:macOS-Benchmark|NIST:CM-6,CM-7|ISO:A.8.9|KISA-PC:PC-01~PC-19" ;;
-    SECRETS-*) echo "NIST:IA-5,SC-28|ISO:A.8.4,A.8.24|ISMS-P:2.5,2.7|SOC2:CC6.1,CC6.7" ;;
-    SAAS-API-*) echo "NIST:AC-2,CM-6|ISO:A.9,A.12|ISMS-P:2.5,2.10|SOC2:CC6.1,CC6.6" ;;
-    SAAS-*) echo "NIST:AC-2,CM-6|ISO:A.9,A.12|ISMS-P:2.5,2.10|SOC2:CC6.1,CC6.6" ;;
-    WIN-*) echo "KISA-W:W-01~W-84|NIST:CM-6,AC-2,IA-5|ISO:A.8,A.9|ISMS-P:2.5,2.10" ;;
-    PROWLER-*) echo "NIST:AC,CM,IA,SC|ISO:A.8,A.9,A.12,A.14|CIS:Benchmark|SOC2:CC6,CC7,CC8" ;;
-    *) echo "" ;;
-  esac
-}
-
 # ── Category check runner (shared by run_scan / run_scan_for_dashboard) ─────
 
 # Runs each category's check files, aggregating global TOTAL_CHECKS/PASSED/FAILED/

--- a/scanner/lib/checks_credentials.sh
+++ b/scanner/lib/checks_credentials.sh
@@ -143,13 +143,6 @@ has_aws_credentials() {
   has_command aws && run_with_timeout 10 aws sts get-caller-identity &>/dev/null
 }
 
-# Check if an API key env var is set (non-empty); does not print the value
-api_key_found() {
-  local var_name="$1"
-  local val="${!var_name:-}"
-  [[ -n "$val" ]]
-}
-
 # Attempt AWS SSO login if configured but session expired
 aws_sso_ensure_login() {
   has_command aws || return 1

--- a/scanner/lib/output.sh
+++ b/scanner/lib/output.sh
@@ -153,16 +153,6 @@ should_report() {
   esac
 }
 
-html_escape() {
-  local s="$1"
-  s="${s//&/\&amp;}"
-  s="${s//</\&lt;}"
-  s="${s//>/\&gt;}"
-  s="${s//\"/\&quot;}"
-  s="${s//\'/\&#x27;}"
-  echo "$s"
-}
-
 _finding_ref_url() {
   case "$1" in
     CODE-INJ-*) echo "https://owasp.org/Top10/A03_2021-Injection/" ;;
@@ -457,119 +447,12 @@ HIST_EOF
   fi
 }
 
-# Load history entries (newest last), output as JSON array
-load_scan_history() {
-  local HISTORY_DIR="${SCAN_DIR:-.}/.claudesec-history"
-  [[ -d "$HISTORY_DIR" ]] || { echo "[]"; return; }
-  local entries=""
-  while IFS= read -r f; do
-    [[ -f "$f" ]] || continue
-    local content
-    content=$(cat "$f" 2>/dev/null) || continue
-    [[ -z "$content" ]] && continue
-    if [[ -n "$entries" ]]; then
-      entries="${entries},${content}"
-    else
-      entries="$content"
-    fi
-  done < <(find "$HISTORY_DIR" -name 'scan-*.json' 2>/dev/null | sort)
-  echo "[${entries}]"
-}
-
-# Compute trend delta vs previous scan
-compute_trend() {
-  local HISTORY_DIR="${SCAN_DIR:-.}/.claudesec-history"
-  [[ -d "$HISTORY_DIR" ]] || return
-  local prev_file
-  prev_file=$(find "$HISTORY_DIR" -name 'scan-*.json' 2>/dev/null | sort | tail -1)
-  [[ -z "$prev_file" || ! -f "$prev_file" ]] && return
-
-  local prev_score prev_failed prev_crit prev_high
-  prev_score=$(grep -o '"score":[0-9]*' "$prev_file" | cut -d: -f2)
-  prev_failed=$(grep -o '"failed":[0-9]*' "$prev_file" | cut -d: -f2)
-  prev_crit=$(grep -o '"critical":[0-9]*' "$prev_file" | cut -d: -f2)
-  prev_high=$(grep -o '"high":[0-9]*' "$prev_file" | cut -d: -f2)
-
-  local active=$((TOTAL_CHECKS - SKIPPED))
-  local score=0
-  [[ $active -gt 0 ]] && score=$(( (PASSED * 100) / active ))
-  local n_crit=${#FINDINGS_CRITICAL[@]}
-  local n_high=${#FINDINGS_HIGH[@]}
-
-  export TREND_SCORE_DELTA=$(( score - ${prev_score:-0} ))
-  export TREND_FAILED_DELTA=$(( FAILED - ${prev_failed:-0} ))
-  export TREND_CRIT_DELTA=$(( n_crit - ${prev_crit:-0} ))
-  export TREND_HIGH_DELTA=$(( n_high - ${prev_high:-0} ))
-  export TREND_PREV_SCORE="${prev_score:-0}"
-  export TREND_HAS_PREV="true"
-}
-
-
 # Prowler dashboard summary (provider-label map + per-provider HTML table) lives
 # in the sibling output_prowler.sh so this file stays focused; sourced by path
 # relative to this script so it resolves however output.sh itself is sourced.
 # shellcheck source=scanner/lib/output_prowler.sh
 source "$(dirname "${BASH_SOURCE[0]}")/output_prowler.sh"
 
-
-_html_findings_rows() {
-  local -n arr=$1
-  local sev_class="$2" badge_class="$3" badge_text="$4"
-  for entry in "${arr[@]+"${arr[@]}"}"; do
-    IFS='|' read -r f_id f_title _ f_fix f_details <<< "$entry"
-    f_title="$(html_escape "$f_title")"
-    f_fix="$(html_escape "$f_fix")"
-    f_details="$(html_escape "$f_details")"
-    # Convert literal \n to <br> for HTML display
-    f_title="${f_title//\\n/<br>}"
-    f_fix="${f_fix//\\n/<br>}"
-    f_details="${f_details//\\n/<br>}"
-
-    local detail_html=""
-    if [[ -n "$f_details" ]]; then
-      detail_html="<tr class=\"detail-row ${sev_class}\" style=\"display:none\"><td colspan=\"4\"><div class=\"detail-content\">${f_details}</div></td></tr>"
-      findings_html+="<tr class=\"${sev_class} clickable\" onclick=\"toggleDetail(this)\"><td><span class=\"badge ${badge_class}\">${badge_text}</span></td><td class=\"mono\">$f_id</td><td>$f_title <span class=\"expand-icon\">▸</span></td><td class=\"fix\">$f_fix</td></tr>${detail_html}"
-    else
-      findings_html+="<tr class=\"${sev_class}\"><td><span class=\"badge ${badge_class}\">${badge_text}</span></td><td class=\"mono\">$f_id</td><td>$f_title</td><td class=\"fix\">$f_fix</td></tr>"
-    fi
-  done
-}
-
-_html_findings_rows_limited() {
-  local outvar="$1"
-  local -n arr=$2
-  local sev_class="$3" badge_class="$4" badge_text="$5"
-  local max="${6:-0}"
-
-  local count=0
-  local current="${!outvar}"
-
-  for entry in "${arr[@]+"${arr[@]}"}"; do
-    if [[ "$max" -gt 0 && "$count" -ge "$max" ]]; then
-      break
-    fi
-    IFS='|' read -r f_id f_title _ f_fix f_details <<< "$entry"
-    f_title="$(html_escape "$f_title")"
-    f_fix="$(html_escape "$f_fix")"
-    f_details="$(html_escape "$f_details")"
-    # Convert literal \n to <br> for HTML display
-    f_title="${f_title//\\n/<br>}"
-    f_fix="${f_fix//\\n/<br>}"
-    f_details="${f_details//\\n/<br>}"
-
-    local detail_html=""
-    if [[ -n "$f_details" ]]; then
-      detail_html="<tr class=\"detail-row ${sev_class}\" style=\"display:none\"><td colspan=\"4\"><div class=\"detail-content\">${f_details}</div></td></tr>"
-      current+="<tr class=\"${sev_class} clickable\" onclick=\"toggleDetail(this)\"><td><span class=\"badge ${badge_class}\">${badge_text}</span></td><td class=\"mono\">$f_id</td><td>$f_title <span class=\"expand-icon\">▸</span></td><td class=\"fix\">$f_fix</td></tr>${detail_html}"
-    else
-      current+="<tr class=\"${sev_class}\"><td><span class=\"badge ${badge_class}\">${badge_text}</span></td><td class=\"mono\">$f_id</td><td>$f_title</td><td class=\"fix\">$f_fix</td></tr>"
-    fi
-
-    count=$((count + 1))
-  done
-
-  printf -v "$outvar" '%s' "$current"
-}
 
 generate_html_dashboard_legacy() {
   # Legacy bash-only generator kept as fallback (v0.2.0)

--- a/scanner/tests/test_checks_helpers.sh
+++ b/scanner/tests/test_checks_helpers.sh
@@ -243,22 +243,6 @@ sso_empty=$(aws_list_sso_profiles)
 assert_eq "aws_list_sso_profiles: missing file empty" "" "$sso_empty"
 
 # ============================================================================
-# api_key_found()
-# ============================================================================
-echo ""
-echo "=== api_key_found() ==="
-
-unset MY_API_KEY
-api_key_found "MY_API_KEY"; assert_false "api_key_found: unset is false" "$?"
-
-export MY_API_KEY=""
-api_key_found "MY_API_KEY"; assert_false "api_key_found: empty is false" "$?"
-
-export MY_API_KEY="abc"
-api_key_found "MY_API_KEY"; assert_true "api_key_found: set returns true" "$?"
-unset MY_API_KEY
-
-# ============================================================================
 # has_gcp_credentials / gcp_ensure_credentials_found
 # ============================================================================
 echo ""
@@ -397,27 +381,6 @@ mkdir -p "$tmpdir/kbase4/configs/custom"
 : > "$tmpdir/kbase4/configs/custom/kubeconfig"
 found=$(kubectl_auto_find_kubeconfig "$tmpdir/kbase4")
 assert_contains "kubectl_auto_find_kubeconfig: custom found" "$found" "kubeconfig"
-
-# ============================================================================
-# compliance_map()
-# ============================================================================
-echo ""
-echo "=== compliance_map() ==="
-
-assert_contains "compliance_map: IAM-*"      "$(compliance_map "IAM-001")"     "NIST:AC-2"
-assert_contains "compliance_map: NET-*"      "$(compliance_map "NET-042")"     "NIST:SC-7"
-assert_contains "compliance_map: CLOUD-*"    "$(compliance_map "CLOUD-013")"   "NIST:CM-6"
-assert_contains "compliance_map: CICD-*"     "$(compliance_map "CICD-007")"    "NIST:SA-11"
-assert_contains "compliance_map: AI-*"       "$(compliance_map "AI-002")"      "NIST-AI:MAP"
-assert_contains "compliance_map: INFRA-*"    "$(compliance_map "INFRA-001")"   "NIST:CM-6"
-assert_contains "compliance_map: MAC-*"      "$(compliance_map "MAC-001")"     "CIS:macOS-Benchmark"
-assert_contains "compliance_map: CIS-*"      "$(compliance_map "CIS-002")"     "CIS:macOS-Benchmark"
-assert_contains "compliance_map: SECRETS-*"  "$(compliance_map "SECRETS-001")" "NIST:IA-5"
-assert_contains "compliance_map: SAAS-API-*" "$(compliance_map "SAAS-API-01")" "NIST:AC-2"
-assert_contains "compliance_map: SAAS-*"     "$(compliance_map "SAAS-ZIA-01")" "NIST:AC-2"
-assert_contains "compliance_map: WIN-*"      "$(compliance_map "WIN-011")"     "KISA-W:W-01"
-assert_contains "compliance_map: PROWLER-*"  "$(compliance_map "PROWLER-1")"   "CIS:Benchmark"
-assert_eq       "compliance_map: unknown empty" "" "$(compliance_map "UNKNOWN-1")"
 
 # ============================================================================
 # kubectl_discover_kubeconfigs() — no HOME/.kube (uses real $HOME but tolerates)

--- a/scanner/tests/test_output_coverage.sh
+++ b/scanner/tests/test_output_coverage.sh
@@ -4,7 +4,6 @@
 # Targets: _id_to_category (L651-668), _emit_finding_json FINDINGS_WARN/LOW (L697-701),
 #          _print_finding_inline_fail severity-color branches (L93-99),
 #          _prowler_dashboard_summary awk severity counter (L551-558),
-#          load_scan_history multi-entry concat (L471),
 #          _prowler_dashboard_summary_provider_label full switch.
 # Run: bash scanner/tests/test_output_coverage.sh
 set -uo pipefail
@@ -313,34 +312,6 @@ assert_eq "provider_label: alibabacloud"   "Alibaba Cloud"   "$( set +x; _prowle
 assert_eq "provider_label: openstack"      "OpenStack"       "$( set +x; _prowler_dashboard_summary_provider_label openstack )"
 assert_eq "provider_label: mongodbatlas"   "MongoDB Atlas"   "$( set +x; _prowler_dashboard_summary_provider_label mongodbatlas )"
 assert_eq "provider_label: unknown passthrough" "custom-prov" "$( set +x; _prowler_dashboard_summary_provider_label custom-prov )"
-
-# ==============================================================================
-# Test Group 6: load_scan_history multi-entry concat (L471 entries="${entries},${content}")
-# Two or more scan files → the entries are comma-joined inside the array.
-# ==============================================================================
-echo ""
-echo "=== load_scan_history multi-entry concat (L471) ==="
-
-hist_base="$(mktemp -d)"
-OLD_SCAN_DIR2="$SCAN_DIR"
-SCAN_DIR="$hist_base"
-
-mkdir -p "$hist_base/.claudesec-history"
-printf '{"timestamp":"2026-01-01T00:00:00Z","score":70,"passed":7,"failed":3,"warnings":0,"skipped":0,"total":10,"critical":0,"high":1,"medium":2,"low":0,"warn":0}\n' \
-  > "$hist_base/.claudesec-history/scan-20260101T000000Z.json"
-printf '{"timestamp":"2026-01-02T00:00:00Z","score":80,"passed":8,"failed":2,"warnings":0,"skipped":0,"total":10,"critical":0,"high":0,"medium":2,"low":0,"warn":0}\n' \
-  > "$hist_base/.claudesec-history/scan-20260102T000000Z.json"
-
-loaded="$( set +x; load_scan_history )"
-# Must be a valid JSON array with both entries comma-separated (L471 exercises the branch)
-assert_contains "load_scan_history multi: starts with ["  "$loaded" "["
-assert_contains "load_scan_history multi: ends with ]"    "$loaded" "]"
-assert_contains "load_scan_history multi: entry1 score70" "$loaded" '"score":70'
-assert_contains "load_scan_history multi: entry2 score80" "$loaded" '"score":80'
-# Comma between entries (the L471 concat branch)
-assert_contains "load_scan_history multi: comma separator" "$loaded" '},'
-
-SCAN_DIR="$OLD_SCAN_DIR2"
 
 # ==============================================================================
 # Summary

--- a/scanner/tests/test_output_functions.sh
+++ b/scanner/tests/test_output_functions.sh
@@ -352,22 +352,6 @@ SEVERITY="$OLD_SEV"
 should_report() { return 0; }
 
 # ==============================================================================
-# Test Group 7: html_escape()
-# ==============================================================================
-echo ""
-echo "=== html_escape() ==="
-
-assert_eq "html_escape: amp"      "&amp;"             "$(html_escape '&')"
-assert_eq "html_escape: lt"       "&lt;"              "$(html_escape '<')"
-assert_eq "html_escape: gt"       "&gt;"              "$(html_escape '>')"
-assert_eq "html_escape: dquote"   "&quot;"            "$(html_escape '"')"
-assert_eq "html_escape: squote"   "&#x27;"            "$(html_escape "'")"
-assert_eq "html_escape: plain"    "Hello World"       "$(html_escape "Hello World")"
-assert_eq "html_escape: mixed"    "a&amp;b&lt;c&gt;d" "$(html_escape 'a&b<c>d')"
-assert_eq "html_escape: empty"    ""                  "$(html_escape '')"
-assert_contains "html_escape: script tag" "$(html_escape '<script>alert(1)</script>')" "&lt;script&gt;"
-
-# ==============================================================================
 # Test Group 8: _finding_ref_url() - ID prefix mapping
 # ==============================================================================
 echo ""
@@ -579,17 +563,14 @@ js_skip="$(print_json_summary 1 2>&1)"
 assert_contains "print_json_summary: skipped=total score 0" "$js_skip" '"score": 0'
 
 # ==============================================================================
-# Test Group 13: save_scan_history / load_scan_history / compute_trend
+# Test Group 13: save_scan_history
 # ==============================================================================
 echo ""
-echo "=== save_scan_history / load_scan_history / compute_trend ==="
+echo "=== save_scan_history ==="
 
 hist_base="$(mktemp -d)"
 OLD_SCAN_DIR="$SCAN_DIR"
 SCAN_DIR="$hist_base"
-
-# Empty history dir → load_scan_history returns "[]"
-assert_eq "load_scan_history: missing dir returns []" "[]" "$(load_scan_history)"
 
 # Save one scan
 _reset_state
@@ -597,22 +578,6 @@ TOTAL_CHECKS=10; PASSED=8; FAILED=2; WARNINGS=0; SKIPPED=0
 save_scan_history
 hist_count=$(find "$hist_base/.claudesec-history" -name 'scan-*.json' | wc -l | tr -d ' ')
 assert_eq "save_scan_history: file created" "1" "$hist_count"
-
-# load_scan_history populates
-loaded="$(load_scan_history)"
-assert_contains "load_scan_history: starts with [" "$loaded" "["
-assert_contains "load_scan_history: ends with ]"   "$loaded" "]"
-assert_contains "load_scan_history: score field"   "$loaded" '"score":80'
-assert_contains "load_scan_history: passed field"  "$loaded" '"passed":8'
-
-# Save second scan (improved) → compute_trend produces deltas
-_reset_state
-TOTAL_CHECKS=10; PASSED=9; FAILED=1; WARNINGS=0; SKIPPED=0
-compute_trend
-assert_eq "compute_trend: TREND_HAS_PREV"      "true" "${TREND_HAS_PREV:-}"
-assert_eq "compute_trend: score delta +10"     "10"   "${TREND_SCORE_DELTA:-}"
-assert_eq "compute_trend: failed delta -1"     "-1"   "${TREND_FAILED_DELTA:-}"
-assert_eq "compute_trend: prev score=80"       "80"   "${TREND_PREV_SCORE:-}"
 
 # History pruning: force HISTORY_MAX=2 and create 5 files so 3 are pruned
 rm -rf "$hist_base/.claudesec-history"
@@ -648,84 +613,6 @@ assert_contains "legacy: body tag"           "$legacy_content" "<body>"
 assert_contains "legacy: title heading"      "$legacy_content" "ClaudeSec Dashboard"
 assert_contains "legacy: fallback mention"   "$legacy_content" "fallback"
 assert_contains "legacy: install python hint" "$legacy_content" "Python 3"
-
-# ==============================================================================
-# Test Group 15: _html_findings_rows / _html_findings_rows_limited
-# ==============================================================================
-echo ""
-echo "=== _html_findings_rows / _html_findings_rows_limited ==="
-
-# Basic rows with details → row + detail-row
-_reset_state
-FINDINGS_HIGH+=("CHK-HR1|High <danger> &title|high|Fix it|extra details")
-findings_html=""
-_html_findings_rows FINDINGS_HIGH "high" "badge-high" "HIGH"
-assert_contains "html_rows: id in output"           "$findings_html" "CHK-HR1"
-assert_contains "html_rows: title escaped"          "$findings_html" "&lt;danger&gt;"
-assert_contains "html_rows: amp escaped"            "$findings_html" "&amp;title"
-assert_contains "html_rows: fix shown"              "$findings_html" "Fix it"
-assert_contains "html_rows: badge class"            "$findings_html" "badge-high"
-assert_contains "html_rows: sev class row"          "$findings_html" '"high clickable"'
-assert_contains "html_rows: detail-row present"     "$findings_html" "detail-row"
-assert_contains "html_rows: clickable handler"      "$findings_html" "toggleDetail"
-assert_contains "html_rows: expand icon"            "$findings_html" "expand-icon"
-
-# Row without details → no detail-row, non-clickable
-_reset_state
-FINDINGS_MEDIUM+=("CHK-HR2|Med title|medium|Fix med|")
-findings_html=""
-_html_findings_rows FINDINGS_MEDIUM "medium" "badge-med" "MED"
-assert_contains     "html_rows(no details): id shown"            "$findings_html" "CHK-HR2"
-assert_not_contains "html_rows(no details): no detail-row"       "$findings_html" "detail-row"
-assert_not_contains "html_rows(no details): no toggle"           "$findings_html" "toggleDetail"
-
-# Empty findings array → no html produced
-_reset_state
-findings_html=""
-_html_findings_rows FINDINGS_LOW "low" "badge-low" "LOW"
-assert_eq "html_rows: empty array produces nothing" "" "$findings_html"
-
-# _html_findings_rows_limited with max=0 (unlimited) emits every entry
-_reset_state
-FINDINGS_HIGH+=("CHK-L1|First|high|fix1|")
-FINDINGS_HIGH+=("CHK-L2|Second|high|fix2|")
-FINDINGS_HIGH+=("CHK-L3|Third|high|fix3|")
-out_unlim=""
-_html_findings_rows_limited out_unlim FINDINGS_HIGH "high" "badge-high" "HIGH" 0
-assert_contains "html_rows_limited(max=0): first"  "$out_unlim" "CHK-L1"
-assert_contains "html_rows_limited(max=0): second" "$out_unlim" "CHK-L2"
-assert_contains "html_rows_limited(max=0): third"  "$out_unlim" "CHK-L3"
-
-# max=1 caps at a single row
-out_capped=""
-_html_findings_rows_limited out_capped FINDINGS_HIGH "high" "badge-high" "HIGH" 1
-assert_contains     "html_rows_limited(max=1): first included"  "$out_capped" "CHK-L1"
-assert_not_contains "html_rows_limited(max=1): second excluded" "$out_capped" "CHK-L2"
-assert_not_contains "html_rows_limited(max=1): third excluded"  "$out_capped" "CHK-L3"
-
-# max=2 caps at two rows
-out_two=""
-_html_findings_rows_limited out_two FINDINGS_HIGH "high" "badge-high" "HIGH" 2
-assert_contains     "html_rows_limited(max=2): first"         "$out_two" "CHK-L1"
-assert_contains     "html_rows_limited(max=2): second"        "$out_two" "CHK-L2"
-assert_not_contains "html_rows_limited(max=2): third missing" "$out_two" "CHK-L3"
-
-# Preserves existing content in outvar (append semantics)
-_reset_state
-FINDINGS_MEDIUM+=("CHK-APP1|Append test|medium|fix|")
-out_existing="PRIOR-CONTENT"
-_html_findings_rows_limited out_existing FINDINGS_MEDIUM "medium" "badge-med" "MED" 0
-assert_contains "html_rows_limited: preserves prior content" "$out_existing" "PRIOR-CONTENT"
-assert_contains "html_rows_limited: appends new row"         "$out_existing" "CHK-APP1"
-
-# Row with details in limited variant → clickable + detail-row
-_reset_state
-FINDINGS_HIGH+=("CHK-LD1|Limited detail|high|fix|lots of details here")
-out_det=""
-_html_findings_rows_limited out_det FINDINGS_HIGH "high" "badge-high" "HIGH" 5
-assert_contains "html_rows_limited: detail-row present" "$out_det" "detail-row"
-assert_contains "html_rows_limited: toggleDetail"       "$out_det" "toggleDetail"
-assert_contains "html_rows_limited: details in output"  "$out_det" "lots of details here"
 
 # ==============================================================================
 # Summary


### PR DESCRIPTION
## Summary

Removes seven bash functions in `scanner/lib` that have **zero production call sites** — reachable only from their own unit tests — plus those dedicated tests. This is the dead-code slice from the fresh `scanner/lib` backlog rescan; a follow-up PR adds a reachability guard so this class can't silently reaccumulate.

## Removed

| Function | File | Why dead |
|----------|------|----------|
| `load_scan_history` | `output.sh` | Dashboard reads history via the separate **Python** `load_scan_history` in `dashboard_data_loader.py`; the bash one has no consumer. |
| `compute_trend` | `output.sh` | No consumer reads any `TREND_*` export anywhere. |
| `_html_findings_rows` | `output.sh` | Superseded bash HTML-row builder; `generate_html_dashboard` emits findings JSON for the Python generator and calls neither. Backlog had mislabelled this "live" — it is dead. |
| `_html_findings_rows_limited` | `output.sh` | Same — superseded. |
| `html_escape` | `output.sh` | **Orphaned by removing the two HTML-row builders above** (its only callers). Removed as direct cleanup of this change per the repo's `karpathy-guidelines` "clean up your own orphans" rule. The Python dashboard path does its own escaping; no bash consumer remains. |
| `api_key_found` | `checks_credentials.sh` | No caller. |
| `compliance_map` (bash) | `checks.sh` | No caller. The live compliance mapping is `compliance-map.py`'s per-check-ID `COMPLIANCE_CONTROL_MAP` (`map_compliance`) — a different, single-sourced subsystem, left untouched. |

**Kept:** `save_scan_history` — it IS used in production (`scanner/claudesec:513`). Its history-pruning test is preserved; only the `load`/`compute` assertions were removed from the shared test group.

> **Scope note:** the original task named 5 functions. `_html_findings_rows` was added after confirming it's dead too (user-approved), and `html_escape` was removed as an orphan this change created. Flagging both explicitly for review.

## Verification

- `test_output_functions.sh` 180/180, `test_output_coverage.sh` 71/71, `test_checks_helpers.sh` 69/69 pass
- `pytest scanner/` — 1468 passed (the 5 `test_scan_report_baseline.py` failures are from a **stale untracked local** `scan-report.json`; identical with these edits stashed, and CI never sees the file since it's not tracked)
- `shellcheck --severity=error -x` clean on all six files
- **kcov bash coverage (docker, CI-exact patterns): 91.43% ≥ 90.0% floor** (`output.sh` 90.60%, `checks.sh` 93.94%)

## Test plan

- [x] Confirm no dangling references to any removed function in `scanner/lib`/`scanner/checks`/`scanner/claudesec`
- [x] Full pytest + affected shell tests green
- [x] Coverage floor still satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)