### PR TITLE
refactor(scanner): extract prowler severity-count awk to program file

### DIFF
--- a/scanner/lib/output_prowler.sh
+++ b/scanner/lib/output_prowler.sh
@@ -51,14 +51,7 @@ _prowler_dashboard_summary() {
     provider=$(basename "$f" .ocsf.json | sed 's/^prowler-//')
     label="$(_prowler_dashboard_summary_provider_label "$provider")"
     total=$(grep -c '"status_code": *"FAIL"' "$f" 2>/dev/null || echo 0)
-    read -r c h m l <<< "$(awk '
-      BEGIN { c=0; h=0; m=0; l=0 }
-      /"severity":/ { gsub(/.*"severity": *"/,""); gsub(/".*/, ""); sev=$0 }
-      /"status_code": *"FAIL"/ {
-        if (sev=="Critical") c++; else if (sev=="High") h++; else if (sev=="Medium") m++; else if (sev=="Low") l++
-      }
-      END { print c+0, h+0, m+0, l+0 }
-    ' "$f" 2>/dev/null)"
+    read -r c h m l <<< "$(awk -f "$(dirname "${BASH_SOURCE[0]}")/prowler_severity_count.awk" "$f" 2>/dev/null)"
     c=${c:-0}; h=${h:-0}; m=${m:-0}; l=${l:-0}
     echo "  <tr><td style=\"padding:0.5rem 0.75rem;border-bottom:1px solid var(--border)\">$label</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border)\">$total</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:#dc2626\">$c</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:#ef4444\">$h</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:#eab308\">$m</td><td style=\"text-align:right;padding:0.5rem 0.75rem;border-bottom:1px solid var(--border);color:var(--muted)\">$l</td></tr>"
   done <<< "$files"

--- a/scanner/lib/prowler_severity_count.awk
+++ b/scanner/lib/prowler_severity_count.awk
@@ -1,0 +1,18 @@
+# ClaudeSec — count Prowler OCSF FAIL findings by severity.
+#
+# Reads one prowler-*.ocsf.json file and prints four space-separated counts:
+#   "<critical> <high> <medium> <low>"
+# for records whose status_code is FAIL, bucketed by the preceding severity.
+#
+# Extracted verbatim from output_prowler.sh::_prowler_dashboard_summary so the
+# awk program body is no longer counted by kcov as uncoverable bash lines (a
+# kcov-v42 limitation for multi-line interpreter strings inside $() ). Invoked
+# as: awk -f prowler_severity_count.awk <file>. Behaviour is identical to the
+# former inline single-quoted program. Covered behaviourally by
+# scanner/tests/test_output_prowler_severity.sh.
+BEGIN { c=0; h=0; m=0; l=0 }
+/"severity":/ { gsub(/.*"severity": *"/,""); gsub(/".*/, ""); sev=$0 }
+/"status_code": *"FAIL"/ {
+  if (sev=="Critical") c++; else if (sev=="High") h++; else if (sev=="Medium") m++; else if (sev=="Low") l++
+}
+END { print c+0, h+0, m+0, l+0 }

--- a/scanner/tests/test_output_prowler_severity.sh
+++ b/scanner/tests/test_output_prowler_severity.sh
@@ -1,15 +1,17 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
-# Cover scanner/lib/output.sh L545-561: _prowler_dashboard_summary main
-# rendering loop including the awk severity counter at L551-558.
+# Cover scanner/lib/output_prowler.sh: _prowler_dashboard_summary main
+# rendering loop including the severity counter.
 #
 # Direct-call pattern (no $() wrapping the SUT) so kcov DEBUG-trap fires
-# on every in-shell command. The awk script body (L552-557) is text data
-# inside a multi-line single-quoted string argument — kcov's per-line
-# accounting may or may not credit those lines (a known kcov-v42 limit
-# for multi-line string literals). The surrounding bash lines (provider
-# loop, basename, total grep, read pipeline, td emission) are
-# unambiguous bash and should all light up.
+# on every in-shell command. The severity counter now runs from an external
+# program file (scanner/lib/prowler_severity_count.awk, invoked via awk -f)
+# rather than an inline multi-line single-quoted awk string — the former
+# inline body was text data that kcov's per-line accounting counted as
+# uncoverable, so it was extracted (kcov measures bash, not the .awk file).
+# This test still validates the counter behaviourally via the emitted HTML
+# cells. The surrounding bash lines (provider loop, basename, total grep,
+# read pipeline, td emission) are unambiguous bash and all light up.
 #
 # Run: bash scanner/tests/test_output_prowler_severity.sh
 set -uo pipefail


### PR DESCRIPTION
## Summary

Follow-up to #346. Moves the inline single-quoted awk severity counter out of `_prowler_dashboard_summary` (`scanner/lib/output_prowler.sh`) into `scanner/lib/prowler_severity_count.awk`, invoked via `awk -f`.

**Why:** like the python heredoc fixed in #346, the awk program body was text data inside a multi-line `$()` string that kcov counts as uncoverable bash lines. Extracting it takes `output_prowler.sh` bash coverage to **100%**.

> **Stacked on #346** — base is `refactor/prowler-compliance-py-extract`. GitHub retargets this to `main` automatically once #346 merges. Review/merge #346 first.

## Changes
- `scanner/lib/prowler_severity_count.awk` (new) — the extracted counter (identical logic).
- `scanner/lib/output_prowler.sh` — call `awk -f "$(dirname "${BASH_SOURCE[0]}")/prowler_severity_count.awk" "$f"`.
- `scanner/tests/test_output_prowler_severity.sh` — refresh stale header comment (no assertion changes).

## Verification
| Check | Result |
|-------|--------|
| `output_prowler.sh` kcov | **90.91% → 100%** (49/49) |
| `test_output_prowler_severity.sh` | 12/12 pass (behaviour unchanged) |
| `shellcheck scanner/lib/output_prowler.sh` | clean |

## Notes
The awk program is **single-quoted (no bash interpolation)**, so this is a coverage/measurability change only — **not** a security fix (unlike the CWE-94 removal in #346). The `.awk` file is not measured by kcov (kcov measures bash) or pytest; it is covered behaviourally by the severity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)