### PR TITLE
refactor(scanner): extract dashboard-serve logic to lib/dashboard_serve.sh

### DIFF
--- a/docs/plans/refactoring-backlog.md
+++ b/docs/plans/refactoring-backlog.md
@@ -62,8 +62,15 @@ Pure moves; the coverage gate is the safety net.
    (bash; kcov floor is the net).
 4. `checks.sh` — TODO: group the AWS / GCP / Azure / datadog credential helpers
    into cohesive sections (bash; preserve global scope + `source` order).
-5. `scanner/claudesec` — TODO, **last** (highest risk, integration-tested):
-   extract Datadog artifact collection and the dashboard-serve logic into `lib/`.
+5. `scanner/claudesec` — ✅ DONE (dashboard-serve extraction): moved the
+   dashboard HTTP-serve logic (`open_url_best_effort`, `serve_dashboard`)
+   verbatim into a new `scanner/lib/dashboard_serve.sh` (839→723 lines in the
+   entrypoint; ~140 lines in the new file). It is sourced after `output.sh`
+   (whose `error`/`warning`/color helpers it uses). Like `datadog.sh` it is
+   network-I/O code, so it is intentionally NOT added to the kcov
+   `--include-pattern` SUT set. The Datadog artifact collection half of this item
+   was already covered by `collect_datadog_dashboard_artifacts` in
+   `scanner/lib/datadog.sh` (#334); only the entrypoint calls it.
 
 **Guardrails for each step**: pure move, no logic change; assert `pytest 99%` /
 `kcov 90%` hold before and after; for sourced bash, keep every function at the

--- a/scanner/claudesec
+++ b/scanner/claudesec
@@ -39,6 +39,8 @@ source "$LIB_DIR/output.sh"
 source "$LIB_DIR/checks.sh"
 # shellcheck source=scanner/lib/datadog.sh
 source "$LIB_DIR/datadog.sh"
+# shellcheck source=scanner/lib/dashboard_serve.sh
+source "$LIB_DIR/dashboard_serve.sh"
 
 # Defaults
 FORMAT="text"
@@ -276,124 +278,6 @@ Examples:
   claudesec dashboard --serve             # Full scan + generate + serve on http://127.0.0.1:11777/
   claudesec dashboard --all               # Full scan + generate dashboard (no server)
 EOF
-}
-
-open_url_best_effort() {
-  local url="$1"
-  if command -v open >/dev/null 2>&1; then
-    open "$url" >/dev/null 2>&1 || true
-    return 0
-  fi
-  if command -v xdg-open >/dev/null 2>&1; then
-    xdg-open "$url" >/dev/null 2>&1 || true
-    return 0
-  fi
-  return 0
-}
-
-serve_dashboard() {
-  local html_path="$1"
-  local host="${2:-127.0.0.1}"
-  local port="${3:-11777}"
-  local abs_dir abs_file url direct_url
-
-  # Validate port is numeric (1-65535)
-  if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
-    error "Invalid port: $port (must be 1-65535)"
-    return 1
-  fi
-  # Validate host is a safe hostname/IP
-  if [[ ! "$host" =~ ^[a-zA-Z0-9._:-]+$ ]]; then
-    error "Invalid host: $host"
-    return 1
-  fi
-
-  if [[ ! -f "$html_path" ]]; then
-    error "Dashboard file not found: $html_path"
-    return 1
-  fi
-
-  abs_dir="$(cd "$(dirname "$html_path")" && pwd)"
-  abs_file="$(basename "$html_path")"
-  url="http://${host}:${port}/"
-  direct_url="http://${host}:${port}/${abs_file}"
-
-  # Fail fast if the port is already in use to avoid confusing "silent" hangs.
-  if command -v python3 >/dev/null 2>&1; then
-    if ! python3 - "$host" "$port" <<'PY' 2>/dev/null
-import socket
-import sys
-
-host = sys.argv[1]
-port = int(sys.argv[2])
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-try:
-    s.bind((host, port))
-except OSError:
-    sys.exit(1)
-finally:
-    s.close()
-sys.exit(0)
-PY
-    then
-      if python3 - "$direct_url" <<'PY' 2>/dev/null
-import sys
-import urllib.request
-
-u = sys.argv[1]
-req = urllib.request.Request(u, headers={"User-Agent": "claudesec/serve-check"})
-with urllib.request.urlopen(req, timeout=3) as res:
-    body = res.read(8192).decode("utf-8", errors="ignore").lower()
-    if res.status >= 400:
-        sys.exit(1)
-    if "claudesec" not in body and "dashboard" not in body:
-        sys.exit(1)
-sys.exit(0)
-PY
-      then
-        warning "Port ${host}:${port} is already in use; detected reachable dashboard. Reusing existing server."
-        echo -e "  ${DIM}Dashboard URL: ${BOLD}${direct_url}${NC}"
-        open_url_best_effort "$direct_url"
-        return 0
-      fi
-      error "Port ${host}:${port} is already in use. Choose another port with: claudesec dashboard --serve --port <port>"
-      return 1
-    fi
-  fi
-
-  # Ensure "/" renders the dashboard by writing an index.html redirect.
-  # This keeps the generated dashboard filename stable while making localhost root convenient.
-  cat > "${abs_dir}/index.html" <<EOF
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta http-equiv="refresh" content="0; url=./${abs_file}" />
-    <meta name="referrer" content="no-referrer" />
-    <title>ClaudeSec Dashboard</title>
-  </head>
-  <body style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
-    <p>Redirecting to <a href="./${abs_file}">${abs_file}</a>…</p>
-  </body>
-</html>
-EOF
-
-  echo -e "  ${DIM}Serving dashboard on: ${BOLD}${url}${NC}"
-  echo -e "  ${DIM}Press Ctrl+C to stop.${NC}"
-  open_url_best_effort "$url"
-
-  if command -v python3 >/dev/null 2>&1; then
-    (cd "$abs_dir" && python3 -m http.server "$port" --bind "$host")
-    return $?
-  fi
-  if command -v python >/dev/null 2>&1; then
-    (cd "$abs_dir" && python -m http.server "$port" --bind "$host")
-    return $?
-  fi
-
-  error "python3 not found — cannot serve dashboard. Open it directly: file://$abs_dir/$abs_file"
-  return 1
 }
 
 parse_args() {

--- a/scanner/lib/dashboard_serve.sh
+++ b/scanner/lib/dashboard_serve.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# ============================================================================
+# ClaudeSec — dashboard serve helper library
+# ============================================================================
+#
+# Holds the local dashboard HTTP-serve logic (open-in-browser + `python3 -m
+# http.server`), extracted from the `scanner/claudesec` entrypoint to keep it
+# focused. This module depends on the output helpers in output.sh (`error`,
+# `warning`) and the color variables (`DIM`, `BOLD`, `NC`) being sourced into
+# the same shell BEFORE serve_dashboard is invoked.
+#
+# Like datadog.sh, this is network-I/O code (binds a socket / spawns an HTTP
+# server) and is therefore intentionally NOT part of the kcov --include-pattern
+# SUT set — see the "kcov SUT allowlist" note and test_ci_scanner_lib_reachability.py.
+#
+# No `set -euo pipefail` here — this is a sourced lib, mirroring the other libs
+# which have no `set` line after the shebang.
+
+# ── Dashboard serve ──────────────────────────────────────────────────────────
+
+open_url_best_effort() {
+  local url="$1"
+  if command -v open >/dev/null 2>&1; then
+    open "$url" >/dev/null 2>&1 || true
+    return 0
+  fi
+  if command -v xdg-open >/dev/null 2>&1; then
+    xdg-open "$url" >/dev/null 2>&1 || true
+    return 0
+  fi
+  return 0
+}
+
+serve_dashboard() {
+  local html_path="$1"
+  local host="${2:-127.0.0.1}"
+  local port="${3:-11777}"
+  local abs_dir abs_file url direct_url
+
+  # Validate port is numeric (1-65535)
+  if [[ ! "$port" =~ ^[0-9]+$ ]] || (( port < 1 || port > 65535 )); then
+    error "Invalid port: $port (must be 1-65535)"
+    return 1
+  fi
+  # Validate host is a safe hostname/IP
+  if [[ ! "$host" =~ ^[a-zA-Z0-9._:-]+$ ]]; then
+    error "Invalid host: $host"
+    return 1
+  fi
+
+  if [[ ! -f "$html_path" ]]; then
+    error "Dashboard file not found: $html_path"
+    return 1
+  fi
+
+  abs_dir="$(cd "$(dirname "$html_path")" && pwd)"
+  abs_file="$(basename "$html_path")"
+  url="http://${host}:${port}/"
+  direct_url="http://${host}:${port}/${abs_file}"
+
+  # Fail fast if the port is already in use to avoid confusing "silent" hangs.
+  if command -v python3 >/dev/null 2>&1; then
+    if ! python3 - "$host" "$port" <<'PY' 2>/dev/null
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+try:
+    s.bind((host, port))
+except OSError:
+    sys.exit(1)
+finally:
+    s.close()
+sys.exit(0)
+PY
+    then
+      if python3 - "$direct_url" <<'PY' 2>/dev/null
+import sys
+import urllib.request
+
+u = sys.argv[1]
+req = urllib.request.Request(u, headers={"User-Agent": "claudesec/serve-check"})
+with urllib.request.urlopen(req, timeout=3) as res:
+    body = res.read(8192).decode("utf-8", errors="ignore").lower()
+    if res.status >= 400:
+        sys.exit(1)
+    if "claudesec" not in body and "dashboard" not in body:
+        sys.exit(1)
+sys.exit(0)
+PY
+      then
+        warning "Port ${host}:${port} is already in use; detected reachable dashboard. Reusing existing server."
+        echo -e "  ${DIM}Dashboard URL: ${BOLD}${direct_url}${NC}"
+        open_url_best_effort "$direct_url"
+        return 0
+      fi
+      error "Port ${host}:${port} is already in use. Choose another port with: claudesec dashboard --serve --port <port>"
+      return 1
+    fi
+  fi
+
+  # Ensure "/" renders the dashboard by writing an index.html redirect.
+  # This keeps the generated dashboard filename stable while making localhost root convenient.
+  cat > "${abs_dir}/index.html" <<EOF
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="refresh" content="0; url=./${abs_file}" />
+    <meta name="referrer" content="no-referrer" />
+    <title>ClaudeSec Dashboard</title>
+  </head>
+  <body style="font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;">
+    <p>Redirecting to <a href="./${abs_file}">${abs_file}</a>…</p>
+  </body>
+</html>
+EOF
+
+  echo -e "  ${DIM}Serving dashboard on: ${BOLD}${url}${NC}"
+  echo -e "  ${DIM}Press Ctrl+C to stop.${NC}"
+  open_url_best_effort "$url"
+
+  if command -v python3 >/dev/null 2>&1; then
+    (cd "$abs_dir" && python3 -m http.server "$port" --bind "$host")
+    return $?
+  fi
+  if command -v python >/dev/null 2>&1; then
+    (cd "$abs_dir" && python -m http.server "$port" --bind "$host")
+    return $?
+  fi
+
+  error "python3 not found — cannot serve dashboard. Open it directly: file://$abs_dir/$abs_file"
+  return 1
+}


### PR DESCRIPTION
## Summary

Completes **backlog item 5** (`docs/plans/refactoring-backlog.md`): moves the local dashboard HTTP-serve helpers (`open_url_best_effort`, `serve_dashboard`) **verbatim** out of the 839-line `scanner/claudesec` entrypoint into a new `scanner/lib/dashboard_serve.sh`.

The entrypoint sources it right after `output.sh`, whose `error`/`warning`/color helpers the serve logic depends on.

> The **"Datadog artifact collection"** half of item 5 was already satisfied — `collect_datadog_dashboard_artifacts` has lived in `scanner/lib/datadog.sh` since #334; the entrypoint only calls it. Item 5 is updated to DONE accordingly.

## Why not kcov-measured

Like `datadog.sh`, `dashboard_serve.sh` is **network-I/O code** (binds a socket, spawns `python3 -m http.server`). Per the kcov SUT allowlist it is intentionally **NOT** added to the kcov `--include-pattern` set nor to the reachability guard's `SUT_FILES` — so no changes to `lint.yml`, `verify-shell-coverage-docker.sh`, or the CI guards were needed.

## Changes

- **`scanner/lib/dashboard_serve.sh`** — new, ~140 lines (pure move; the moved function block is **byte-identical** — md5 verified against the removed entrypoint region)
- **`scanner/claudesec`** — 839 → 723 lines; sources `lib/dashboard_serve.sh`
- **`docs/plans/refactoring-backlog.md`** — item 5 → ✅ DONE

## Test plan

- [x] `shellcheck -x` clean on `dashboard_serve.sh` + `scanner/claudesec`; `bash -n` clean
- [x] `serve_dashboard` + validation branches (invalid port/host, missing file) load and return correctly via the entrypoint source chain
- [x] **Real end-to-end HTTP serve test**: `/` → `200` via written `index.html` redirect, direct dashboard file served, clean shutdown
- [x] `claudesec scan -c infra` exits 0, no missing-function errors
- [x] 297 CI guard tests pass (no guard changes required)
- [x] 48/48 non-tty shell tests pass; markdownlint clean
- [x] Docker kcov bash coverage floor: **91.32% ≥ 90.0%** (4-file SUT set unchanged — serve logic is unmeasured net-I/O)

🤖 Generated with [Claude Code](https://claude.com/claude-code)