### PR TITLE
refactor(scanner): extract prowler compliance-summary python to lib module

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -233,7 +233,7 @@ jobs:
           PYTHONPATH: .
           CLAUDESEC_DASHBOARD_OFFLINE: "1"
         run: |
-          python3 -m py_compile scanner/lib/dashboard-gen.py scanner/lib/compliance-map.py scanner/tests/test_dashboard_gen_smoke.py scanner/tests/test_markdown_preview.py scanner/tests/test_prowler_ocsf.py scanner/tests/test_prowler_ocsf_e2e.py scanner/tests/test_compliance_map.py
+          python3 -m py_compile scanner/lib/dashboard-gen.py scanner/lib/compliance-map.py scanner/lib/prowler_compliance_summary.py scanner/tests/test_dashboard_gen_smoke.py scanner/tests/test_markdown_preview.py scanner/tests/test_prowler_ocsf.py scanner/tests/test_prowler_ocsf_e2e.py scanner/tests/test_compliance_map.py scanner/tests/test_prowler_compliance_summary.py
           mkdir -p test-reports
           set +e
           python3 -m pytest scanner/tests/ \

--- a/scanner/lib/output_prowler.sh
+++ b/scanner/lib/output_prowler.sh
@@ -70,8 +70,10 @@ _prowler_dashboard_summary() {
 # Build a compact compliance-summary JSON from .claudesec-prowler/*.ocsf.json
 # (embedded into the scan-history entry by save_scan_history in output.sh).
 # Echoes the JSON object on success, or nothing when there are no OCSF artifacts,
-# no FAIL findings, or python3 is unavailable. compliance-map.py resolves relative
-# to this file's directory (same scanner/lib/ dir as when this lived in output.sh).
+# no FAIL findings, or python3 is unavailable. The parsing + compliance-mapping
+# logic lives in prowler_compliance_summary.py, a sibling module resolved
+# relative to this file's directory (same scanner/lib/ dir as when this lived
+# inline in output.sh); it in turn loads compliance-map.py the same way.
 _prowler_compliance_summary_json() {
   local prowler_dir="${SCAN_DIR:-.}/.claudesec-prowler"
   local _has_ocsf=0 _f
@@ -82,26 +84,5 @@ _prowler_compliance_summary_json() {
   fi
   [[ "$_has_ocsf" == "1" ]] || return 0
   command -v python3 &>/dev/null || return 0
-  timeout 10 python3 -c "
-import json, glob, os, importlib.util
-pdir = '$prowler_dir'
-findings = []
-for fp in glob.glob(os.path.join(pdir, 'prowler-*.ocsf.json')):
-    try:
-        with open(fp, encoding='utf-8') as f:
-            raw = f.read().strip()
-        data = json.loads(raw) if raw.startswith('[') else [json.loads(l) for l in raw.splitlines() if l.strip()]
-        for item in data:
-            if item.get('status_code') != 'FAIL': continue
-            findings.append({'check': item.get('metadata',{}).get('event_code',''),
-                'title': item.get('finding_info',{}).get('title',''),
-                'message': item.get('message',''),
-                'compliance': item.get('unmapped',{}).get('compliance',{})})
-    except Exception: pass
-if not findings: exit(0)
-spec = importlib.util.spec_from_file_location('cm', '$(dirname "${BASH_SOURCE[0]}")/compliance-map.py')
-cm = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(cm)
-print(json.dumps(cm.compliance_summary(cm.map_compliance(findings)), separators=(',', ':')))
-" 2>/dev/null || true
+  timeout 10 python3 "$(dirname "${BASH_SOURCE[0]}")/prowler_compliance_summary.py" "$prowler_dir" 2>/dev/null || true
 }

--- a/scanner/lib/prowler_compliance_summary.py
+++ b/scanner/lib/prowler_compliance_summary.py
@@ -1,0 +1,111 @@
+"""
+ClaudeSec — Prowler OCSF compliance-summary builder.
+
+Extracted from the inline ``python3 -c "..."`` heredoc previously embedded in
+``output_prowler.sh``'s ``_prowler_compliance_summary_json`` (see
+scanner/lib/output_prowler.sh). The extraction exists purely for coverage
+measurability: kcov instruments bash heredoc string content as if it were
+executable bash, which it never is, so ~21 lines of unreachable "coverage"
+polluted output_prowler.sh's kcov numbers. As a standalone module, real
+coverage is enforced by pytest instead
+(scanner/tests/test_prowler_compliance_summary.py).
+
+Behavior is unchanged from the original heredoc: read every
+``prowler-*.ocsf.json`` file in a directory, collect FAIL findings, and
+return a compact JSON compliance summary via compliance-map.py (NIST SP
+800-53 Rev5 / ISO 27001:2022 / KISA ISMS-P mappings — see
+compliance-map.py). Malformed or unreadable files are tolerated per-file so
+one bad Prowler output does not blank the whole summary (fail-safe defaults,
+aligned with OWASP ASVS V1.1 / NIST SP 800-218 SSDF PW.7).
+"""
+
+import glob
+import importlib.util
+import json
+import os
+import sys
+
+
+def _load_compliance_map():
+    """Load the sibling compliance-map.py module.
+
+    The filename has a hyphen, so a normal ``import`` statement cannot
+    reference it; resolve it relative to this file's directory instead
+    (same scanner/lib/ dir the module previously lived in as part of
+    output.sh).
+    """
+    module_dir = os.path.dirname(os.path.abspath(__file__))
+    spec = importlib.util.spec_from_file_location(
+        "compliance_map", os.path.join(module_dir, "compliance-map.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _read_findings(prowler_dir):
+    """Collect FAIL findings from every prowler-*.ocsf.json file in prowler_dir.
+
+    Each OCSF file may be a JSON array or newline-delimited JSON (NDJSON).
+    A malformed or unreadable file is skipped rather than aborting the whole
+    scan — one bad Prowler artifact should not blank the compliance summary.
+    """
+    findings = []
+    for file_path in glob.glob(os.path.join(prowler_dir, "prowler-*.ocsf.json")):
+        try:
+            with open(file_path, encoding="utf-8") as fh:
+                raw = fh.read().strip()
+            data = (
+                json.loads(raw)
+                if raw.startswith("[")
+                else [json.loads(line) for line in raw.splitlines() if line.strip()]
+            )
+            for item in data:
+                if item.get("status_code") != "FAIL":
+                    continue
+                findings.append(
+                    {
+                        "check": item.get("metadata", {}).get("event_code", ""),
+                        "title": item.get("finding_info", {}).get("title", ""),
+                        "message": item.get("message", ""),
+                        "compliance": item.get("unmapped", {}).get("compliance", {}),
+                    }
+                )
+        except Exception:
+            pass
+    return findings
+
+
+def build_summary(prowler_dir):
+    """Return a compact JSON compliance-summary string for prowler_dir.
+
+    Returns "" when there are no FAIL findings — no OCSF artifacts, only
+    PASS findings, or every file was malformed.
+    """
+    findings = _read_findings(prowler_dir)
+    if not findings:
+        return ""
+    compliance_map = _load_compliance_map()
+    summary = compliance_map.compliance_summary(compliance_map.map_compliance(findings))
+    return json.dumps(summary, separators=(",", ":"))
+
+
+def main(argv=None):
+    """CLI entry point: build_summary(argv[0]) and print it if non-empty.
+
+    Called by output_prowler.sh's _prowler_compliance_summary_json as
+    ``python3 prowler_compliance_summary.py <prowler_dir>``. Missing argv is
+    handled gracefully (returns 0, prints nothing) so the calling bash
+    (already wrapped in ``timeout ... || true``) never breaks.
+    """
+    args = argv if argv is not None else sys.argv[1:]
+    if not args:
+        return 0
+    result = build_summary(args[0])
+    if result:
+        print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scanner/tests/test_prowler_compliance_summary.py
+++ b/scanner/tests/test_prowler_compliance_summary.py
@@ -1,0 +1,188 @@
+"""
+Unit tests for scanner/lib/prowler_compliance_summary.py.
+
+This module was extracted from the inline `python3 -c "..."` heredoc that
+used to live in scanner/lib/output_prowler.sh's
+_prowler_compliance_summary_json (see that file's function comment). These
+tests exercise every branch in-process so coverage.py actually measures it —
+the bash subprocess invocation (`python3 prowler_compliance_summary.py
+<dir>`) is invisible to `--cov=scanner/lib`.
+
+Run: python3 -m pytest scanner/tests/test_prowler_compliance_summary.py -q
+"""
+
+import importlib.util
+import json
+import os
+import runpy
+import sys
+
+import pytest
+
+LIB_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "lib")
+sys.path.insert(0, os.path.abspath(LIB_DIR))
+
+import prowler_compliance_summary as pcs  # noqa: E402
+
+
+FAIL_ARRAY = """[
+  {
+    "status_code": "FAIL",
+    "message": "S3 bucket public read access detected",
+    "metadata": {"event_code": "s3_bucket_public_access"},
+    "finding_info": {"title": "S3 Bucket Public Access"},
+    "unmapped": {"compliance": {"iso27001_2022": ["A.5.1"]}}
+  },
+  {
+    "status_code": "PASS",
+    "message": "MFA enabled for root account",
+    "metadata": {"event_code": "iam_root_mfa_enabled"},
+    "finding_info": {"title": "Root Account MFA"},
+    "unmapped": {"compliance": {"iso27001_2022": ["A.8.2"]}}
+  }
+]
+"""
+
+PASS_ONLY_ARRAY = """[
+  {
+    "status_code": "PASS",
+    "message": "OK",
+    "metadata": {"event_code": "everything_fine"},
+    "finding_info": {"title": "All good"},
+    "unmapped": {"compliance": {}}
+  }
+]
+"""
+
+FAIL_NDJSON = (
+    '{"status_code":"FAIL","message":"IAM weak policy",'
+    '"metadata":{"event_code":"iam_weak_pwd"},'
+    '"finding_info":{"title":"Weak IAM policy"},'
+    '"unmapped":{"compliance":{"iso27001_2022":["A.8.5"]}}}\n'
+    '{"status_code":"FAIL","message":"Encryption disabled",'
+    '"metadata":{"event_code":"rds_encryption_off"},'
+    '"finding_info":{"title":"RDS Encryption"},'
+    '"unmapped":{"compliance":{"iso27001_2022":["A.8.5"]}}}\n'
+)
+
+MALFORMED = "not-json{{{\n"
+
+
+def _write(tmp_path, name, content):
+    path = tmp_path / name
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_build_summary_json_array_fail_findings(tmp_path):
+    _write(tmp_path, "prowler-aws.ocsf.json", FAIL_ARRAY)
+
+    result = pcs.build_summary(str(tmp_path))
+
+    assert result != ""
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict)
+    assert len(parsed) > 0
+    assert any(
+        isinstance(v, dict) and {"pass", "fail", "na", "total"} <= v.keys()
+        for v in parsed.values()
+    )
+
+
+def test_build_summary_ndjson_fail_findings(tmp_path):
+    _write(tmp_path, "prowler-ndjson.ocsf.json", FAIL_NDJSON)
+
+    result = pcs.build_summary(str(tmp_path))
+
+    assert result != ""
+    parsed = json.loads(result)
+    assert len(parsed) > 0
+
+
+def test_build_summary_pass_only_returns_empty(tmp_path):
+    _write(tmp_path, "prowler-pass-only.ocsf.json", PASS_ONLY_ARRAY)
+
+    assert pcs.build_summary(str(tmp_path)) == ""
+
+
+def test_build_summary_malformed_json_tolerated(tmp_path):
+    _write(tmp_path, "prowler-bad.ocsf.json", MALFORMED)
+
+    assert pcs.build_summary(str(tmp_path)) == ""
+
+
+def test_build_summary_empty_dir_returns_empty(tmp_path):
+    assert pcs.build_summary(str(tmp_path)) == ""
+
+
+def test_build_summary_mixed_malformed_and_valid(tmp_path):
+    _write(tmp_path, "prowler-bad.ocsf.json", MALFORMED)
+    _write(tmp_path, "prowler-aws.ocsf.json", FAIL_ARRAY)
+
+    result = pcs.build_summary(str(tmp_path))
+
+    assert result != ""
+    parsed = json.loads(result)
+    assert len(parsed) > 0
+
+
+def test_load_compliance_map_exposes_public_api():
+    module = pcs._load_compliance_map()
+
+    assert hasattr(module, "map_compliance")
+    assert hasattr(module, "compliance_summary")
+
+
+def test_main_with_argv_prints_json_and_returns_zero(tmp_path, capsys):
+    _write(tmp_path, "prowler-aws.ocsf.json", FAIL_ARRAY)
+
+    rc = pcs.main([str(tmp_path)])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out.strip() != ""
+    json.loads(captured.out.strip())
+
+
+def test_main_with_pass_only_dir_prints_nothing(tmp_path, capsys):
+    _write(tmp_path, "prowler-pass-only.ocsf.json", PASS_ONLY_ARRAY)
+
+    rc = pcs.main([str(tmp_path)])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_main_with_empty_argv_returns_zero_prints_nothing(capsys):
+    rc = pcs.main([])
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_main_with_none_argv_uses_sys_argv(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(sys, "argv", ["prowler_compliance_summary.py"])
+
+    rc = pcs.main(None)
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_module_main_guard_runs_via_runpy(monkeypatch, capsys):
+    """Exercise the `if __name__ == "__main__": sys.exit(main())` guard,
+    which normal `import` never executes."""
+    module_path = os.path.join(LIB_DIR, "prowler_compliance_summary.py")
+    monkeypatch.setattr(sys, "argv", ["prowler_compliance_summary.py"])
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(module_path, run_name="__main__")
+
+    assert exc_info.value.code == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Extracts the inline `python3 -c "<heredoc>"` block out of `_prowler_compliance_summary_json` in `scanner/lib/output_prowler.sh` into a standalone importable module `scanner/lib/prowler_compliance_summary.py`, invoked from bash via a file path.

**Why:** the heredoc's ~20 string-literal lines were counted by kcov as bash-instrumentable lines that can *never* execute as bash, structurally capping `output_prowler.sh` coverage at ~65.79%. Extraction removes those uncoverable lines from the bash file and makes the logic measurable by pytest instead.

## Changes

- `scanner/lib/output_prowler.sh` — replace the heredoc with `timeout 10 python3 "$(dirname "${BASH_SOURCE[0]}")/prowler_compliance_summary.py" "$prowler_dir"`. All bash guards (dir check, `_has_ocsf` loop, `command -v python3`, `2>/dev/null || true`) unchanged.
- `scanner/lib/prowler_compliance_summary.py` (new) — `build_summary(prowler_dir)` + `main()`; stdlib-only; loads `compliance-map.py` as a sibling via importlib relative to `__file__` (cwd-independent).
- `scanner/tests/test_prowler_compliance_summary.py` (new) — 12 tests, 100% line coverage of the new module.
- `.github/workflows/lint.yml` — register the new module + test in the `py_compile` list.

## Verification

| Check | Result |
|-------|--------|
| `output_prowler.sh` kcov | **65.79% → 90.91%** (50/55) |
| new module pytest coverage | **100%** (42/42) |
| full `--cov=scanner/lib --cov-fail-under=99` | **99.13% pass** (1489 passed) |
| `shellcheck scanner/lib/output_prowler.sh` | clean |
| all `test_ci_*.py` guards | 297 passed |
| behavior parity (sec-reviewer) | exact — array/NDJSON/malformed-tolerance/empty conditions identical |

## Security

Passing `prowler_dir` as `sys.argv[1]` instead of interpolating it into Python source (`pdir = '$prowler_dir'`) removes a CWE-94 code-injection smell (OWASP A03:2021 – Injection). Same-user/local exploitability was low, but the pattern is eliminated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)