### PR TITLE
fix(scanner): read all 6 packed fields in _print_findings

### DIFF
--- a/scanner/lib/output.sh
+++ b/scanner/lib/output.sh
@@ -233,7 +233,12 @@ _print_findings() {
   local -n arr=$1
   local label="$2" show_fix="${3:-true}"
   for entry in "${arr[@]+"${arr[@]}"}"; do
-    IFS="$_FINDING_SEP" read -r f_id f_title _ f_fix <<< "$entry"
+    # Read all 6 packed fields (id/title/severity/remediation/details/location)
+    # so f_fix holds ONLY the remediation. Reading into 4 vars glued
+    # remediation+details+location into f_fix (with the \x1f separators still
+    # embedded, invisible since \x1f is non-printing) — a silent corruption of
+    # the summary "→ fix" hint. details/location are consumed but unused here.
+    IFS="$_FINDING_SEP" read -r f_id f_title _ f_fix _ _ <<< "$entry"
     local f_cat; f_cat=$(_finding_id_to_category "$f_id")
     echo -e "  ${label}${NC}  ${DIM}[$f_id]${NC} ${DIM}(${f_cat})${NC} $f_title"
     [[ "$show_fix" == "true" && -n "$f_fix" ]] && echo -e "          ${CYAN}→ $f_fix${NC}"

--- a/scanner/tests/test_output_functions.sh
+++ b/scanner/tests/test_output_functions.sh
@@ -515,6 +515,16 @@ _reset_state
 pf_empty="$(_print_findings FINDINGS_LOW "LOW" true 2>&1)"
 assert_eq "_print_findings: empty array no output" "" "$pf_empty"
 
+# 6-field entry (real fail() shape): the "→ fix" hint must show ONLY the
+# remediation, NOT details/location glued on. Regression pin for the 4-var
+# read that concatenated remediation+details+location into f_fix.
+_reset_state
+FINDINGS_HIGH+=("CHK-300"$'\x1f'"Six field"$'\x1f'"high"$'\x1f'"ROTATE_KEY"$'\x1f'"DETAIL_TEXT"$'\x1f'"/path/LOC_FILE")
+pf6="$(_print_findings FINDINGS_HIGH "HIGH" true 2>&1)"
+assert_contains     "_print_findings: 6-field remediation shown"      "$pf6" "ROTATE_KEY"
+assert_not_contains "_print_findings: 6-field details NOT glued"      "$pf6" "DETAIL_TEXT"
+assert_not_contains "_print_findings: 6-field location NOT glued"     "$pf6" "LOC_FILE"
+
 # ==============================================================================
 # Test Group 11: print_summary()
 # ==============================================================================


### PR DESCRIPTION
## Summary

`_print_findings` unpacked `FINDINGS_*` entries into only 4 variables (`read -r f_id f_title _ f_fix`), so bash dumped the remaining fields into the last variable: **`f_fix` became `remediation + details + location` glued together** with the `\x1f` separators still embedded. Since `\x1f` is non-printing, the summary `→ fix` hint rendered as the remediation silently run together with the details text and file path.

Fix: read all 6 packed fields (`id/title/severity/remediation/details/location`) so `f_fix` holds only the remediation; `details`/`location` are consumed by `_`.

## Context
Pre-existing bug flagged as MEDIUM in the #356 review — it predates the `\x1f` pack (the old `|` pack had the identical 4-var read). The tests missed it because they used 5-field entries plus substring assertions (`"fix this nowdetails"` still contains `"fix this now"`).

## Test plan
- Added a 6-field regression pin asserting the fix hint shows the remediation (`ROTATE_KEY`) but NOT the details (`DETAIL_TEXT`) or location (`LOC_FILE`). **Verified it FAILS without the fix** (2 assertions) and passes with it.
- `bash test_output_functions.sh` → 194 passed; `test_generate_html_dashboard.sh` 36; `test_output_coverage.sh` 71.
- `pytest scanner/lib scanner/tests` → 1542 passed / 5 skipped; CI guards 324 passed; `shellcheck -S error` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)