### PR TITLE
fix(scanner): emit both details and remediation in findings JSON

### DIFF
--- a/scanner/lib/dashboard_html_builders.py
+++ b/scanner/lib/dashboard_html_builders.py
@@ -90,21 +90,30 @@ def _build_scanner_section(findings_list):
             badge = sev_badge(sev)
             fid = h(f.get("id", ""))
             title = h(f.get("title", ""))
-            details = h(f.get("details", ""))
+            raw_details = f.get("details") or ""
+            raw_remediation = f.get("remediation") or ""
+            # Backward compat: reports generated before the details/remediation
+            # split stored fix text in "details"; fall back so old reports
+            # (and the row/action rendering below) still show a remediation.
+            remediation_text = raw_remediation or raw_details
+            remediation = h(remediation_text)
+            details = h(raw_details) if raw_details and raw_details != remediation_text else ""
             status_icon = "✗" if sev in ("critical", "high", "medium") else "⚠"
             status_label = (
                 "Fail" if sev in ("critical", "high", "medium") else "Warning"
             )
             location = h(f.get("location", ""))
             loc_html = f' <span class="scan-loc">📍 <code>{location}</code></span>' if location else ""
-            has_expandable = location or details
+            has_expandable = location or details or remediation
             row_cls = f'{sev_cls} expandable' if has_expandable else sev_cls
             toggle = ' data-action="toggleRow"' if has_expandable else ""
-            scanner_rows += f'<tr class="{row_cls}"{toggle}><td>{badge}</td><td><span class="scan-status-{sev}">{status_icon} {status_label}</span></td><td class="mono">{fid}</td><td>{title}</td><td class="fix">{details if details else "<em>-</em>"}</td></tr>'
+            scanner_rows += f'<tr class="{row_cls}"{toggle}><td>{badge}</td><td><span class="scan-status-{sev}">{status_icon} {status_label}</span></td><td class="mono">{fid}</td><td>{title}</td><td class="fix">{remediation if remediation else "<em>-</em>"}</td></tr>'
             if has_expandable:
                 detail_parts = []
+                if remediation:
+                    detail_parts.append(f'<p style="margin-bottom:.4rem"><strong>Remediation:</strong> {remediation}</p>')
                 if details:
-                    detail_parts.append(f'<p style="margin-bottom:.4rem"><strong>Remediation:</strong> {details}</p>')
+                    detail_parts.append(f'<p style="margin-top:.3rem"><strong>Details:</strong> {details}</p>')
                 if location:
                     detail_parts.append(f'<p style="margin-top:.3rem"><strong>Location:</strong> <code style="font-size:.75rem;word-break:break-all">{location}</code></p>')
                 scanner_rows += f'<tr class="row-detail"><td colspan="5"><div class="detail-panel">{"".join(detail_parts)}</div></td></tr>'
@@ -169,7 +178,7 @@ def _build_scanner_section(findings_list):
     seen_actions = set()
     for f in top_findings:
         cat = f.get("category") or _infer_category(f.get("id", ""))
-        raw_action = (f.get("details") or "").strip()
+        raw_action = (f.get("remediation") or f.get("details") or "").strip()
         action = raw_action if raw_action else _scanner_default_action(cat)
         action_norm = action.lower()
         if action_norm in seen_actions:

--- a/scanner/lib/output.sh
+++ b/scanner/lib/output.sh
@@ -469,12 +469,17 @@ generate_html_dashboard() {
     IFS='|' read -r f_id f_title _f_sev f_fix f_details f_loc <<< "$2"
     f_title="${f_title//\"/\\\"}"
     f_fix="${f_fix//\"/\\\"}"
+    f_details="${f_details//\"/\\\"}"
     f_loc="${f_loc//\"/\\\"}"
     local f_cat; f_cat=$(_finding_id_to_category "$f_id")
     [[ "$first" == "true" ]] && first=false || findings_json+=","
     local loc_field=""
     [[ -n "$f_loc" ]] && loc_field=",\"location\":\"$f_loc\""
-    findings_json+="{\"id\":\"$f_id\",\"title\":\"$f_title\",\"severity\":\"$f_sev_label\",\"details\":\"$f_fix\",\"category\":\"$f_cat\"${loc_field}}"
+    local details_field=""
+    [[ -n "$f_details" ]] && details_field=",\"details\":\"$f_details\""
+    local remediation_field=""
+    [[ -n "$f_fix" ]] && remediation_field=",\"remediation\":\"$f_fix\""
+    findings_json+="{\"id\":\"$f_id\",\"title\":\"$f_title\",\"severity\":\"$f_sev_label\",\"category\":\"$f_cat\"${details_field}${remediation_field}${loc_field}}"
   }
 
   for entry in "${FINDINGS_CRITICAL[@]+"${FINDINGS_CRITICAL[@]}"}"; do

--- a/scanner/tests/test_dashboard_html_builders_pure.py
+++ b/scanner/tests/test_dashboard_html_builders_pure.py
@@ -169,6 +169,57 @@ def test_scanner_section_location_adds_expandable_row():
     assert "row-detail" in rows
 
 
+def test_scanner_section_remediation_and_details_render_separately():
+    """When both 'remediation' and 'details' are set (new schema), the row's
+    fix column and the 'Remediation:' label use remediation, while a
+    distinct 'Details:' line renders the actual author-provided details."""
+    findings = [{
+        "id": "CODE-005",
+        "title": "Hardcoded secret",
+        "details": "Found a hardcoded API key in config.py line 12",
+        "remediation": "Move the secret to an environment variable",
+        "severity": "high",
+        "category": "code",
+    }]
+    rows, _, _ = builders._build_scanner_section(findings)
+    assert '<td class="fix">Move the secret to an environment variable</td>' in rows
+    assert "<strong>Remediation:</strong> Move the secret to an environment variable" in rows
+    assert "<strong>Details:</strong> Found a hardcoded API key in config.py line 12" in rows
+
+
+def test_scanner_section_remediation_missing_falls_back_to_details_no_duplicate():
+    """Backward compat: reports without 'remediation' (old schema) show
+    details as the Remediation label, and do NOT also render a duplicate
+    Details: line for the same text."""
+    findings = [{
+        "id": "CODE-006",
+        "title": "Old-format finding",
+        "details": "This is old fix text stored in details",
+        "severity": "medium",
+        "category": "code",
+    }]
+    rows, _, _ = builders._build_scanner_section(findings)
+    assert "<strong>Remediation:</strong> This is old fix text stored in details" in rows
+    assert "<strong>Details:</strong>" not in rows
+
+
+def test_scanner_section_remediation_only_renders_no_details_line():
+    """New schema, remediation set but details empty: the Remediation label
+    and fix column use remediation, and no Details: line is rendered."""
+    findings = [{
+        "id": "CODE-007",
+        "title": "Remediation-only finding",
+        "details": "",
+        "remediation": "Rotate the exposed credential",
+        "severity": "high",
+        "category": "code",
+    }]
+    rows, _, _ = builders._build_scanner_section(findings)
+    assert '<td class="fix">Rotate the exposed credential</td>' in rows
+    assert "<strong>Remediation:</strong> Rotate the exposed credential" in rows
+    assert "<strong>Details:</strong>" not in rows
+
+
 def test_scanner_section_no_details_no_location_no_expandable():
     """A finding without details/location does NOT render row-detail."""
     findings = [{

--- a/scanner/tests/test_output_functions.sh
+++ b/scanner/tests/test_output_functions.sh
@@ -190,6 +190,45 @@ IFS='|' read -r _ _ _ _ _ f_loc2 <<< "$entry"
 assert_eq "pipe format: location field preserved" "/k8s/deployment.yaml" "$f_loc2"
 
 # ==============================================================================
+# Test Group 3b: _emit_finding_json() emits BOTH details and remediation
+# ==============================================================================
+echo ""
+echo "=== _emit_finding_json(): details + remediation JSON fields ==="
+
+# 1. Details and remediation both populated -> both keys present with correct
+#    (non-swapped) values in the generated scan-report.json
+_reset_state
+fail "CHK-020" "Details vs remediation" "high" "actual detail text" "apply this fix" "/tmp/example.yaml"
+generate_html_dashboard "$tmpdir/dashboard-details-remediation.html" >/dev/null 2>&1
+report_json="$(cat "$tmpdir/scan-report.json" 2>/dev/null)"
+assert_contains "emit: details field carries author details" "$report_json" '"details":"actual detail text"'
+assert_contains "emit: remediation field carries fix text"   "$report_json" '"remediation":"apply this fix"'
+
+# 2. Empty details and remediation -> neither key present (conditional emit)
+_reset_state
+fail "CHK-021" "Empty detail and fix" "high" "" "" "/tmp/empty.yaml"
+generate_html_dashboard "$tmpdir/dashboard-empty-detail-fix.html" >/dev/null 2>&1
+report_json_empty="$(cat "$tmpdir/scan-report.json" 2>/dev/null)"
+assert_not_contains "emit: no details key when empty"     "$report_json_empty" '"details":'
+assert_not_contains "emit: no remediation key when empty" "$report_json_empty" '"remediation":'
+
+# 3. details-only (no remediation) -> only details key present
+_reset_state
+fail "CHK-022" "Detail only" "high" "only detail" "" "/tmp/d.yaml"
+generate_html_dashboard "$tmpdir/dashboard-detail-only.html" >/dev/null 2>&1
+report_json_donly="$(cat "$tmpdir/scan-report.json" 2>/dev/null)"
+assert_contains     "emit: details-only carries details"      "$report_json_donly" '"details":"only detail"'
+assert_not_contains "emit: details-only omits remediation"    "$report_json_donly" '"remediation":'
+
+# 4. remediation-only (no details) -> only remediation key present
+_reset_state
+fail "CHK-023" "Remediation only" "high" "" "only fix" "/tmp/r.yaml"
+generate_html_dashboard "$tmpdir/dashboard-remediation-only.html" >/dev/null 2>&1
+report_json_ronly="$(cat "$tmpdir/scan-report.json" 2>/dev/null)"
+assert_contains     "emit: remediation-only carries remediation" "$report_json_ronly" '"remediation":"only fix"'
+assert_not_contains "emit: remediation-only omits details"       "$report_json_ronly" '"details":'
+
+# ==============================================================================
 # Test Group 4: print_banner / section / category_label
 # ==============================================================================
 echo ""


### PR DESCRIPTION
## Summary

`scanner/lib/output.sh` `_emit_finding_json` emitted `"details":"$f_fix"` — placing the **remediation** text under the `details` key and silently **dropping the author-written details** (pipe field 5), leaving `f_details` a dead variable (SC2034). Authors populate field 5 (asserted in `test_output_functions.sh:182`), but that data never reached the dashboard-facing `scan-report.json` `findings[]`.

This surfaces **both** fields as separate, omit-when-empty keys:
- `details` → the real author details (field 5)
- `remediation` → the fix text (field 4)

## Why no collision with Prowler

Prowler's `remediation` is a nested object (`{desc,references}`) consumed only by `dashboard_data_analysis.py:55` over the **OCSF Prowler array** (`finding_info/resources/cloud`). Scanner `scan-report.json` findings[] are a separate array loaded via a different path (`dashboard-gen.py:169`) and never reach that dict-expecting consumer. A top-level string `remediation` on scanner findings is safe.

## Dashboard changes (`dashboard_html_builders.py`)

- "Remediation:" label + row fix column render `remediation`, **falling back to `details`** for pre-existing/old reports so no rendered text disappears (backward compatible).
- A distinct "Details:" line renders `details` only when non-empty **and** different from the remediation text (prevents a duplicate block on old-format reports).
- Top-actions list reads `remediation or details`.

## Test plan

- `bash scanner/tests/test_output_functions.sh` → **188 passed** (asserts non-swapped values for both-set, both-empty, details-only, remediation-only)
- `CLAUDESEC_DASHBOARD_OFFLINE=1 python3 -m pytest scanner/lib scanner/tests -q` → **1522 passed, 5 skipped**, scanner/lib coverage **99%** (≥99% floor)
- `shellcheck scanner/lib/output.sh` clean at `severity: error` (removes the pre-existing SC2034)

## Review notes

Independently reviewed in a separate lane (sec-reviewer): no CRITICAL/HIGH/MEDIUM. One LOW (partial-combination test gap) closed in this PR. A second LOW — pre-existing quote-only JSON escaping (no newline/backslash handling) — is unchanged by this PR and tracked as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)