### PR TITLE
fix(scanner): build findings JSON via json.dumps for robust escaping

### DIFF
--- a/scanner/checks/code/injection.sh
+++ b/scanner/checks/code/injection.sh
@@ -55,7 +55,13 @@ _code_grep() {
   echo "$results" | head -"$max_hits"
 }
 
-# Format findings for details field (uses literal \n for pipe-delimited storage)
+# Format findings for the details field. Uses a REAL newline (not a literal
+# backslash-n) between entries: findings are now packed with the Unit
+# Separator (\x1f, see output.sh's fail()/_FINDING_SEP) instead of "|", and
+# the JSON emitter (scanner/lib/findings_json.py) uses json.dumps, which
+# escapes a real newline to the correct "\n" JSON sequence on its own. A
+# literal two-character "\n" here would instead be double-escaped to a
+# visible "\\n" in the rendered dashboard.
 _format_hits() {
   local hits="$1" max="${2:-10}"
   local output="" count=0
@@ -64,12 +70,12 @@ _format_hits() {
     [[ $count -ge $max ]] && break
     # Shorten path relative to SCAN_DIR
     line="${line#"$SCAN_DIR"/}"
-    output="${output}\\n    ${line}"
+    output="${output}"$'\n'"    ${line}"
     count=$((count + 1))
   done <<< "$hits"
   local total
   total=$(echo "$hits" | grep -c . 2>/dev/null || true)
-  [[ $total -gt $max ]] && output="${output}\\n    ... and $((total - max)) more"
+  [[ $total -gt $max ]] && output="${output}"$'\n'"    ... and $((total - max)) more"
   echo "$output"
 }
 

--- a/scanner/lib/findings_json.py
+++ b/scanner/lib/findings_json.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+ClaudeSec — findings-JSON builder for the dashboard's scan-report.json.
+
+Extracted from the inline bash string-concatenation previously embedded in
+scanner/lib/output.sh's ``_emit_finding_json`` (see that file's
+``generate_html_dashboard``). The bash version only escaped double-quotes,
+so a finding ``details``/``remediation``/``location`` value containing a
+literal backslash (e.g. a Windows path like ``C:\\temp``) produced invalid
+JSON. Using ``json.dumps`` here handles backslashes, quotes, control
+characters, and Unicode correctly, matching the extraction pattern already
+used for ``prowler_compliance_summary.py`` (kcov cannot usefully measure
+coverage of logic embedded in a bash heredoc/subshell, so real coverage is
+enforced by pytest instead — see
+scanner/tests/test_findings_json_pure.py).
+
+Input contract (stdin): a NUL (``\\0``)-delimited stream of finding
+records. Within each record, fields are Unit-Separator (``\\x1f``)-delimited
+in this fixed order::
+
+    severity_label, id, title, remediation, details, category, location
+
+This mirrors the ``\\x1f``-packed ``FINDINGS_*`` array entries built by
+``fail()``/``warn()`` in output.sh (severity_label, id, title, and category
+are supplied separately by the bash caller; category is computed via the
+single-source-of-truth ``_finding_id_to_category``).
+"""
+
+import json
+import sys
+
+_NUM_FIELDS = 7  # severity_label, id, title, remediation, details, category, location
+
+
+def build_findings_json(records):
+    """Return a compact JSON array string for an iterable of finding records.
+
+    Each record is a 7-item sequence in the fixed order documented above.
+    Key order in the emitted dict matches the pre-refactor schema exactly:
+    id, title, severity, category, then details/remediation/location, each
+    omitted when empty.
+    """
+    items = []
+    for severity_label, finding_id, title, remediation, details, category, location in records:
+        item = {
+            "id": finding_id,
+            "title": title,
+            "severity": severity_label,
+            "category": category,
+        }
+        if details:
+            item["details"] = details
+        if remediation:
+            item["remediation"] = remediation
+        if location:
+            item["location"] = location
+        items.append(item)
+    return json.dumps(items, ensure_ascii=False, separators=(",", ":"))
+
+
+def _iter_records(raw):
+    """Yield 7-tuples parsed from a NUL-delimited, \\x1f-separated blob.
+
+    A trailing NUL (the terminator of the last record) produces one empty
+    trailing chunk after splitting on "\\0"; that chunk is skipped.
+    """
+    if not raw:
+        return
+    for chunk in raw.split("\0"):
+        if chunk == "":
+            continue
+        fields = chunk.split("\x1f")
+        if len(fields) != _NUM_FIELDS:
+            raise ValueError(
+                f"expected {_NUM_FIELDS} \\x1f-delimited fields, got {len(fields)}: {fields!r}"
+            )
+        yield tuple(fields)
+
+
+def main():
+    """CLI entry point: read NUL-delimited records from stdin, print the JSON array.
+
+    Called by output.sh's generate_html_dashboard as
+    ``python3 findings_json.py`` with the record stream piped in. Missing/
+    empty stdin yields ``[]``, matching the pre-refactor empty-findings
+    behavior. Takes no CLI arguments — the module is entirely stdin-driven.
+    """
+    raw = sys.stdin.read()
+    records = list(_iter_records(raw))
+    print(build_findings_json(records))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scanner/lib/output.sh
+++ b/scanner/lib/output.sh
@@ -18,6 +18,15 @@ NC='\033[0m'
 # JSON results array
 JSON_RESULTS="[]"
 
+# Field separator used to pack FINDINGS_* entries (id/title/severity/
+# remediation/details/location — see fail()/warn()). Unit Separator (0x1F)
+# instead of "|": a finding's title/details/remediation text can legitimately
+# contain a literal "|" or a real newline (e.g. multi-line _format_hits
+# output), and both would corrupt a "|"-delimited pack/unpack. \x1f is a
+# non-printing control character no finding text is expected to contain.
+# (Not `readonly`: output.sh may be re-sourced in the same shell by tests.)
+_FINDING_SEP=$'\x1f'
+
 # Findings tracking for dashboard
 declare -a FINDINGS_CRITICAL=()
 declare -a FINDINGS_HIGH=()
@@ -80,7 +89,7 @@ fail() {
   TOTAL_CHECKS=$((TOTAL_CHECKS + 1))
   FAILED=$((FAILED + 1))
 
-  local entry="$id|$title|$severity|$remediation|$details|$location"
+  local entry="${id}${_FINDING_SEP}${title}${_FINDING_SEP}${severity}${_FINDING_SEP}${remediation}${_FINDING_SEP}${details}${_FINDING_SEP}${location}"
   case "$severity" in
     critical) FINDINGS_CRITICAL+=("$entry") ;;
     high)     FINDINGS_HIGH+=("$entry") ;;
@@ -107,7 +116,7 @@ warn() {
   TOTAL_CHECKS=$((TOTAL_CHECKS + 1))
   WARNINGS=$((WARNINGS + 1))
 
-  FINDINGS_WARN+=("$id|$title|medium||$details")
+  FINDINGS_WARN+=("${id}${_FINDING_SEP}${title}${_FINDING_SEP}medium${_FINDING_SEP}${_FINDING_SEP}${details}")
 
   if [[ "$FORMAT" == "text" && -z "${QUIET:-}" ]]; then
     echo -e "  ${YELLOW}⚠ WARN${NC}  ${DIM}[$id]${NC} $title"
@@ -224,7 +233,7 @@ _print_findings() {
   local -n arr=$1
   local label="$2" show_fix="${3:-true}"
   for entry in "${arr[@]+"${arr[@]}"}"; do
-    IFS='|' read -r f_id f_title _ f_fix <<< "$entry"
+    IFS="$_FINDING_SEP" read -r f_id f_title _ f_fix <<< "$entry"
     local f_cat; f_cat=$(_finding_id_to_category "$f_id")
     echo -e "  ${label}${NC}  ${DIM}[$f_id]${NC} ${DIM}(${f_cat})${NC} $f_title"
     [[ "$show_fix" == "true" && -n "$f_fix" ]] && echo -e "          ${CYAN}→ $f_fix${NC}"
@@ -459,45 +468,74 @@ generate_html_dashboard() {
   local n_low=${#FINDINGS_LOW[@]}
   local n_warn=${#FINDINGS_WARN[@]}
 
-  # Build findings JSON for Python generator
-  local findings_json="["
-  local first=true
-
-  _emit_finding_json() {
-    local f_sev_label="$1"
+  # Build findings JSON via a single python3 invocation (findings_json.py),
+  # instead of hand-built string concatenation. The old bash concat only
+  # escaped double-quotes (not backslashes or control chars), so a details/
+  # remediation/location value containing a literal backslash (e.g. a
+  # Windows path like C:\temp) produced invalid JSON. json.dumps handles
+  # backslashes, quotes, control characters, and real embedded newlines
+  # (e.g. multi-line _format_hits output) correctly.
+  #
+  # Each FINDINGS_* array entry is unpacked into a 7-field Unit-Separator
+  # (\x1f)-joined, NUL (\0)-terminated record — severity_label, id, title,
+  # remediation, details, category, location — and the whole batch is
+  # streamed to ONE python3 process (not one fork per finding); category is
+  # still computed in bash via _finding_id_to_category, the single source of
+  # truth for id-prefix -> category mapping.
+  _emit_finding_record() {
+    local f_sev_label="$1" f_entry="$2"
     local f_id f_title _f_sev f_fix f_details f_loc
-    IFS='|' read -r f_id f_title _f_sev f_fix f_details f_loc <<< "$2"
-    f_title="${f_title//\"/\\\"}"
-    f_fix="${f_fix//\"/\\\"}"
-    f_details="${f_details//\"/\\\"}"
-    f_loc="${f_loc//\"/\\\"}"
-    local f_cat; f_cat=$(_finding_id_to_category "$f_id")
-    [[ "$first" == "true" ]] && first=false || findings_json+=","
-    local loc_field=""
-    [[ -n "$f_loc" ]] && loc_field=",\"location\":\"$f_loc\""
-    local details_field=""
-    [[ -n "$f_details" ]] && details_field=",\"details\":\"$f_details\""
-    local remediation_field=""
-    [[ -n "$f_fix" ]] && remediation_field=",\"remediation\":\"$f_fix\""
-    findings_json+="{\"id\":\"$f_id\",\"title\":\"$f_title\",\"severity\":\"$f_sev_label\",\"category\":\"$f_cat\"${details_field}${remediation_field}${loc_field}}"
+    # NUL-delimited read (`-d ''`) via process substitution — NOT a `<<<`
+    # herestring — so a REAL newline embedded in $f_entry (e.g. multi-line
+    # details from _format_hits) does not truncate the record: `read`'s
+    # default line-based mode stops at the first newline in the input
+    # regardless of $IFS, which `-d ''` avoids by reading to EOF instead.
+    # Process substitution (unlike `<<<`) appends no extra trailing
+    # newline, so the last field (location) is not corrupted. `read -d ''`
+    # returns non-zero when it hits EOF without finding its delimiter (the
+    # normal case here, since $f_entry has no NUL byte) — that failure is
+    # expected and intentionally swallowed.
+    IFS="$_FINDING_SEP" read -rd '' f_id f_title _f_sev f_fix f_details f_loc \
+      < <(printf '%s' "$f_entry") || true
+    local f_cat
+    f_cat=$(_finding_id_to_category "$f_id")
+    printf '%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\x1f%s\0' \
+      "$f_sev_label" "$f_id" "$f_title" "$f_fix" "$f_details" "$f_cat" "$f_loc"
   }
 
-  for entry in "${FINDINGS_CRITICAL[@]+"${FINDINGS_CRITICAL[@]}"}"; do
-    _emit_finding_json "critical" "$entry"
-  done
-  for entry in "${FINDINGS_HIGH[@]+"${FINDINGS_HIGH[@]}"}"; do
-    _emit_finding_json "high" "$entry"
-  done
-  for entry in "${FINDINGS_MEDIUM[@]+"${FINDINGS_MEDIUM[@]}"}"; do
-    _emit_finding_json "medium" "$entry"
-  done
-  for entry in "${FINDINGS_WARN[@]+"${FINDINGS_WARN[@]}"}"; do
-    _emit_finding_json "warning" "$entry"
-  done
-  for entry in "${FINDINGS_LOW[@]+"${FINDINGS_LOW[@]}"}"; do
-    _emit_finding_json "low" "$entry"
-  done
-  findings_json+="]"
+  local findings_json="[]"
+  if command -v python3 >/dev/null 2>&1 && [[ -f "$LIB_DIR/findings_json.py" ]]; then
+    # Write the \0-terminated record stream to a temp file with a BRACE-GROUP
+    # redirection (`{ ...; } > file`) rather than piping into python via a
+    # subshell. A brace group with redirection runs in the CURRENT shell, so
+    # these for-loops / _emit_finding_record calls stay visible to kcov; the
+    # previous `findings_json=$( { ...; } | python3 )` ran the loop on the
+    # left side of a pipe (a subshell) AND inside command substitution, both
+    # of which kcov cannot trace — silently dropping ~12 covered lines and
+    # risking the 90% bash floor.
+    local _records_file
+    _records_file=$(mktemp "${TMPDIR:-/tmp}/claudesec-findings.XXXXXX")
+    {
+      for entry in "${FINDINGS_CRITICAL[@]+"${FINDINGS_CRITICAL[@]}"}"; do
+        _emit_finding_record "critical" "$entry"
+      done
+      for entry in "${FINDINGS_HIGH[@]+"${FINDINGS_HIGH[@]}"}"; do
+        _emit_finding_record "high" "$entry"
+      done
+      for entry in "${FINDINGS_MEDIUM[@]+"${FINDINGS_MEDIUM[@]}"}"; do
+        _emit_finding_record "medium" "$entry"
+      done
+      for entry in "${FINDINGS_WARN[@]+"${FINDINGS_WARN[@]}"}"; do
+        _emit_finding_record "warning" "$entry"
+      done
+      for entry in "${FINDINGS_LOW[@]+"${FINDINGS_LOW[@]}"}"; do
+        _emit_finding_record "low" "$entry"
+      done
+    } > "$_records_file"
+    findings_json=$(python3 "$LIB_DIR/findings_json.py" < "$_records_file")
+    rm -f "$_records_file"
+    [[ -z "$findings_json" ]] && findings_json="[]"
+  fi
 
   # Persist scan summary for diagrams/docs (no identifiers by design).
   # Consumers: scanner/lib/diagram-gen.py, docs/architecture assets, local dashboards.

--- a/scanner/tests/test_findings_json_pure.py
+++ b/scanner/tests/test_findings_json_pure.py
@@ -1,0 +1,198 @@
+"""
+Unit tests for scanner/lib/findings_json.py.
+
+This module was extracted from the inline bash string-concatenation that
+used to live in scanner/lib/output.sh's `_emit_finding_json` (see that
+file's `generate_html_dashboard`). These tests exercise `build_findings_json`
+in-process so coverage.py actually measures it — the bash subprocess
+invocation (`python3 findings_json.py` fed via a piped NUL/\x1f record
+stream) is invisible to `--cov=scanner/lib`.
+
+Run: python3 -m pytest scanner/tests/test_findings_json_pure.py -q
+"""
+
+import io
+import json
+import os
+import runpy
+import sys
+
+import pytest
+
+LIB_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "lib")
+sys.path.insert(0, os.path.abspath(LIB_DIR))
+
+import findings_json as fj  # noqa: E402
+
+
+def _rec(severity_label="high", finding_id="CHK-001", title="Title",
+         remediation="", details="", category="code", location=""):
+    """Build a 7-field record tuple in build_findings_json()'s fixed order."""
+    return (severity_label, finding_id, title, remediation, details, category, location)
+
+
+class TestBuildFindingsJsonPure:
+    def test_empty_records_yields_empty_array(self):
+        assert fj.build_findings_json([]) == "[]"
+
+    def test_both_details_and_remediation_present(self):
+        rec = _rec(details="actual detail text", remediation="apply this fix")
+        result = json.loads(fj.build_findings_json([rec]))
+        assert result == [
+            {
+                "id": "CHK-001",
+                "title": "Title",
+                "severity": "high",
+                "category": "code",
+                "details": "actual detail text",
+                "remediation": "apply this fix",
+            }
+        ]
+
+    def test_details_only_omits_remediation_key(self):
+        rec = _rec(details="only detail", remediation="")
+        result = json.loads(fj.build_findings_json([rec]))
+        assert result[0]["details"] == "only detail"
+        assert "remediation" not in result[0]
+
+    def test_remediation_only_omits_details_key(self):
+        rec = _rec(details="", remediation="only fix")
+        result = json.loads(fj.build_findings_json([rec]))
+        assert result[0]["remediation"] == "only fix"
+        assert "details" not in result[0]
+
+    def test_neither_details_nor_remediation_present(self):
+        rec = _rec(details="", remediation="")
+        result = json.loads(fj.build_findings_json([rec]))
+        assert "details" not in result[0]
+        assert "remediation" not in result[0]
+
+    def test_location_omitted_when_empty(self):
+        rec = _rec(location="")
+        result = json.loads(fj.build_findings_json([rec]))
+        assert "location" not in result[0]
+
+    def test_location_present_when_set(self):
+        rec = _rec(location="/etc/passwd")
+        result = json.loads(fj.build_findings_json([rec]))
+        assert result[0]["location"] == "/etc/passwd"
+
+    def test_key_order_matches_pre_refactor_schema(self):
+        rec = _rec(details="d", remediation="r", location="/x")
+        raw = fj.build_findings_json([rec])
+        # json.dumps with dict input preserves insertion order in the
+        # emitted text (Python 3.7+ dicts are ordered); assert the exact
+        # key sequence id/title/severity/category/details/remediation/location.
+        assert raw.startswith(
+            '[{"id":"CHK-001","title":"Title","severity":"high",'
+            '"category":"code","details":"d","remediation":"r","location":"/x"}]'
+        )
+
+    def test_multiple_records_preserve_order(self):
+        records = [
+            _rec(finding_id="CHK-001", title="First"),
+            _rec(finding_id="CHK-002", title="Second"),
+        ]
+        result = json.loads(fj.build_findings_json(records))
+        assert [r["id"] for r in result] == ["CHK-001", "CHK-002"]
+
+    def test_special_characters_newline_backslash_quote(self):
+        """The exact bug this refactor fixes: the old bash concat only
+        escaped double-quotes, so a backslash produced invalid JSON, and a
+        "|"-packed real newline truncated the read."""
+        details = 'line1\nline2 with "quote" and back\\slash'
+        rec = _rec(details=details)
+        raw = fj.build_findings_json([rec])
+        # Must be valid JSON (would raise if the backslash broke it).
+        result = json.loads(raw)
+        assert result[0]["details"] == details
+
+    def test_unicode_passthrough_not_ascii_escaped(self):
+        rec = _rec(title="한글 제목 — 유니코드")
+        raw = fj.build_findings_json([rec])
+        # ensure_ascii=False: Unicode should appear literally, not as \uXXXX.
+        assert "한글 제목" in raw
+        assert json.loads(raw)[0]["title"] == "한글 제목 — 유니코드"
+
+    def test_embedded_unit_separator_delimiter_in_details_field(self):
+        """A details value that happens to already contain the pack
+        delimiter (\\x1f) must still round-trip correctly through
+        build_findings_json — this function receives pre-split fields, so
+        the delimiter, once split upstream, is just ordinary text here."""
+        details = "value\x1fwith\x1funit-separators"
+        rec = _rec(details=details)
+        result = json.loads(fj.build_findings_json([rec]))
+        assert result[0]["details"] == details
+
+
+class TestIterRecords:
+    def test_empty_stdin_yields_no_records(self):
+        assert list(fj._iter_records("")) == []
+
+    def test_single_record_nul_terminated(self):
+        raw = "high\x1fCHK-001\x1fTitle\x1frem\x1fdet\x1fcode\x1floc\0"
+        records = list(fj._iter_records(raw))
+        assert records == [("high", "CHK-001", "Title", "rem", "det", "code", "loc")]
+
+    def test_multiple_records(self):
+        raw = (
+            "high\x1fCHK-001\x1fT1\x1f\x1f\x1fcode\x1f\0"
+            "low\x1fCHK-002\x1fT2\x1f\x1f\x1finfra\x1f\0"
+        )
+        records = list(fj._iter_records(raw))
+        assert len(records) == 2
+        assert records[0][1] == "CHK-001"
+        assert records[1][1] == "CHK-002"
+
+    def test_record_with_embedded_real_newline_in_details_field(self):
+        raw = "high\x1fCHK-001\x1fTitle\x1frem\x1fline1\nline2\x1fcode\x1floc\0"
+        records = list(fj._iter_records(raw))
+        assert records == [
+            ("high", "CHK-001", "Title", "rem", "line1\nline2", "code", "loc")
+        ]
+
+    def test_malformed_record_wrong_field_count_raises(self):
+        raw = "high\x1fCHK-001\x1fonly-three-fields\0"
+        try:
+            list(fj._iter_records(raw))
+        except ValueError as exc:
+            assert "7" in str(exc)
+        else:
+            raise AssertionError("expected ValueError for malformed record")
+
+
+class TestMainCliDriver:
+    def test_main_empty_stdin_prints_empty_array(self, monkeypatch, capsys):
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+        rc = fj.main()
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "[]"
+
+    def test_main_reads_stdin_and_prints_json(self, monkeypatch, capsys):
+        raw = "critical\x1fCHK-099\x1fTitle\x1frem\x1fdet\x1fcode\x1f\0"
+        monkeypatch.setattr(sys, "stdin", io.StringIO(raw))
+        rc = fj.main()
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out == [
+            {
+                "id": "CHK-099",
+                "title": "Title",
+                "severity": "critical",
+                "category": "code",
+                "details": "det",
+                "remediation": "rem",
+            }
+        ]
+
+    def test_module_main_guard_runs_via_runpy(self, monkeypatch, capsys):
+        """Exercise the `if __name__ == "__main__": sys.exit(main())` guard,
+        which a normal `import` never executes."""
+        module_path = os.path.join(LIB_DIR, "findings_json.py")
+        monkeypatch.setattr(sys, "stdin", io.StringIO(""))
+
+        with pytest.raises(SystemExit) as exc_info:
+            runpy.run_path(module_path, run_name="__main__")
+
+        assert exc_info.value.code == 0
+        assert capsys.readouterr().out.strip() == "[]"

--- a/scanner/tests/test_generate_html_dashboard.sh
+++ b/scanner/tests/test_generate_html_dashboard.sh
@@ -110,6 +110,12 @@ assert_contains "scan-report: findings key"  "$report_content" '"findings":['
 echo ""
 echo "=== generate_html_dashboard() — findings serialization ==="
 
+# Restore the real LIB_DIR (Group 1 above pointed it at an empty directory
+# to force the legacy-fallback path). generate_html_dashboard now needs
+# $LIB_DIR/findings_json.py to build findings_json from FINDINGS_*, so
+# leaving it stale here would silently degrade every finding below to "[]".
+LIB_DIR="$LIB_DIR_REAL"
+
 rm -f "$scan_report" "$out_html"
 
 TOTAL_CHECKS=4
@@ -117,9 +123,9 @@ PASSED=1
 FAILED=3
 WARNINGS=0
 SKIPPED=0
-FINDINGS_CRITICAL=("IAM-001|Root key exposed|critical|Rotate now|Key present in .env|/app/.env")
-FINDINGS_HIGH=("NET-010|TLS 1.0 enabled|high|Disable TLS 1.0|Legacy protocol|")
-FINDINGS_MEDIUM=("CICD-020|No branch protection|medium|Enable protection||")
+FINDINGS_CRITICAL=("IAM-001"$'\x1f'"Root key exposed"$'\x1f'"critical"$'\x1f'"Rotate now"$'\x1f'"Key present in .env"$'\x1f'"/app/.env")
+FINDINGS_HIGH=("NET-010"$'\x1f'"TLS 1.0 enabled"$'\x1f'"high"$'\x1f'"Disable TLS 1.0"$'\x1f'"Legacy protocol"$'\x1f'"")
+FINDINGS_MEDIUM=("CICD-020"$'\x1f'"No branch protection"$'\x1f'"medium"$'\x1f'"Enable protection"$'\x1f'""$'\x1f'"")
 FINDINGS_LOW=()
 FINDINGS_WARN=()
 

--- a/scanner/tests/test_output_coverage.sh
+++ b/scanner/tests/test_output_coverage.sh
@@ -159,11 +159,11 @@ SCAN_DURATION=0
 
 # Populate all severity arrays including FINDINGS_WARN and FINDINGS_LOW to
 # cover L697 (FINDINGS_WARN loop) and L700 (FINDINGS_LOW loop).
-FINDINGS_CRITICAL+=("INFRA-001|Infra finding|critical|fix infra|d")
-FINDINGS_HIGH+=("CODE-INJ-001|Code injection|high|fix code|d")
-FINDINGS_MEDIUM+=("CLOUD-001|Cloud finding|medium|fix cloud|d")
-FINDINGS_WARN+=("AI-001|AI warning|medium||warn detail")
-FINDINGS_LOW+=("WIN-001|Windows low|low|fix win|d")
+FINDINGS_CRITICAL+=("INFRA-001"$'\x1f'"Infra finding"$'\x1f'"critical"$'\x1f'"fix infra"$'\x1f'"d")
+FINDINGS_HIGH+=("CODE-INJ-001"$'\x1f'"Code injection"$'\x1f'"high"$'\x1f'"fix code"$'\x1f'"d")
+FINDINGS_MEDIUM+=("CLOUD-001"$'\x1f'"Cloud finding"$'\x1f'"medium"$'\x1f'"fix cloud"$'\x1f'"d")
+FINDINGS_WARN+=("AI-001"$'\x1f'"AI warning"$'\x1f'"medium"$'\x1f'$'\x1f'"warn detail")
+FINDINGS_LOW+=("WIN-001"$'\x1f'"Windows low"$'\x1f'"low"$'\x1f'"fix win"$'\x1f'"d")
 
 # Disable diagram-gen (no python script present in test env) to keep test fast
 CLAUDESEC_GENERATE_DIAGRAMS=0
@@ -207,7 +207,7 @@ _exercise_category() {
   local id="$1" expected_cat="$2"
   _reset_state
   TOTAL_CHECKS=1; PASSED=0; FAILED=1; WARNINGS=0; SKIPPED=0; SCAN_DURATION=0
-  FINDINGS_HIGH+=("${id}|Test title|high|fix|detail")
+  FINDINGS_HIGH+=("${id}"$'\x1f'"Test title"$'\x1f'"high"$'\x1f'"fix"$'\x1f'"detail")
   CLAUDESEC_GENERATE_DIAGRAMS=0
   generate_html_dashboard "$tmpdir/cat_test.html" 2>/dev/null || true
   local content

--- a/scanner/tests/test_output_functions.sh
+++ b/scanner/tests/test_output_functions.sh
@@ -165,35 +165,45 @@ fail "CHK-006" "High with loc" "high" "details" "remediate" "/k8s/pod.yaml"
 assert_contains "location in FINDINGS_HIGH entry" "${FINDINGS_HIGH[0]}" "/k8s/pod.yaml"
 
 # ==============================================================================
-# Test Group 3: pipe-delimited format (indirect _emit_finding_json testing)
+# Test Group 3: \x1f-delimited format (indirect _emit_finding_record testing)
 # ==============================================================================
 echo ""
-echo "=== pipe-delimited entry format (for _emit_finding_json) ==="
+echo "=== \\x1f-delimited entry format (for _emit_finding_record) ==="
 
-# 1. Entry has 6 pipe-delimited fields in order: id|title|severity|remediation|details|location
+# 1. Entry has 6 \x1f-delimited fields in order: id, title, severity,
+#    remediation, details, location (see output.sh's _FINDING_SEP/fail()).
 _reset_state
 fail "CHK-010" "Pipe test" "high" "detail text" "fix text" "/some/file"
 entry="${FINDINGS_HIGH[0]}"
-IFS='|' read -r f_id f_title f_sev f_fix f_details f_loc <<< "$entry"
-assert_eq "pipe format: field 1 = id"          "CHK-010"    "$f_id"
-assert_eq "pipe format: field 2 = title"       "Pipe test"  "$f_title"
-assert_eq "pipe format: field 3 = severity"    "high"       "$f_sev"
-assert_eq "pipe format: field 4 = remediation" "fix text"   "$f_fix"
-assert_eq "pipe format: field 5 = details"     "detail text" "$f_details"
-assert_eq "pipe format: field 6 = location"    "/some/file" "$f_loc"
+IFS="$_FINDING_SEP" read -r f_id f_title f_sev f_fix f_details f_loc <<< "$entry"
+assert_eq "\\x1f format: field 1 = id"          "CHK-010"    "$f_id"
+assert_eq "\\x1f format: field 2 = title"       "Pipe test"  "$f_title"
+assert_eq "\\x1f format: field 3 = severity"    "high"       "$f_sev"
+assert_eq "\\x1f format: field 4 = remediation" "fix text"   "$f_fix"
+assert_eq "\\x1f format: field 5 = details"     "detail text" "$f_details"
+assert_eq "\\x1f format: field 6 = location"    "/some/file" "$f_loc"
 
 # 2. Location (field 6) is preserved correctly
 _reset_state
 fail "CHK-011" "Loc test" "high" "" "" "/k8s/deployment.yaml"
 entry="${FINDINGS_HIGH[0]}"
-IFS='|' read -r _ _ _ _ _ f_loc2 <<< "$entry"
-assert_eq "pipe format: location field preserved" "/k8s/deployment.yaml" "$f_loc2"
+IFS="$_FINDING_SEP" read -r _ _ _ _ _ f_loc2 <<< "$entry"
+assert_eq "\\x1f format: location field preserved" "/k8s/deployment.yaml" "$f_loc2"
+
+# 3. A field containing a literal "|" is NOT split (regression guard for the
+#    old "|"-delimited pack, which would have corrupted this entry)
+_reset_state
+fail "CHK-012" "Pipe-in-text test" "high" "value|with|pipes" "fix" "/x"
+entry="${FINDINGS_HIGH[0]}"
+IFS="$_FINDING_SEP" read -r _ _ _ _ f_details3 _ <<< "$entry"
+assert_eq "\\x1f format: literal | preserved in details" "value|with|pipes" "$f_details3"
 
 # ==============================================================================
-# Test Group 3b: _emit_finding_json() emits BOTH details and remediation
+# Test Group 3b: _emit_finding_record() / findings_json.py: details + remediation
+# JSON fields
 # ==============================================================================
 echo ""
-echo "=== _emit_finding_json(): details + remediation JSON fields ==="
+echo "=== findings JSON emission: details + remediation JSON fields ==="
 
 # 1. Details and remediation both populated -> both keys present with correct
 #    (non-swapped) values in the generated scan-report.json
@@ -227,6 +237,30 @@ generate_html_dashboard "$tmpdir/dashboard-remediation-only.html" >/dev/null 2>&
 report_json_ronly="$(cat "$tmpdir/scan-report.json" 2>/dev/null)"
 assert_contains     "emit: remediation-only carries remediation" "$report_json_ronly" '"remediation":"only fix"'
 assert_not_contains "emit: remediation-only omits details"       "$report_json_ronly" '"details":'
+
+# 5. Special-character round-trip: details containing a REAL newline, a
+# backslash, and a double-quote must survive fail() -> generate_html_dashboard
+# -> scan-report.json as VALID JSON, with all three characters preserved
+# (not truncated at the newline — the bug the old "|" + hand-built-JSON
+# concat had: it escaped only quotes, so a backslash produced invalid JSON,
+# and a real newline in a "|"-packed entry truncated the read).
+_reset_state
+special_details=$'line1\nline2 with "quote" and back\\slash'
+fail "CHK-030" "Special chars" "high" "$special_details" "fix it" "/tmp/special.yaml"
+generate_html_dashboard "$tmpdir/dashboard-special-chars.html" >/dev/null 2>&1
+scan_report_special="$tmpdir/scan-report.json"
+assert_eq "special chars: scan-report.json is valid JSON" "0" \
+  "$(python3 -m json.tool "$scan_report_special" >/dev/null 2>&1; echo $?)"
+special_extracted="$(python3 -c '
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+for f in data["findings"]:
+    if f["id"] == "CHK-030":
+        print(f["details"])
+        break
+' "$scan_report_special")"
+assert_eq "special chars: newline preserved"  "$special_details" "$special_extracted"
 
 # ==============================================================================
 # Test Group 4: print_banner / section / category_label
@@ -460,8 +494,8 @@ echo ""
 echo "=== _print_findings() ==="
 
 _reset_state
-FINDINGS_HIGH+=("CHK-100|High finding title|high|fix this now|details")
-FINDINGS_HIGH+=("CHK-101|Second high|high|remediate me|more details")
+FINDINGS_HIGH+=("CHK-100"$'\x1f'"High finding title"$'\x1f'"high"$'\x1f'"fix this now"$'\x1f'"details")
+FINDINGS_HIGH+=("CHK-101"$'\x1f'"Second high"$'\x1f'"high"$'\x1f'"remediate me"$'\x1f'"more details")
 pf_out="$(_print_findings FINDINGS_HIGH "HIGH" true 2>&1)"
 assert_contains "_print_findings: first id"       "$pf_out" "CHK-100"
 assert_contains "_print_findings: second id"      "$pf_out" "CHK-101"
@@ -471,7 +505,7 @@ assert_contains "_print_findings: label present"  "$pf_out" "HIGH"
 
 # show_fix=false suppresses fix text
 _reset_state
-FINDINGS_MEDIUM+=("CHK-200|Medium title|medium|should be hidden|d")
+FINDINGS_MEDIUM+=("CHK-200"$'\x1f'"Medium title"$'\x1f'"medium"$'\x1f'"should be hidden"$'\x1f'"d")
 pf_out2="$(_print_findings FINDINGS_MEDIUM "MED" false 2>&1)"
 assert_contains     "_print_findings(no fix): id shown"    "$pf_out2" "CHK-200"
 assert_not_contains "_print_findings(no fix): fix hidden"  "$pf_out2" "should be hidden"
@@ -537,11 +571,11 @@ assert_contains "print_summary: seconds in duration"  "$ps_min" "5s"
 # Severity breakdown with critical/high/med/low/warn all populated
 _reset_state
 TOTAL_CHECKS=5; PASSED=0; FAILED=4; WARNINGS=1; SKIPPED=0
-FINDINGS_CRITICAL+=("CHK-C1|Critical thing|critical|fix crit|d")
-FINDINGS_HIGH+=("CHK-H1|High thing|high|fix high|d")
-FINDINGS_MEDIUM+=("CHK-M1|Medium thing|medium|fix med|d")
-FINDINGS_LOW+=("CHK-L1|Low thing|low|fix low|d")
-FINDINGS_WARN+=("CHK-W1|Warn thing|medium||d")
+FINDINGS_CRITICAL+=("CHK-C1"$'\x1f'"Critical thing"$'\x1f'"critical"$'\x1f'"fix crit"$'\x1f'"d")
+FINDINGS_HIGH+=("CHK-H1"$'\x1f'"High thing"$'\x1f'"high"$'\x1f'"fix high"$'\x1f'"d")
+FINDINGS_MEDIUM+=("CHK-M1"$'\x1f'"Medium thing"$'\x1f'"medium"$'\x1f'"fix med"$'\x1f'"d")
+FINDINGS_LOW+=("CHK-L1"$'\x1f'"Low thing"$'\x1f'"low"$'\x1f'"fix low"$'\x1f'"d")
+FINDINGS_WARN+=("CHK-W1"$'\x1f'"Warn thing"$'\x1f'"medium"$'\x1f'$'\x1f'"d")
 ps_sev="$(print_summary 3 2>&1)"
 assert_contains "print_summary sev: CRITICAL shown" "$ps_sev" "CRITICAL"
 assert_contains "print_summary sev: HIGH shown"     "$ps_sev" "HIGH"


### PR DESCRIPTION
## Summary

Replaces the hand-rolled bash string-concat that built `scan-report.json` `findings[]` with a Python `json.dumps` emitter, and makes the `FINDINGS_*` pack/unpack robust against special characters.

**Root cause:** `_emit_finding_json` escaped only the double-quote (not backslashes or control chars), so a `details`/`remediation`/`location` value containing a backslash (e.g. a Windows path `C:\temp` → `\t`/`\u`) produced **invalid JSON**. The `|`-delimited pack + line-oriented `read` also truncated any real embedded newline and mis-split on a literal `|`.

## Changes
- **`scanner/lib/findings_json.py` (new):** stdin NUL-delimited / `\x1f`-field record stream → `json.dumps(..., ensure_ascii=False, separators=(",",":"))`. Preserves key order `id,title,severity,category,[details],[remediation],[location]` and omit-when-empty. Extracting the interpreter out of bash follows the established kcov pattern (cf. `prowler_compliance_summary.py`) and is covered by pytest.
- **`output.sh`:** `FINDINGS_*` entries packed with Unit Separator (`\x1f`, new `_FINDING_SEP`) instead of `|`; `fail()`/`warn()`/`_print_findings` updated. `_emit_finding_record` reads fields NUL-safely via `read -rd '' < <(printf ...)` (no herestring truncation). The record batch is written to a temp file with a **brace-group redirection** (`{ … } > file`, runs in the current shell so the loop stays visible to kcov) and fed to one `python3` process.
- **`injection.sh` `_format_hits`:** emits a real newline instead of a literal `\n` (so `json.dumps` escapes it correctly; net no change to rendered output).

## Test plan
- Real-newline + backslash + quote + literal-`|` `details` now round-trips **exactly** and produces valid JSON — asserted in `test_output_functions.sh` and `test_findings_json_pure.py` (new, 20 cases).
- `bash test_output_functions.sh` 191 · `test_generate_html_dashboard.sh` 36 · `test_output_coverage.sh` 71 pass.
- `CLAUDESEC_DASHBOARD_OFFLINE=1 pytest scanner/lib scanner/tests` → **1542 passed / 5 skipped**, scanner/lib **99%**; CI guards **324 passed**; `shellcheck -S error` clean.

## Review notes
Independently reviewed (sec-reviewer, sole lane — authoring agent was interrupted). Findings actioned:
- **HIGH (fixed in this PR):** the first cut captured the emission loop via `$( { … } | python3 )`; kcov cannot trace lines inside a pipe-left subshell / command substitution, dropping ~12 previously-covered `output.sh` lines and risking the 90% floor. Restructured to a brace-group file redirection so the loop runs in the current shell and stays traceable. **The definitive kcov % is confirmed by the CI `scanner-shell-coverage` job** (local macOS kcov v43 could not exercise bash tracing).
- **MEDIUM (pre-existing, out of scope):** `_print_findings` reads 6 packed fields into 4 vars, gluing `remediation+details+location` into the last var. Predates this PR (identical with the old `|` pack); tracked as a follow-up, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)