### PR TITLE
refactor(scanner): extract prowler compliance-summary to output_prowler.sh

### DIFF
--- a/docs/plans/refactoring-backlog.md
+++ b/docs/plans/refactoring-backlog.md
@@ -58,8 +58,14 @@ Pure moves; the coverage gate is the safety net.
    so the `test_ci_diagram_gen_canonical_sync` frameworks-derive guard still fires.
    Verified: pytest 99.12% floor holds, 129 diagram tests pass, and all six
    generated `.drawio`/`.svg` files are **byte-identical** (SHA-256) before/after.
-3. `output.sh` — TODO: extract the prowler-summary block into a focused unit
-   (bash; kcov floor is the net).
+3. `output.sh` — ✅ DONE (prowler compliance-summary extraction): moved the
+   OCSF detection loop + embedded `python3` compliance parser out of
+   `save_scan_history` into `_prowler_compliance_summary_json` in the sibling
+   `scanner/lib/output_prowler.sh` (the existing home for prowler output logic).
+   `save_scan_history` now just calls it and keeps the `comp_field` assignment.
+   The python body is **byte-identical** (md5 verified); `${BASH_SOURCE[0]}` still
+   resolves `compliance-map.py` from `scanner/lib/`. The prowler dashboard-summary
+   HTML table (`_prowler_dashboard_summary`) was already split out earlier.
 4. `checks.sh` — ✅ DONE (kubectl extraction): moved the 11 kubectl/kubeconfig
    discovery and cluster-access helpers (`_kubectl_cmd`, `has_kubectl_access`,
    `kubectl_list_contexts`, `kubectl_current_context`,

--- a/docs/plans/refactoring-backlog.md
+++ b/docs/plans/refactoring-backlog.md
@@ -41,8 +41,9 @@ shared prefix into `_saas_curl() { run_with_timeout 15 curl -sSf "$@"; }`; each
 call keeps its exact headers/flags. Proven byte-identical via an arg-capture
 equivalence harness.
 
-## Priority 2 — Large-file decomposition — 🔄 IN PROGRESS
+## Priority 2 — Large-file decomposition — ✅ DONE
 
+All five items shipped as their own PRs (#325, #339/#340, #343, #341, #342).
 Incremental, **one file per PR**, safest-first (thickest test coverage first).
 Pure moves; the coverage gate is the safety net.
 

--- a/scanner/lib/output.sh
+++ b/scanner/lib/output.sh
@@ -408,39 +408,11 @@ save_scan_history() {
   local n_low=${#FINDINGS_LOW[@]}
   local n_warn=${#FINDINGS_WARN[@]}
 
-  # Build compliance summary from prowler OCSF results if available
-  local compliance_json=""
-  local prowler_dir="${SCAN_DIR:-.}/.claudesec-prowler"
-  local _has_ocsf=0
-  if [[ -d "$prowler_dir" ]]; then
-    for _f in "$prowler_dir"/prowler-*.ocsf.json; do
-      [[ -f "$_f" ]] && _has_ocsf=1 && break
-    done
-  fi
-  if [[ "$_has_ocsf" == "1" ]] && command -v python3 &>/dev/null; then
-    compliance_json=$(timeout 10 python3 -c "
-import json, glob, os, importlib.util
-pdir = '$prowler_dir'
-findings = []
-for fp in glob.glob(os.path.join(pdir, 'prowler-*.ocsf.json')):
-    try:
-        with open(fp, encoding='utf-8') as f:
-            raw = f.read().strip()
-        data = json.loads(raw) if raw.startswith('[') else [json.loads(l) for l in raw.splitlines() if l.strip()]
-        for item in data:
-            if item.get('status_code') != 'FAIL': continue
-            findings.append({'check': item.get('metadata',{}).get('event_code',''),
-                'title': item.get('finding_info',{}).get('title',''),
-                'message': item.get('message',''),
-                'compliance': item.get('unmapped',{}).get('compliance',{})})
-    except Exception: pass
-if not findings: exit(0)
-spec = importlib.util.spec_from_file_location('cm', '$(dirname "${BASH_SOURCE[0]}")/compliance-map.py')
-cm = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(cm)
-print(json.dumps(cm.compliance_summary(cm.map_compliance(findings)), separators=(',', ':')))
-" 2>/dev/null) || compliance_json=""
-  fi
+  # Build compliance summary from prowler OCSF results if available.
+  # Extracted into _prowler_compliance_summary_json (output_prowler.sh, sourced
+  # below); called at runtime so the later source order is fine.
+  local compliance_json
+  compliance_json=$(_prowler_compliance_summary_json)
 
   local comp_field=""
   if [[ -n "$compliance_json" && "$compliance_json" != "{}" ]]; then

--- a/scanner/lib/output_prowler.sh
+++ b/scanner/lib/output_prowler.sh
@@ -66,3 +66,42 @@ _prowler_dashboard_summary() {
   echo "  <p style=\"margin-top:0.75rem;font-size:0.78rem;color:var(--muted)\">원본 리포트 파일: <code>.claudesec-prowler/prowler-*.ocsf.json</code> (JSON-OCSF). 최신 상태로 갱신하려면 <code>claudesec scan -c prowler</code> 또는 <code>claudesec dashboard -c prowler</code>를 다시 실행하세요.</p>"
   echo "  </div></div>"
 }
+
+# Build a compact compliance-summary JSON from .claudesec-prowler/*.ocsf.json
+# (embedded into the scan-history entry by save_scan_history in output.sh).
+# Echoes the JSON object on success, or nothing when there are no OCSF artifacts,
+# no FAIL findings, or python3 is unavailable. compliance-map.py resolves relative
+# to this file's directory (same scanner/lib/ dir as when this lived in output.sh).
+_prowler_compliance_summary_json() {
+  local prowler_dir="${SCAN_DIR:-.}/.claudesec-prowler"
+  local _has_ocsf=0 _f
+  if [[ -d "$prowler_dir" ]]; then
+    for _f in "$prowler_dir"/prowler-*.ocsf.json; do
+      [[ -f "$_f" ]] && _has_ocsf=1 && break
+    done
+  fi
+  [[ "$_has_ocsf" == "1" ]] || return 0
+  command -v python3 &>/dev/null || return 0
+  timeout 10 python3 -c "
+import json, glob, os, importlib.util
+pdir = '$prowler_dir'
+findings = []
+for fp in glob.glob(os.path.join(pdir, 'prowler-*.ocsf.json')):
+    try:
+        with open(fp, encoding='utf-8') as f:
+            raw = f.read().strip()
+        data = json.loads(raw) if raw.startswith('[') else [json.loads(l) for l in raw.splitlines() if l.strip()]
+        for item in data:
+            if item.get('status_code') != 'FAIL': continue
+            findings.append({'check': item.get('metadata',{}).get('event_code',''),
+                'title': item.get('finding_info',{}).get('title',''),
+                'message': item.get('message',''),
+                'compliance': item.get('unmapped',{}).get('compliance',{})})
+    except Exception: pass
+if not findings: exit(0)
+spec = importlib.util.spec_from_file_location('cm', '$(dirname "${BASH_SOURCE[0]}")/compliance-map.py')
+cm = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cm)
+print(json.dumps(cm.compliance_summary(cm.map_compliance(findings)), separators=(',', ':')))
+" 2>/dev/null || true
+}

--- a/scanner/tests/test_save_scan_history_ocsf.sh
+++ b/scanner/tests/test_save_scan_history_ocsf.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 # Unit tests for scanner/lib/output.sh: save_scan_history prowler OCSF
-# compliance python block (L414-445). Exercises:
-#   L414-416  prowler-*.ocsf.json detection loop
-#   L418-440  embedded python3 OCSF parser + compliance-map invocation
-#   L443-445  comp_field assignment when compliance_json is non-empty
+# compliance summary. The OCSF detection loop + embedded python3 parser +
+# compliance-map invocation now live in _prowler_compliance_summary_json
+# (scanner/lib/output_prowler.sh); save_scan_history calls it and assigns
+# comp_field when the returned compliance_json is non-empty. Exercised here
+# end-to-end through save_scan_history.
 #
 # Run: bash scanner/tests/test_save_scan_history_ocsf.sh
 set -uo pipefail


### PR DESCRIPTION
## Summary

Completes the **last open Priority-2 item (backlog #3)**: moves the prowler OCSF compliance-summary block out of `save_scan_history` (`output.sh`) into a focused `_prowler_compliance_summary_json()` in the sibling `scanner/lib/output_prowler.sh` — the existing home for prowler output logic (`_prowler_dashboard_summary`, provider-label map).

`save_scan_history` now just calls it and keeps the `comp_field` assignment.

## Behavior-preserving

- The embedded `python3` OCSF parser body is moved **verbatim** — md5-verified byte-identical (`c7f49382…`).
- `compliance-map.py` still resolves via `$(dirname "${BASH_SOURCE[0]}")`; both files live in `scanner/lib/`, so the path is unchanged.
- `output_prowler.sh` is sourced near the end of `output.sh`, but the call happens at scan time, so source order is fine (same pattern as the pre-existing `_prowler_dashboard_summary`).
- The function returns the compliance JSON on stdout (empty when there are no OCSF artifacts / no FAIL findings / `python3` absent) — exactly as the inline block produced. Confirmed by running **pre-change** `output.sh` against the same fixtures: identical output.

## Changes

- **`scanner/lib/output.sh`** — −34 lines (`save_scan_history` block → one call); file kcov **90.27% → 96.15%**
- **`scanner/lib/output_prowler.sh`** — `+ _prowler_compliance_summary_json` (verbatim python body)
- **`scanner/tests/test_save_scan_history_ocsf.sh`** — refresh stale header comment (block moved)
- **`docs/plans/refactoring-backlog.md`** — item 3 → ✅ DONE

## Test plan

- [x] `shellcheck -S error` clean; `bash -n` clean
- [x] python body **byte-identical** (md5 match against the removed block)
- [x] `test_save_scan_history_ocsf.sh` (exercises the compliance path with an ISO-27001-mapping OCSF fixture) passes on the refactored code
- [x] output / prowler suites pass; 297 CI guard tests pass (reachability guard sees the new SUT function referenced from `output.sh`)
- [x] Docker kcov bash coverage **MERGED 91.35% ≥ 90.0%** (held: 91.33% before; coverage moved output.sh↑ / output_prowler.sh as the block relocated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)