### PR TITLE
refactor(scanner): decompose diagram-gen.py into diagram_data + diagram_svg leaf modules

### DIFF
--- a/docs/plans/refactoring-backlog.md
+++ b/docs/plans/refactoring-backlog.md
@@ -50,8 +50,14 @@ Pure moves; the coverage gate is the safety net.
    closures out of the 308-line `load_datadog_logs` to module level
    (`_dd_normalize_log`, `_dd_normalize_signal_severity`, `_dd_inc_severity`,
    `_dd_extract_items`, `_dd_normalize_log_severity`).
-2. `diagram-gen.py` — TODO: split the section/diagram builders (mirror the
-   `dashboard_html_*` module split). Strong pytest coverage → low risk.
+2. `diagram-gen.py` — ✅ DONE: extracted the scan-data layer to `diagram_data.py`
+   (`CATEGORIES` + `_parse_ocsf_json` / `load_prowler_files` / `load_scan_history`
+   / `aggregate_scan_data`) and the SVG builders to `diagram_svg.py` (`_svg_escape`
+   / `generate_architecture_svg` / `generate_overview_svg`), re-exported into
+   `diagram-gen.py` (838→545 lines). `generate_security_domains_diagram` stays put
+   so the `test_ci_diagram_gen_canonical_sync` frameworks-derive guard still fires.
+   Verified: pytest 99.12% floor holds, 129 diagram tests pass, and all six
+   generated `.drawio`/`.svg` files are **byte-identical** (SHA-256) before/after.
 3. `output.sh` — TODO: extract the prowler-summary block into a focused unit
    (bash; kcov floor is the net).
 4. `checks.sh` — TODO: group the AWS / GCP / Azure / datadog credential helpers

--- a/scanner/lib/diagram-gen.py
+++ b/scanner/lib/diagram-gen.py
@@ -6,10 +6,8 @@ Combines scan results, Prowler OCSF, and history to produce .drawio diagrams.
 import json
 import os
 import sys
-import glob
 import xml.etree.ElementTree as ET  # builders only (Element, SubElement, tostring) — no untrusted XML parsed here
 from pathlib import Path
-from collections import defaultdict
 import hashlib
 
 # Sibling-module imports: ensure this file's dir (scanner/lib) is importable
@@ -35,131 +33,31 @@ from diagram_drawio import (  # noqa: E402,F401
     add_drawio_page,
     _draw_edge,
 )
+# Scan data loading/aggregation lives in the diagram_data leaf module; the draw.io
+# builders below and the tests (MOD.aggregate_scan_data / MOD.load_prowler_files /
+# MOD.CATEGORIES …) resolve them via these re-exports.
+from diagram_data import (  # noqa: E402,F401
+    CATEGORIES,
+    _parse_ocsf_json,
+    load_prowler_files,
+    load_scan_history,
+    aggregate_scan_data,
+)
+# SVG builders live in the diagram_svg leaf module (re-exported so
+# MOD.generate_architecture_svg / MOD.generate_overview_svg / MOD._svg_escape
+# resolve as before).
+from diagram_svg import (  # noqa: E402,F401
+    _svg_escape,
+    generate_architecture_svg,
+    generate_overview_svg,
+)
 
 VERSION = "0.1.0"
-
-# Scanner categories — order must mirror the `CLAUDESEC_ALL_CATEGORIES` array in
-# scanner/claudesec (the authoritative scan order). CATEGORIES[:8]/[:7] slices
-# feed diagram labels, so order matters. Kept honest by
-# scanner/tests/test_ci_diagram_gen_canonical_sync.py.
-CATEGORIES = [
-    "infra", "ai", "network", "cloud", "access-control",
-    "cicd", "code", "macos", "windows", "saas", "prowler",
-]
 
 # Security architecture domains and compliance frameworks are single-sourced
 # from dashboard_arch.ARCH_DOMAINS and dashboard_compliance.COMPLIANCE_FRAMEWORKS
 # (imported above) — no inline copies here, so the diagram never drifts from the
 # dashboard. Kept honest by scanner/tests/test_ci_diagram_gen_canonical_sync.py.
-
-
-def _parse_ocsf_json(content):
-    items = []
-    decoder = json.JSONDecoder()
-    idx = 0
-    while idx < len(content):
-        while idx < len(content) and content[idx] in " \t\n\r":
-            idx += 1
-        if idx >= len(content):
-            break
-        try:
-            obj, end = decoder.raw_decode(content, idx)
-            if isinstance(obj, list):
-                items.extend(o for o in obj if isinstance(o, dict))
-            elif isinstance(obj, dict):
-                items.append(obj)
-            idx = end
-        except json.JSONDecodeError:
-            idx += 1
-    return items
-
-
-def load_prowler_files(prowler_dir):
-    providers = {}
-    if not os.path.isdir(prowler_dir):
-        return providers
-    for fpath in sorted(glob.glob(os.path.join(prowler_dir, "prowler-*.ocsf.json"))):
-        name = Path(fpath).stem.replace(".ocsf", "").replace("prowler-", "")
-        try:
-            with open(fpath) as f:
-                content = f.read().strip()
-            items = _parse_ocsf_json(content)
-            providers[name] = items
-        except Exception:
-            providers[name] = []
-    return providers
-
-
-def load_scan_history(history_dir):
-    entries = []
-    if not os.path.isdir(history_dir):
-        return entries
-    for fpath in sorted(glob.glob(os.path.join(history_dir, "scan-*.json"))):
-        try:
-            with open(fpath) as f:
-                entries.append(json.load(f))
-        except Exception:
-            pass
-    return entries
-
-
-def aggregate_scan_data(scan_dir):
-    """Load and aggregate all scan-related data for diagram labels."""
-    base = Path(scan_dir or ".")
-    scan_json = base / "scan-report.json"
-    prowler_dir = base / ".claudesec-prowler"
-    history_dir = base / ".claudesec-history"
-
-    scan_data = load_scan_results(str(scan_json))
-    # Fallback: allow overriding scan JSON file.
-    if (not scan_data.get("total")) and os.environ.get("CLAUDESEC_SCAN_JSON"):
-        p = os.environ.get("CLAUDESEC_SCAN_JSON")
-        if os.path.isfile(p):
-            scan_data = load_scan_results(p)
-
-    # Fallback: build minimal scan_data from env vars (dashboard generation path).
-    # This keeps diagram generation functional even when scan-report.json is missing.
-    if not scan_data.get("total"):
-        try:
-            passed = int(os.environ.get("CLAUDESEC_PASSED", "0") or "0")
-            failed = int(os.environ.get("CLAUDESEC_FAILED", "0") or "0")
-            warnings = int(os.environ.get("CLAUDESEC_WARNINGS", "0") or "0")
-            skipped = int(os.environ.get("CLAUDESEC_SKIPPED", "0") or "0")
-            total = int(os.environ.get("CLAUDESEC_TOTAL", "0") or "0")
-            score = int(os.environ.get("CLAUDESEC_SCORE", "0") or "0")
-            grade = os.environ.get("CLAUDESEC_GRADE", "F") or "F"
-            duration = int(os.environ.get("CLAUDESEC_DURATION", "0") or "0")
-            findings = []
-            env_findings = os.environ.get("CLAUDESEC_FINDINGS_JSON", "") or ""
-            if env_findings.strip().startswith("["):
-                findings = json.loads(env_findings)
-            scan_data = {
-                "passed": passed,
-                "failed": failed,
-                "warnings": warnings,
-                "skipped": skipped,
-                "total": total,
-                "score": score,
-                "grade": grade,
-                "duration": duration,
-                "findings": findings if isinstance(findings, list) else [],
-            }
-        except Exception:
-            pass
-
-    providers = load_prowler_files(str(prowler_dir))
-    prov_summary = {}
-    for prov, items in providers.items():
-        fails = [i for i in items if i.get("status_code") == "FAIL"]
-        prov_summary[prov] = {"fail": len(fails), "total": len(items)}
-
-    history = load_scan_history(str(history_dir))
-    return {
-        "scan": scan_data,
-        "prowler_providers": list(providers.keys()),
-        "prowler_summary": prov_summary,
-        "history_count": len(history),
-    }
 
 
 def _overview_architecture_page(gr, agg):
@@ -554,197 +452,6 @@ def generate_architecture_diagram(agg, out_path):
         sid += 1
 
     write_drawio_file(root, out_path)
-
-
-def _svg_escape(s):
-    if s is None:
-        return ""
-    s = str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
-    return s
-
-
-def generate_architecture_svg(agg, out_path):
-    """Same layout as architecture drawio, as SVG for viewing in browser/docs."""
-    scan = agg.get("scan", {})
-    score = scan.get("score", 0)
-    grade = scan.get("grade", "F")
-    total = scan.get("total", 0)
-    failed = scan.get("failed", 0)
-    warnings = scan.get("warnings", 0)
-    findings = scan.get("findings", []) or []
-
-    # Summaries from scan findings JSON (best-effort).
-    sev_counts = defaultdict(int)
-    cat_counts = defaultdict(int)
-    for f in findings:
-        if not isinstance(f, dict):
-            continue
-        sev = (f.get("severity") or "").lower().strip()
-        cat = (f.get("category") or "").lower().strip()
-        if sev:
-            sev_counts[sev] += 1
-        if cat:
-            cat_counts[cat] += 1
-
-    prowler_list = agg.get("prowler_providers", [])
-    prowler_str = ", ".join(prowler_list[:5]) + ("..." if len(prowler_list) > 5 else "") if prowler_list else "no data"
-    hist = agg.get("history_count", 0)
-    prov_summary = agg.get("prowler_summary", {}) or {}
-    total_prowler_fail = sum(int(v.get("fail", 0) or 0) for v in prov_summary.values()) if isinstance(prov_summary, dict) else 0
-
-    # Top categories by count (for quick "what's noisy" signal).
-    top_cats = sorted(cat_counts.items(), key=lambda kv: (-kv[1], kv[0]))[:4]
-    top_cats_str = ", ".join(f"{k}:{v}" for k, v in top_cats) if top_cats else "none"
-
-    # Coordinates (match drawio layout)
-    boxes = [
-        (40, 80, 140, 50, "#dae8fc", "#6c8ebf", ["ClaudeSec Scanner", "(CLI)"]),
-        (260, 40, 160, 140, "#dae8fc", "#6c8ebf", ["Scan Categories"] + CATEGORIES[:7] + ["..."]),
-        (520, 50, 220, 64, "#fff2cc", "#d6b656", [
-            "Scan Results",
-            f"Total:{total} Failed:{failed} Warn:{warnings}",
-            f"Score:{score}% Grade:{grade}  Crit:{sev_counts.get('critical', 0)} High:{sev_counts.get('high', 0)}",
-        ]),
-        (520, 120, 140, 40, "#fff2cc", "#d6b656", ["scan-report.json", "(results)"]),
-        (520, 190, 200, 56, "#fff2cc", "#d6b656", ["Prowler OCSF", f"Fail:{total_prowler_fail} ({prowler_str})"]),
-        (720, 80, 120, 50, "#e1d5e7", "#9673a6", ["Dashboard", "(HTML)"]),
-        (720, 150, 160, 40, "#e1d5e7", "#9673a6", [f"History", f"({hist} entries)"]),
-        (40, 10, 840, 26, "#111827", "#111827", [f"Top categories: {top_cats_str}"]),
-    ]
-    w, h = 900, 270
-    lines = [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">',
-        '<defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#374151"/></marker></defs>',
-        '<style>text { font-family: system-ui, sans-serif; font-size: 11px; fill: #333; } .title { font-weight: bold; } .banner { font-size: 11px; fill: #f9fafb; }</style>',
-    ]
-    # Arrows (under boxes): Scanner→Categories, Categories→Results, Results→Dashboard, Results→History
-    arrow_list = [(180, 105, 260, 105), (420, 110, 520, 75), (700, 75, 720, 105), (700, 100, 720, 170)]
-    for sx, sy, ex, ey in arrow_list:
-        lines.append(f'<line x1="{sx}" y1="{sy}" x2="{ex}" y2="{ey}" stroke="#374151" stroke-width="1.5" marker-end="url(#arrow)"/>')
-    # Boxes
-    for x, y, bw, bh, fill, stroke, labels in boxes:
-        lines.append(f'<rect x="{x}" y="{y}" width="{bw}" height="{bh}" rx="6" fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>')
-        for i, label in enumerate(labels):
-            ly = y + 16 + i * 14
-            if ly < y + bh - 4:
-                cls = "banner" if (fill == "#111827") else ("title" if i == 0 else "")
-                lines.append(f'<text x="{x + bw/2}" y="{ly}" text-anchor="middle" class="{cls}">{_svg_escape(label)}</text>')
-    lines.append("</svg>")
-    with open(out_path, "w", encoding="utf-8") as f:
-        f.write("\n".join(lines))
-    print(f"  {out_path}")
-
-
-def generate_overview_svg(agg, scan_dir, out_path):
-    """One-screen overview SVG: Architecture + Service flow + Network flow.
-
-    This is optimized for embedding into claudesec-dashboard.html.
-    """
-    scan = agg.get("scan", {}) or {}
-    total = scan.get("total", 0)
-    failed = scan.get("failed", 0)
-    warnings = scan.get("warnings", 0)
-    score = scan.get("score", 0)
-    grade = scan.get("grade", "F")
-
-    prov_summary = agg.get("prowler_summary", {}) or {}
-    total_prowler_fail = (
-        sum(int(v.get("fail", 0) or 0) for v in prov_summary.values())
-        if isinstance(prov_summary, dict)
-        else 0
-    )
-
-    # Network report (best-effort)
-    net_dir = Path(scan_dir or ".") / ".claudesec-network"
-    net_report = net_dir / "network-report.v1.json"
-    net_targets = 0
-    net_header_issues = 0
-    if net_report.is_file():
-        try:
-            d = json.loads(net_report.read_text(encoding="utf-8"))
-            targets = d.get("targets") or []
-            if isinstance(targets, list):
-                net_targets = len(targets)
-                for t in targets[:20]:
-                    http = t.get("http") if isinstance(t, dict) else None
-                    issues = http.get("issues") if isinstance(http, dict) else []
-                    if isinstance(issues, list):
-                        net_header_issues += len(issues)
-        except Exception:
-            pass
-
-    w, h = 1100, 720
-    lines = [
-        '<?xml version="1.0" encoding="UTF-8"?>',
-        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">',
-        "<defs>",
-        '<marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#334155"/></marker>',
-        "</defs>",
-        "<style>",
-        "  .bg{fill:#0b1220}",
-        "  .card{fill:#0f172a;stroke:#334155;stroke-width:1.5}",
-        "  .boxA{fill:#0b2a4a;stroke:#38bdf8;stroke-width:1.5}",
-        "  .boxB{fill:#3a2503;stroke:#eab308;stroke-width:1.5}",
-        "  .boxC{fill:#2b1b57;stroke:#a78bfa;stroke-width:1.5}",
-        "  .txt{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:12px;fill:#e5e7eb}",
-        "  .muted{fill:#94a3b8}",
-        "  .title{font-size:16px;font-weight:700}",
-        "  .h2{font-size:13px;font-weight:700;fill:#e2e8f0}",
-        "  .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:11px}",
-        "</style>",
-        f'<rect class="bg" x="0" y="0" width="{w}" height="{h}"/>',
-        # Header
-        '<text class="txt title" x="30" y="38">ClaudeSec Overview Architecture</text>',
-        f'<text class="txt muted" x="30" y="60">Scan: total {total}, failed {failed}, warnings {warnings} · Score {score}% (Grade {mx_escape(grade)}) · Prowler fail {total_prowler_fail} · Network targets {net_targets} (header issues {net_header_issues})</text>',
-        # Panels
-        '<rect class="card" x="20" y="90" width="520" height="290" rx="12"/>',
-        '<rect class="card" x="560" y="90" width="520" height="290" rx="12"/>',
-        '<rect class="card" x="20" y="400" width="1060" height="290" rx="12"/>',
-        f'<text class="txt h2" x="40" y="120">{_svg_escape("Architecture (artifacts & data)")}</text>',
-        f'<text class="txt h2" x="580" y="120">{_svg_escape("Service flow (who calls what)")}</text>',
-        f'<text class="txt h2" x="40" y="430">{_svg_escape("Network flow (DNS → TLS → HTTP)")}</text>',
-    ]
-
-    # Panel 1: Architecture
-    def box(x, y, bw, bh, cls, title, subtitle=""):
-        lines.append(f'<rect x="{x}" y="{y}" width="{bw}" height="{bh}" rx="10" class="{cls}"/>')
-        lines.append(f'<text class="txt" x="{x + bw/2}" y="{y + 22}" text-anchor="middle">{_svg_escape(title)}</text>')
-        if subtitle:
-            lines.append(f'<text class="txt muted mono" x="{x + bw/2}" y="{y + 42}" text-anchor="middle">{_svg_escape(subtitle)}</text>')
-
-    box(50, 150, 150, 60, "boxA", "Scanner", "claudesec (CLI)")
-    box(240, 150, 150, 60, "boxA", "Categories", "infra/ai/network/…")
-    box(430, 150, 90, 60, "boxB", "JSON", "scan-report.json")
-    box(50, 240, 180, 60, "boxB", "Prowler", f"fail:{total_prowler_fail}")
-    box(260, 240, 150, 60, "boxC", "Dashboard", "claudesec-dashboard.html")
-    box(430, 240, 90, 60, "boxC", "History", f"{agg.get('history_count', 0)} entries")
-    # arrows
-    lines.append('<line x1="200" y1="180" x2="240" y2="180" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
-    lines.append('<line x1="390" y1="180" x2="430" y2="180" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
-    lines.append('<line x1="295" y1="210" x2="295" y2="240" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
-
-    # Panel 2: Service flow
-    box(590, 150, 160, 60, "boxA", "Engineer / CI", "runs scan/dashboard")
-    box(780, 150, 160, 60, "boxA", "claudesec", "scan → aggregate")
-    box(970, 150, 90, 60, "boxB", "Outputs", "HTML/SVG")
-    lines.append('<line x1="750" y1="180" x2="780" y2="180" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
-    lines.append('<line x1="940" y1="180" x2="970" y2="180" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
-    lines.append('<text class="txt muted mono" x="590" y="245">Artifacts: docs/architecture/*.drawio + *.svg</text>')
-    lines.append('<text class="txt muted mono" x="590" y="265">Logs/findings: scan-report.json (+ .claudesec-history)</text>')
-
-    # Panel 3: Network flow (summary)
-    box(60, 470, 260, 70, "boxA", "DNS", "resolve host → IPs")
-    box(370, 470, 260, 70, "boxA", "TLS", "grade A/B/D/unknown")
-    box(680, 470, 380, 70, "boxA", "HTTP(S)", "headers, redirects, HSTS, CSP")
-    lines.append('<line x1="320" y1="505" x2="370" y2="505" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
-    lines.append('<line x1="630" y1="505" x2="680" y2="505" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
-    lines.append(f'<text class="txt muted mono" x="60" y="565">Source: .claudesec-network/network-report.v1.json (targets: {net_targets})</text>')
-    lines.append(f'<text class="txt muted mono" x="60" y="585">HTTP header issues (sum, top20 targets): {net_header_issues}</text>')
-
-    lines.append("</svg>")
-    Path(out_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
-    print(f"  {out_path}")
 
 
 def generate_scan_flow_diagram(agg, out_path):

--- a/scanner/lib/diagram_data.py
+++ b/scanner/lib/diagram_data.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+ClaudeSec diagram data layer — scan/Prowler/history loading and aggregation.
+
+Leaf module for the diagram generator: it loads scan-report.json, Prowler OCSF
+provider files, and scan history, then aggregates them into the label dict the
+draw.io / SVG builders consume. No draw.io/SVG concerns live here.
+
+`load_scan_results` is single-sourced from `dashboard_data_loader` (with
+try/except hardening) so the two implementations can't drift.
+"""
+import json
+import os
+import sys
+import glob
+from pathlib import Path
+
+# Sibling-module imports: ensure this file's dir (scanner/lib) is importable
+# whether imported by diagram-gen.py (which already inserts scanner/lib) or
+# loaded standalone (e.g. by pytest for coverage). Mirrors the pattern used by
+# diagram-gen.py and the dashboard_* modules.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from dashboard_data_loader import load_scan_results  # noqa: E402,F401
+
+# Scanner categories — order must mirror the `CLAUDESEC_ALL_CATEGORIES` array in
+# scanner/claudesec (the authoritative scan order). CATEGORIES[:8]/[:7] slices
+# feed diagram labels, so order matters. Kept honest by
+# scanner/tests/test_ci_diagram_gen_canonical_sync.py.
+CATEGORIES = [
+    "infra", "ai", "network", "cloud", "access-control",
+    "cicd", "code", "macos", "windows", "saas", "prowler",
+]
+
+
+def _parse_ocsf_json(content):
+    items = []
+    decoder = json.JSONDecoder()
+    idx = 0
+    while idx < len(content):
+        while idx < len(content) and content[idx] in " \t\n\r":
+            idx += 1
+        if idx >= len(content):
+            break
+        try:
+            obj, end = decoder.raw_decode(content, idx)
+            if isinstance(obj, list):
+                items.extend(o for o in obj if isinstance(o, dict))
+            elif isinstance(obj, dict):
+                items.append(obj)
+            idx = end
+        except json.JSONDecodeError:
+            idx += 1
+    return items
+
+
+def load_prowler_files(prowler_dir):
+    providers = {}
+    if not os.path.isdir(prowler_dir):
+        return providers
+    for fpath in sorted(glob.glob(os.path.join(prowler_dir, "prowler-*.ocsf.json"))):
+        name = Path(fpath).stem.replace(".ocsf", "").replace("prowler-", "")
+        try:
+            with open(fpath) as f:
+                content = f.read().strip()
+            items = _parse_ocsf_json(content)
+            providers[name] = items
+        except Exception:
+            providers[name] = []
+    return providers
+
+
+def load_scan_history(history_dir):
+    entries = []
+    if not os.path.isdir(history_dir):
+        return entries
+    for fpath in sorted(glob.glob(os.path.join(history_dir, "scan-*.json"))):
+        try:
+            with open(fpath) as f:
+                entries.append(json.load(f))
+        except Exception:
+            pass
+    return entries
+
+
+def aggregate_scan_data(scan_dir):
+    """Load and aggregate all scan-related data for diagram labels."""
+    base = Path(scan_dir or ".")
+    scan_json = base / "scan-report.json"
+    prowler_dir = base / ".claudesec-prowler"
+    history_dir = base / ".claudesec-history"
+
+    scan_data = load_scan_results(str(scan_json))
+    # Fallback: allow overriding scan JSON file.
+    if (not scan_data.get("total")) and os.environ.get("CLAUDESEC_SCAN_JSON"):
+        p = os.environ.get("CLAUDESEC_SCAN_JSON")
+        if os.path.isfile(p):
+            scan_data = load_scan_results(p)
+
+    # Fallback: build minimal scan_data from env vars (dashboard generation path).
+    # This keeps diagram generation functional even when scan-report.json is missing.
+    if not scan_data.get("total"):
+        try:
+            passed = int(os.environ.get("CLAUDESEC_PASSED", "0") or "0")
+            failed = int(os.environ.get("CLAUDESEC_FAILED", "0") or "0")
+            warnings = int(os.environ.get("CLAUDESEC_WARNINGS", "0") or "0")
+            skipped = int(os.environ.get("CLAUDESEC_SKIPPED", "0") or "0")
+            total = int(os.environ.get("CLAUDESEC_TOTAL", "0") or "0")
+            score = int(os.environ.get("CLAUDESEC_SCORE", "0") or "0")
+            grade = os.environ.get("CLAUDESEC_GRADE", "F") or "F"
+            duration = int(os.environ.get("CLAUDESEC_DURATION", "0") or "0")
+            findings = []
+            env_findings = os.environ.get("CLAUDESEC_FINDINGS_JSON", "") or ""
+            if env_findings.strip().startswith("["):
+                findings = json.loads(env_findings)
+            scan_data = {
+                "passed": passed,
+                "failed": failed,
+                "warnings": warnings,
+                "skipped": skipped,
+                "total": total,
+                "score": score,
+                "grade": grade,
+                "duration": duration,
+                "findings": findings if isinstance(findings, list) else [],
+            }
+        except Exception:
+            pass
+
+    providers = load_prowler_files(str(prowler_dir))
+    prov_summary = {}
+    for prov, items in providers.items():
+        fails = [i for i in items if i.get("status_code") == "FAIL"]
+        prov_summary[prov] = {"fail": len(fails), "total": len(items)}
+
+    history = load_scan_history(str(history_dir))
+    return {
+        "scan": scan_data,
+        "prowler_providers": list(providers.keys()),
+        "prowler_summary": prov_summary,
+        "history_count": len(history),
+    }

--- a/scanner/lib/diagram_svg.py
+++ b/scanner/lib/diagram_svg.py
@@ -1,0 +1,211 @@
+#!/usr/bin/env python3
+"""
+ClaudeSec diagram SVG builders — architecture and overview SVGs.
+
+Renders the same layouts as the draw.io diagrams as standalone SVG for viewing
+in a browser or embedding into claudesec-dashboard.html. Pure string builders:
+no draw.io/mxGraph XML, no untrusted parsing.
+"""
+import os
+import sys
+import json
+from pathlib import Path
+from collections import defaultdict
+
+# Sibling-module imports: ensure this file's dir (scanner/lib) is importable
+# whether imported by diagram-gen.py or loaded standalone (pytest coverage).
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from diagram_drawio import mx_escape  # noqa: E402
+from diagram_data import CATEGORIES  # noqa: E402
+
+
+def _svg_escape(s):
+    if s is None:
+        return ""
+    s = str(s).replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;")
+    return s
+
+
+def generate_architecture_svg(agg, out_path):
+    """Same layout as architecture drawio, as SVG for viewing in browser/docs."""
+    scan = agg.get("scan", {})
+    score = scan.get("score", 0)
+    grade = scan.get("grade", "F")
+    total = scan.get("total", 0)
+    failed = scan.get("failed", 0)
+    warnings = scan.get("warnings", 0)
+    findings = scan.get("findings", []) or []
+
+    # Summaries from scan findings JSON (best-effort).
+    sev_counts = defaultdict(int)
+    cat_counts = defaultdict(int)
+    for f in findings:
+        if not isinstance(f, dict):
+            continue
+        sev = (f.get("severity") or "").lower().strip()
+        cat = (f.get("category") or "").lower().strip()
+        if sev:
+            sev_counts[sev] += 1
+        if cat:
+            cat_counts[cat] += 1
+
+    prowler_list = agg.get("prowler_providers", [])
+    prowler_str = ", ".join(prowler_list[:5]) + ("..." if len(prowler_list) > 5 else "") if prowler_list else "no data"
+    hist = agg.get("history_count", 0)
+    prov_summary = agg.get("prowler_summary", {}) or {}
+    total_prowler_fail = sum(int(v.get("fail", 0) or 0) for v in prov_summary.values()) if isinstance(prov_summary, dict) else 0
+
+    # Top categories by count (for quick "what's noisy" signal).
+    top_cats = sorted(cat_counts.items(), key=lambda kv: (-kv[1], kv[0]))[:4]
+    top_cats_str = ", ".join(f"{k}:{v}" for k, v in top_cats) if top_cats else "none"
+
+    # Coordinates (match drawio layout)
+    boxes = [
+        (40, 80, 140, 50, "#dae8fc", "#6c8ebf", ["ClaudeSec Scanner", "(CLI)"]),
+        (260, 40, 160, 140, "#dae8fc", "#6c8ebf", ["Scan Categories"] + CATEGORIES[:7] + ["..."]),
+        (520, 50, 220, 64, "#fff2cc", "#d6b656", [
+            "Scan Results",
+            f"Total:{total} Failed:{failed} Warn:{warnings}",
+            f"Score:{score}% Grade:{grade}  Crit:{sev_counts.get('critical', 0)} High:{sev_counts.get('high', 0)}",
+        ]),
+        (520, 120, 140, 40, "#fff2cc", "#d6b656", ["scan-report.json", "(results)"]),
+        (520, 190, 200, 56, "#fff2cc", "#d6b656", ["Prowler OCSF", f"Fail:{total_prowler_fail} ({prowler_str})"]),
+        (720, 80, 120, 50, "#e1d5e7", "#9673a6", ["Dashboard", "(HTML)"]),
+        (720, 150, 160, 40, "#e1d5e7", "#9673a6", [f"History", f"({hist} entries)"]),
+        (40, 10, 840, 26, "#111827", "#111827", [f"Top categories: {top_cats_str}"]),
+    ]
+    w, h = 900, 270
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">',
+        '<defs><marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#374151"/></marker></defs>',
+        '<style>text { font-family: system-ui, sans-serif; font-size: 11px; fill: #333; } .title { font-weight: bold; } .banner { font-size: 11px; fill: #f9fafb; }</style>',
+    ]
+    # Arrows (under boxes): Scanner→Categories, Categories→Results, Results→Dashboard, Results→History
+    arrow_list = [(180, 105, 260, 105), (420, 110, 520, 75), (700, 75, 720, 105), (700, 100, 720, 170)]
+    for sx, sy, ex, ey in arrow_list:
+        lines.append(f'<line x1="{sx}" y1="{sy}" x2="{ex}" y2="{ey}" stroke="#374151" stroke-width="1.5" marker-end="url(#arrow)"/>')
+    # Boxes
+    for x, y, bw, bh, fill, stroke, labels in boxes:
+        lines.append(f'<rect x="{x}" y="{y}" width="{bw}" height="{bh}" rx="6" fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>')
+        for i, label in enumerate(labels):
+            ly = y + 16 + i * 14
+            if ly < y + bh - 4:
+                cls = "banner" if (fill == "#111827") else ("title" if i == 0 else "")
+                lines.append(f'<text x="{x + bw/2}" y="{ly}" text-anchor="middle" class="{cls}">{_svg_escape(label)}</text>')
+    lines.append("</svg>")
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))
+    print(f"  {out_path}")
+
+
+def generate_overview_svg(agg, scan_dir, out_path):
+    """One-screen overview SVG: Architecture + Service flow + Network flow.
+
+    This is optimized for embedding into claudesec-dashboard.html.
+    """
+    scan = agg.get("scan", {}) or {}
+    total = scan.get("total", 0)
+    failed = scan.get("failed", 0)
+    warnings = scan.get("warnings", 0)
+    score = scan.get("score", 0)
+    grade = scan.get("grade", "F")
+
+    prov_summary = agg.get("prowler_summary", {}) or {}
+    total_prowler_fail = (
+        sum(int(v.get("fail", 0) or 0) for v in prov_summary.values())
+        if isinstance(prov_summary, dict)
+        else 0
+    )
+
+    # Network report (best-effort)
+    net_dir = Path(scan_dir or ".") / ".claudesec-network"
+    net_report = net_dir / "network-report.v1.json"
+    net_targets = 0
+    net_header_issues = 0
+    if net_report.is_file():
+        try:
+            d = json.loads(net_report.read_text(encoding="utf-8"))
+            targets = d.get("targets") or []
+            if isinstance(targets, list):
+                net_targets = len(targets)
+                for t in targets[:20]:
+                    http = t.get("http") if isinstance(t, dict) else None
+                    issues = http.get("issues") if isinstance(http, dict) else []
+                    if isinstance(issues, list):
+                        net_header_issues += len(issues)
+        except Exception:
+            pass
+
+    w, h = 1100, 720
+    lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {w} {h}" width="{w}" height="{h}">',
+        "<defs>",
+        '<marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto"><path d="M0,0 L0,6 L9,3 z" fill="#334155"/></marker>',
+        "</defs>",
+        "<style>",
+        "  .bg{fill:#0b1220}",
+        "  .card{fill:#0f172a;stroke:#334155;stroke-width:1.5}",
+        "  .boxA{fill:#0b2a4a;stroke:#38bdf8;stroke-width:1.5}",
+        "  .boxB{fill:#3a2503;stroke:#eab308;stroke-width:1.5}",
+        "  .boxC{fill:#2b1b57;stroke:#a78bfa;stroke-width:1.5}",
+        "  .txt{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;font-size:12px;fill:#e5e7eb}",
+        "  .muted{fill:#94a3b8}",
+        "  .title{font-size:16px;font-weight:700}",
+        "  .h2{font-size:13px;font-weight:700;fill:#e2e8f0}",
+        "  .mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;font-size:11px}",
+        "</style>",
+        f'<rect class="bg" x="0" y="0" width="{w}" height="{h}"/>',
+        # Header
+        '<text class="txt title" x="30" y="38">ClaudeSec Overview Architecture</text>',
+        f'<text class="txt muted" x="30" y="60">Scan: total {total}, failed {failed}, warnings {warnings} · Score {score}% (Grade {mx_escape(grade)}) · Prowler fail {total_prowler_fail} · Network targets {net_targets} (header issues {net_header_issues})</text>',
+        # Panels
+        '<rect class="card" x="20" y="90" width="520" height="290" rx="12"/>',
+        '<rect class="card" x="560" y="90" width="520" height="290" rx="12"/>',
+        '<rect class="card" x="20" y="400" width="1060" height="290" rx="12"/>',
+        f'<text class="txt h2" x="40" y="120">{_svg_escape("Architecture (artifacts & data)")}</text>',
+        f'<text class="txt h2" x="580" y="120">{_svg_escape("Service flow (who calls what)")}</text>',
+        f'<text class="txt h2" x="40" y="430">{_svg_escape("Network flow (DNS → TLS → HTTP)")}</text>',
+    ]
+
+    # Panel 1: Architecture
+    def box(x, y, bw, bh, cls, title, subtitle=""):
+        lines.append(f'<rect x="{x}" y="{y}" width="{bw}" height="{bh}" rx="10" class="{cls}"/>')
+        lines.append(f'<text class="txt" x="{x + bw/2}" y="{y + 22}" text-anchor="middle">{_svg_escape(title)}</text>')
+        if subtitle:
+            lines.append(f'<text class="txt muted mono" x="{x + bw/2}" y="{y + 42}" text-anchor="middle">{_svg_escape(subtitle)}</text>')
+
+    box(50, 150, 150, 60, "boxA", "Scanner", "claudesec (CLI)")
+    box(240, 150, 150, 60, "boxA", "Categories", "infra/ai/network/…")
+    box(430, 150, 90, 60, "boxB", "JSON", "scan-report.json")
+    box(50, 240, 180, 60, "boxB", "Prowler", f"fail:{total_prowler_fail}")
+    box(260, 240, 150, 60, "boxC", "Dashboard", "claudesec-dashboard.html")
+    box(430, 240, 90, 60, "boxC", "History", f"{agg.get('history_count', 0)} entries")
+    # arrows
+    lines.append('<line x1="200" y1="180" x2="240" y2="180" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
+    lines.append('<line x1="390" y1="180" x2="430" y2="180" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
+    lines.append('<line x1="295" y1="210" x2="295" y2="240" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
+
+    # Panel 2: Service flow
+    box(590, 150, 160, 60, "boxA", "Engineer / CI", "runs scan/dashboard")
+    box(780, 150, 160, 60, "boxA", "claudesec", "scan → aggregate")
+    box(970, 150, 90, 60, "boxB", "Outputs", "HTML/SVG")
+    lines.append('<line x1="750" y1="180" x2="780" y2="180" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
+    lines.append('<line x1="940" y1="180" x2="970" y2="180" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
+    lines.append('<text class="txt muted mono" x="590" y="245">Artifacts: docs/architecture/*.drawio + *.svg</text>')
+    lines.append('<text class="txt muted mono" x="590" y="265">Logs/findings: scan-report.json (+ .claudesec-history)</text>')
+
+    # Panel 3: Network flow (summary)
+    box(60, 470, 260, 70, "boxA", "DNS", "resolve host → IPs")
+    box(370, 470, 260, 70, "boxA", "TLS", "grade A/B/D/unknown")
+    box(680, 470, 380, 70, "boxA", "HTTP(S)", "headers, redirects, HSTS, CSP")
+    lines.append('<line x1="320" y1="505" x2="370" y2="505" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
+    lines.append('<line x1="630" y1="505" x2="680" y2="505" stroke="#334155" stroke-width="2" marker-end="url(#arrow)"/>')
+    lines.append(f'<text class="txt muted mono" x="60" y="565">Source: .claudesec-network/network-report.v1.json (targets: {net_targets})</text>')
+    lines.append(f'<text class="txt muted mono" x="60" y="585">HTTP header issues (sum, top20 targets): {net_header_issues}</text>')
+
+    lines.append("</svg>")
+    Path(out_path).write_text("\n".join(lines) + "\n", encoding="utf-8")
+    print(f"  {out_path}")


### PR DESCRIPTION
## Summary

Priority-2 backlog item #2 (`docs/plans/refactoring-backlog.md`). A pure,
**behavior-preserving** move — no logic change — bringing `diagram-gen.py` back
under the 800-line coding-style soft max by extracting two cohesive leaf modules.

- **`diagram_data.py`** (new) — scan-data layer: `CATEGORIES` + `_parse_ocsf_json`
  / `load_prowler_files` / `load_scan_history` / `aggregate_scan_data`.
- **`diagram_svg.py`** (new) — SVG builders: `_svg_escape` /
  `generate_architecture_svg` / `generate_overview_svg`.
- Both re-exported into `diagram-gen.py` (mirrors the existing `diagram_drawio`
  re-export) so the importlib test harness resolves `MOD.<name>` unchanged.
- `generate_security_domains_diagram` + the two canonical imports **stay** in
  `diagram-gen.py` so `test_ci_diagram_gen_canonical_sync` (frameworks-derive +
  `ARCH_DOMAINS` same-object) keeps firing.
- Dropped now-unused `glob` / `defaultdict`; `hashlib` stays (network page).

`diagram-gen.py`: **838 → 545 lines**.

## Test plan

All run offline (`CLAUDESEC_DASHBOARD_OFFLINE=1`):

- [x] `pytest scanner/tests --cov=scanner/lib --cov-fail-under=99` → **99.12%**, 1477 passed.
- [x] 129 diagram + canonical-sync tests pass.
- [x] **Byte-equivalence**: all six generated `.drawio`/`.svg` files are
  SHA-256-identical to `origin/main` output on the same scan data.
- [x] `python3 -m py_compile` clean on all three files.
- [x] gitleaks clean.

> Note: 5 `test_scan_report_baseline` failures seen locally are a stale local
> `scan-report.json` (gitignored) in the old flat format — they fail identically
> with this change stashed, so they are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)