### PR TITLE
fix(scanner): make append_json emit spec-valid JSON for control chars

### DIFF
--- a/scanner/lib/output.sh
+++ b/scanner/lib/output.sh
@@ -185,12 +185,49 @@ _finding_ref_url() {
   esac
 }
 
+# JSON-escape a string for embedding inside a double-quoted JSON value, per
+# RFC 8259 §7. Handles backslash, double-quote, and every C0 control character
+# (U+0000–U+001F): \b \t \n \f \r use their two-char short escapes, any other
+# control char uses \u00XX. The previous append_json escaping handled only \
+# and " — so a finding whose details carried a real embedded newline (the
+# multi-line _format_hits output noted at the top of this file) or a tab
+# produced INVALID JSON in the --format json / scan-report.json output. This is
+# the CLI-path analog of the backslash bug findings_json.py's json.dumps fixed
+# for the dashboard; both paths now emit spec-valid JSON for the same inputs.
+# NUL (U+0000) cannot occur here — bash strips NUL bytes from string values.
+# Writes the escaped string to the global _JSON_ESCAPED (no subshell, so this
+# stays cheap on append_json's hot path — it runs once per check).
+_JSON_ESCAPED=""
+_json_escape_str() {
+  local s="$1"
+  s="${s//\\/\\\\}"   # backslash FIRST, before other rules add backslashes
+  s="${s//\"/\\\"}"
+  s="${s//$'\b'/\\b}"
+  s="${s//$'\f'/\\f}"
+  s="${s//$'\n'/\\n}"
+  s="${s//$'\r'/\\r}"
+  s="${s//$'\t'/\\t}"
+  # Remaining C0 controls (rare — raw bytes from a scanned file) → \u00XX.
+  # Guarded by one glob test so the common control-free path pays nothing more.
+  if [[ "$s" == *[[:cntrl:]]* ]]; then
+    local i byte esc
+    for i in 1 2 3 4 5 6 7 11 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31; do
+      printf -v byte '%b' "$(printf '\\%03o' "$i")"
+      printf -v esc '\\u%04x' "$i"
+      s="${s//"$byte"/$esc}"
+    done
+  fi
+  _JSON_ESCAPED="$s"
+}
+
 append_json() {
   local id="$1" title="$2" status="$3" details="$4" severity="${5:-}" location="${6:-}"
-  # Escape JSON strings
-  title="${title//\\/\\\\}"; title="${title//\"/\\\"}"
-  details="${details//\\/\\\\}"; details="${details//\"/\\\"}"
-  location="${location//\\/\\\\}"; location="${location//\"/\\\"}"
+  # Escape JSON strings (id/status/severity/category/ref_url are developer-
+  # controlled fixed vocabularies; only title/details/location carry scanned
+  # content and can contain quotes/backslashes/control chars).
+  _json_escape_str "$title";    title="$_JSON_ESCAPED"
+  _json_escape_str "$details";  details="$_JSON_ESCAPED"
+  _json_escape_str "$location"; location="$_JSON_ESCAPED"
   local category ref_url
   category="$(_finding_id_to_category "$id")"
   ref_url="$(_finding_ref_url "$id")"

--- a/scanner/tests/test_output_functions.sh
+++ b/scanner/tests/test_output_functions.sh
@@ -128,6 +128,92 @@ append_json "CHK-001" "No location" "pass" "" ""
 assert_not_contains "empty location: no location key" "$JSON_RESULTS" '"location"'
 
 # ==============================================================================
+# Test Group 1b: append_json() control-character / valid-JSON regression
+# Guards the RFC 8259 §7 escaper (_json_escape_str). Before it, append_json
+# escaped only \ and ", so a detail with a real newline/tab/backslash yielded
+# INVALID JSON in the --format json output. Each case asserts the whole
+# JSON_RESULTS array parses with json.loads AND the field round-trips.
+# ==============================================================================
+echo ""
+echo "=== append_json() control-char / valid-JSON regression ==="
+
+# python3 is required to validate; skip the group (not fail) if unavailable so
+# the suite stays runnable on minimal hosts, matching output.sh's own guard.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  SKIP: python3 not available — JSON validity regression group skipped"
+else
+  # Parse JSON_RESULTS and print the value at results[0].<key>, or "__ERR__"
+  # on any parse error. Reads JSON from argv (not stdin) so embedded control
+  # chars survive the shell boundary as-is.
+  _json_field() {
+    python3 - "$1" "$2" <<'PY'
+import json, sys
+raw, key = sys.argv[1], sys.argv[2]
+try:
+    arr = json.loads(raw)
+    sys.stdout.write(str(arr[0].get(key, "__MISSING__")))
+except Exception:
+    sys.stdout.write("__ERR__")
+PY
+  }
+
+  # 1b-1. Embedded real newline in details (the multi-line _format_hits case)
+  _reset_state
+  append_json "CHK-NL" "nl title" "fail" $'line1\nline2' "high"
+  nl_details="$(_json_field "$JSON_RESULTS" details)"
+  assert_eq "newline: details round-trips (real newline preserved)" $'line1\nline2' "$nl_details"
+
+  # 1b-2. Tab + carriage return in details
+  _reset_state
+  append_json "CHK-TAB" "tab title" "fail" $'a\tb\rc' "high"
+  tab_details="$(_json_field "$JSON_RESULTS" details)"
+  assert_eq "tab/cr: details round-trips" $'a\tb\rc' "$tab_details"
+
+  # 1b-3. Backslash (Windows path) — old escaper handled \ but the array must
+  # still parse cleanly alongside the quote handling.
+  _reset_state
+  append_json "CHK-BS" 'C:\temp\file' "fail" 'path C:\Users\x' "high" 'C:\loc'
+  bs_title="$(_json_field "$JSON_RESULTS" title)"
+  bs_loc="$(_json_field "$JSON_RESULTS" location)"
+  assert_eq "backslash: title round-trips"    'C:\temp\file'  "$bs_title"
+  assert_eq "backslash: location round-trips" 'C:\loc'        "$bs_loc"
+
+  # 1b-4. Quote + backslash together must not corrupt the array
+  _reset_state
+  append_json "CHK-Q" 'say "hi" \n not-a-newline' "fail" "d" "high"
+  q_title="$(_json_field "$JSON_RESULTS" title)"
+  assert_eq "quote+backslash: title round-trips" 'say "hi" \n not-a-newline' "$q_title"
+
+  # 1b-5. Exotic C0 control char (0x07 BEL) → , array still valid
+  _reset_state
+  append_json "CHK-BEL" "bel" "fail" $'x\x07y' "high"
+  bel_valid="$(_json_field "$JSON_RESULTS" id)"
+  assert_eq "bel(0x07): array parses and id intact" "CHK-BEL" "$bel_valid"
+  bel_details="$(_json_field "$JSON_RESULTS" details)"
+  assert_eq "bel(0x07): details round-trips" $'x\x07y' "$bel_details"
+
+  # 1b-6. fail() end-to-end (multi-line details via the real code path)
+  _reset_state
+  fail "CODE-INJ-001" "injection" "critical" $'hit1\nhit2' "fix it" "app.js:42"
+  fj_details="$(_json_field "$JSON_RESULTS" details)"
+  assert_eq "fail(): multi-line details round-trips" $'hit1\nhit2' "$fj_details"
+
+  # 1b-7. Backspace (0x08) and form-feed (0x0C) short escapes — the two C0
+  # short-escape rules not otherwise covered by the newline/tab cases above.
+  _reset_state
+  append_json "CHK-BF" "bf" "fail" $'a\bb\fc' "high"
+  bf_details="$(_json_field "$JSON_RESULTS" details)"
+  assert_eq "backspace/formfeed: details round-trips" $'a\bb\fc' "$bf_details"
+
+  # 1b-8. DEL (0x7F) is NOT a C0 control and must pass through unescaped,
+  # matching json.dumps(ensure_ascii=False) — the array must still parse.
+  _reset_state
+  append_json "CHK-DEL" "del" "fail" $'x\x7fy' "high"
+  del_details="$(_json_field "$JSON_RESULTS" details)"
+  assert_eq "DEL(0x7f): details round-trips unescaped" $'x\x7fy' "$del_details"
+fi
+
+# ==============================================================================
 # Test Group 2: fail()
 # ==============================================================================
 echo ""


### PR DESCRIPTION
## Summary

`append_json` (`scanner/lib/output.sh`) escaped only `\` and `"`, so a finding whose `details` carried a **real embedded newline** (multi-line `_format_hits` output — see the note at the top of `output.sh`) or a tab produced **invalid JSON** in the `--format json` / `scan-report.json` output. This is the CLI-path analog of the backslash bug that `findings_json.py`'s `json.dumps` fixed for the dashboard (#356).

This PR unifies the CLI path on spec-valid JSON escaping — pure bash, no python dependency added to the `--format json` path.

## Changes

- **`scanner/lib/output.sh`** — new `_json_escape_str` helper (RFC 8259 §7): backslash → quote → `\b \f \n \r \t` short escapes → any other C0 control (U+0001–U+001F) as `\u00XX`. Applied to `title`/`details`/`location` in `append_json`. Writes to global `_JSON_ESCAPED` (no subshell on the once-per-check hot path).
- **`scanner/tests/test_output_functions.sh`** — control-char / valid-JSON regression group (10 cases): each asserts `JSON_RESULTS` parses with `json.loads` **and** the field round-trips.

## Parity & robustness

- Output is **byte-identical to `json.dumps(ensure_ascii=False)`** for the same input (DEL `0x7F` and non-ASCII left unescaped), so the CLI (`append_json`) and dashboard (`findings_json.py`) paths now agree.
- The loop list `{1-7,11,14-31}` is exactly the complement of the short-escape set `{8,9,10,12,13}` — no double-replace, no missed code point. NUL (`0x00`) can't occur (bash strips it).
- Eliminating raw newlines from `JSON_RESULTS` makes the `--parallel` bracket-splice merge in `checks.sh:391` strictly more robust (net positive, no behavior change to the mechanism).

## Test plan

- [x] `bash scanner/tests/test_output_functions.sh` → **204 passed, 0 failed** (incl. 10 new cases)
- [x] `shellcheck -x --severity=error` (matches CI) → clean on both files
- [x] No regression in adjacent JSON tests: `test_run_category_checks` 38/38, `test_output_coverage` 71/71, `test_save_scan_history_ocsf` 6/6
- [x] Independent `sec-reviewer` pass: no correctness defects; escaping order, complement loop list, and parallel-merge interaction all verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)