### PR TITLE
fix(scanner): merge FINDINGS_* arrays back from parallel category subshells

### DIFF
--- a/scanner/lib/checks.sh
+++ b/scanner/lib/checks.sh
@@ -291,6 +291,32 @@ collect_environment_info() {
 # SC2030/SC2031: subshell counter resets are intentional — each category subshell
 # writes counters to a temp file that the parent re-reads and aggregates.
 # (These were suppressed file-wide in scanner/claudesec before the extraction.)
+# Serialize a FINDINGS_* array to a NUL-separated file so a category subshell
+# can hand its findings back to the parent. Entries are \x1f-packed and may
+# contain real newlines (multi-line _format_hits details), but never a NUL, so
+# \0 is a safe record separator. An empty array yields a truncated (empty) file
+# — NOT a single empty record — which matters so the parent merge adds nothing.
+_write_findings_file() {
+  local file="$1"; shift
+  : > "$file"
+  local entry
+  for entry in "$@"; do
+    printf '%s\0' "$entry" >> "$file"
+  done
+}
+
+# Merge a NUL-separated findings file (written by _write_findings_file in a
+# subshell) into the named parent array. No-op if the file is missing or empty.
+_merge_findings_file() {
+  local file="$1"
+  local -n _target="$2"
+  [[ -f "$file" ]] || return 0
+  local entry
+  while IFS= read -r -d '' entry; do
+    _target+=("$entry")
+  done < "$file"
+}
+
 run_category_checks() {
   local parallel="$1" verbose="$2"; shift 2
   local categories=("$@")
@@ -331,6 +357,14 @@ run_category_checks() {
           > "$tmpdir/${cat}.counters"
         # Write JSON results for merging
         echo "$JSON_RESULTS" > "$tmpdir/${cat}.json"
+        # Hand the FINDINGS_* arrays back to the parent (counters + JSON alone
+        # left the parent's arrays empty, blanking the summary/dashboard
+        # findings in parallel mode).
+        _write_findings_file "$tmpdir/${cat}.crit" "${FINDINGS_CRITICAL[@]+"${FINDINGS_CRITICAL[@]}"}"
+        _write_findings_file "$tmpdir/${cat}.high" "${FINDINGS_HIGH[@]+"${FINDINGS_HIGH[@]}"}"
+        _write_findings_file "$tmpdir/${cat}.med"  "${FINDINGS_MEDIUM[@]+"${FINDINGS_MEDIUM[@]}"}"
+        _write_findings_file "$tmpdir/${cat}.low"  "${FINDINGS_LOW[@]+"${FINDINGS_LOW[@]}"}"
+        _write_findings_file "$tmpdir/${cat}.warn" "${FINDINGS_WARN[@]+"${FINDINGS_WARN[@]}"}"
       ) > "$tmpdir/${cat}.out" 2>&1 &
       pids+=($!)
     done
@@ -368,6 +402,13 @@ run_category_checks() {
           fi
         fi
       fi
+      # Merge the subshell's FINDINGS_* arrays back into the parent, in
+      # category order, so the summary + dashboard findings are populated.
+      _merge_findings_file "$tmpdir/${cat}.crit" FINDINGS_CRITICAL
+      _merge_findings_file "$tmpdir/${cat}.high" FINDINGS_HIGH
+      _merge_findings_file "$tmpdir/${cat}.med"  FINDINGS_MEDIUM
+      _merge_findings_file "$tmpdir/${cat}.low"  FINDINGS_LOW
+      _merge_findings_file "$tmpdir/${cat}.warn" FINDINGS_WARN
     done
     rm -rf "$tmpdir"
   else

--- a/scanner/tests/test_run_category_checks.sh
+++ b/scanner/tests/test_run_category_checks.sh
@@ -257,6 +257,49 @@ else
 fi
 
 # ==============================================================================
+# Group 10: parallel mode merges FINDINGS_* arrays back to the parent.
+# Regression for the writeback gap where each category subshell populated its
+# own FINDINGS_CRITICAL/HIGH/MEDIUM/LOW/WARN but only counters + JSON_RESULTS
+# crossed the subshell boundary — leaving the parent arrays empty, so the
+# summary "Severity Breakdown"/"Recommended Fixes" and the dashboard findings
+# table (both driven by FINDINGS_* lengths) rendered blank in parallel mode
+# even with a correct non-zero FAILED count.
+# ==============================================================================
+echo ""
+echo "=== parallel mode: FINDINGS_* arrays merged back to parent ==="
+
+mkdir -p "$CHECKS_DIR/cat_sev"
+cat > "$CHECKS_DIR/cat_sev/check.sh" <<'EOF'
+fail "SEV-CRIT" "crit finding" "critical" "fix-crit" "detail-crit" "/f/crit"
+fail "SEV-HIGH" "high finding" "high" "fix-high" "detail-high" "/f/high"
+fail "SEV-MED"  "med finding"  "medium"   "fix-med"  "detail-med"  "/f/med"
+fail "SEV-LOW"  "low finding"  "low"      "fix-low"  "detail-low"  "/f/low"
+warn "SEV-WARN" "warn finding" "warn detail"
+EOF
+
+# Baseline: sequential mode already populates the arrays
+_reset_state
+run_category_checks 0 0 cat_sev >/dev/null 2>&1
+assert_eq "seq: FINDINGS_CRITICAL=1" "1" "${#FINDINGS_CRITICAL[@]}"
+assert_eq "seq: FINDINGS_HIGH=1"     "1" "${#FINDINGS_HIGH[@]}"
+assert_eq "seq: FINDINGS_MEDIUM=1"   "1" "${#FINDINGS_MEDIUM[@]}"
+assert_eq "seq: FINDINGS_LOW=1"      "1" "${#FINDINGS_LOW[@]}"
+assert_eq "seq: FINDINGS_WARN=1"     "1" "${#FINDINGS_WARN[@]}"
+
+# Parallel mode MUST merge the same findings back (2 categories force the
+# parallel branch, which requires >1 category)
+_reset_state
+run_category_checks 1 0 cat_sev cat1 >/dev/null 2>&1
+assert_eq "parallel: FINDINGS_CRITICAL merged=1" "1" "${#FINDINGS_CRITICAL[@]}"
+assert_eq "parallel: FINDINGS_HIGH merged=1"     "1" "${#FINDINGS_HIGH[@]}"
+assert_eq "parallel: FINDINGS_MEDIUM merged=1"   "1" "${#FINDINGS_MEDIUM[@]}"
+assert_eq "parallel: FINDINGS_LOW merged=1"      "1" "${#FINDINGS_LOW[@]}"
+assert_eq "parallel: FINDINGS_WARN merged=1"     "1" "${#FINDINGS_WARN[@]}"
+# Content integrity: the packed \x1f entry survives the file round-trip
+assert_contains "parallel: crit entry id preserved"   "${FINDINGS_CRITICAL[0]:-}" "SEV-CRIT"
+assert_contains "parallel: high entry remediation"    "${FINDINGS_HIGH[0]:-}"     "fix-high"
+
+# ==============================================================================
 echo ""
 echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
 [[ "$TEST_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

In parallel scan mode (`--parallel` / `CLAUDESEC_DASHBOARD_PARALLEL=1`), `run_category_checks` runs each category in a subshell that populates its own `FINDINGS_CRITICAL/HIGH/MEDIUM/LOW/WARN` arrays — but only the counters (`TOTAL/PASSED/FAILED/WARNINGS/SKIPPED`) and `JSON_RESULTS` were written back to the parent. **The `FINDINGS_*` arrays were never merged, so they stayed empty in the caller.**

### Impact
Parallel mode produced a correct Security Score / pass-fail count / grade, but `print_summary`'s Severity Breakdown / Action Required / Recommended Fixes and `generate_html_dashboard`'s findings table + `scan-report.json` `findings[]` (all driven by `FINDINGS_*` lengths) rendered **blank** — a dashboard reporting "Grade F, N failed" with no findings listed. Only `--format json` (reads `JSON_RESULTS`) was unaffected.

Found by an independent scanner/lib audit (HIGH); reproduced empirically (`FAILED=1` but `FINDINGS_HIGH=0` in parallel; both correct sequentially).

## Fix
Each subshell serializes its `FINDINGS_*` arrays to **NUL-separated files** (entries are `\x1f`-packed and may contain real newlines from multi-line `_format_hits` details, but never a NUL, so `\0` is a safe record separator); the parent merges them back **in category order** via two helpers (`_write_findings_file` / `_merge_findings_file`). Empty arrays yield truncated files so the merge adds nothing.

## Test plan
- **TDD regression** in `test_run_category_checks.sh`: a category emitting one finding of each severity + a warn, asserted present in the parent arrays after BOTH sequential and parallel runs. The 7 parallel assertions **fail without this fix** (verified: 31 passed/7 failed → 38 passed/0 failed).
- Verified empirically that a **multi-line + pipe + quote** detail round-trips intact through the NUL-delimited merge.
- `shellcheck -S error scanner/lib/checks.sh` clean; `pytest scanner/lib scanner/tests` 1542 passed / 5 skipped; CI guards 324 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)