### PR TITLE
fix(scanner): JSON-escape SCAN_DIR and Datadog service/env in hand-built JSON

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -179,6 +179,8 @@ jobs:
         run: bash scanner/tests/test_kube_discovery.sh
       - name: Run bash unit tests (output.sh functions)
         run: bash scanner/tests/test_output_functions.sh
+      - name: Run bash unit tests (datadog JSON payload escaping)
+        run: bash scanner/tests/test_datadog_json_payloads.sh
       - name: Run bash unit tests (checks.sh run_category_checks)
         run: bash scanner/tests/test_run_category_checks.sh
       - name: Run bash unit tests (infra/docker checks)

--- a/scanner/lib/datadog.sh
+++ b/scanner/lib/datadog.sh
@@ -169,12 +169,25 @@ collect_datadog_dashboard_artifacts() {
   local dd_tags="service:${dd_service},env:${dd_env},ci_pipeline_id:${run_id}"
   local dd_query="service:${dd_service} env:${dd_env} ci_pipeline_id:${run_id}"
 
+  # JSON-escape the config/env-derived values before embedding them in the
+  # intake/query payload heredocs. DD_SERVICE / DD_ENV come from the
+  # environment, so a value containing a " or \ (e.g. DD_ENV='a" ,"x":"y')
+  # would otherwise emit an invalid — or structurally injected — request body.
+  # _json_escape_str is defined in output.sh, which the claudesec entrypoint
+  # sources before this file (see the header note). The URL-embedded dd_tags is
+  # a separate (URL) surface and intentionally left unchanged here.
+  local dd_service_j dd_env_j run_id_j dd_query_j
+  _json_escape_str "$dd_service"; dd_service_j="$_JSON_ESCAPED"
+  _json_escape_str "$dd_env";     dd_env_j="$_JSON_ESCAPED"
+  _json_escape_str "$run_id";     run_id_j="$_JSON_ESCAPED"
+  _json_escape_str "$dd_query";   dd_query_j="$_JSON_ESCAPED"
+
   cat > "$dd_dir/intake.json" <<JSON
 {
   "message": "ClaudeSec local dashboard run",
-  "service": "${dd_service}",
-  "env": "${dd_env}",
-  "ci_pipeline_id": "${run_id}",
+  "service": "${dd_service_j}",
+  "env": "${dd_env_j}",
+  "ci_pipeline_id": "${run_id_j}",
   "status": "info",
   "source": "claudesec-local"
 }
@@ -189,7 +202,7 @@ JSON
   "filter": {
     "from": "${from_1h_ts}",
     "to": "${to_ts}",
-    "query": "${dd_query}"
+    "query": "${dd_query_j}"
   },
   "sort": "timestamp",
   "page": { "limit": 200 }

--- a/scanner/lib/output.sh
+++ b/scanner/lib/output.sh
@@ -420,10 +420,19 @@ print_json_summary() {
   local active=$((TOTAL_CHECKS - SKIPPED))
   local score=0
   [[ $active -gt 0 ]] && score=$(( (PASSED * 100) / active ))
+  # JSON-escape the two free-form string fields. VERSION is a developer-set
+  # constant but SCAN_DIR is a scan-target path: a directory containing a
+  # literal " or \ (e.g. /tmp/pro"ject or a Windows path) would otherwise
+  # break this --format json output as invalid JSON (same class as the
+  # append_json control-char bug fixed in #359, but this CLI-summary path
+  # never went through _json_escape_str).
+  local version_esc scan_dir_esc
+  _json_escape_str "$VERSION";  version_esc="$_JSON_ESCAPED"
+  _json_escape_str "$SCAN_DIR"; scan_dir_esc="$_JSON_ESCAPED"
   cat <<EOF
 {
-  "version": "$VERSION",
-  "scan_directory": "$SCAN_DIR",
+  "version": "$version_esc",
+  "scan_directory": "$scan_dir_esc",
   "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
   "duration_seconds": $duration,
   "summary": {

--- a/scanner/tests/test_datadog_json_payloads.sh
+++ b/scanner/tests/test_datadog_json_payloads.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034,SC1091
+# Regression: collect_datadog_dashboard_artifacts() must emit VALID JSON request
+# payloads (intake.json / query.json) even when DD_SERVICE / DD_ENV carry a
+# double-quote, backslash, or newline.
+#
+# Risk #2 of the 2026-07-27 JSON-escaping audit: the intake/query heredocs
+# interpolated $dd_service / $dd_env / $dd_query raw, so an env value like
+# DD_ENV='a" ,"injected":"1' produced an invalid — or structurally injected —
+# request body POSTed to Datadog's API. Fixed by routing those values through
+# _json_escape_str (output.sh) before embedding.
+#
+# The function writes the payloads, POSTs them, then `rm -f`s them at the end,
+# so this test CAPTURES each payload inside stubbed network calls (the exact
+# bytes that would be sent) rather than reading the deleted files. No network:
+# run_with_timeout / curl / datadog_api_request_with_retry are all stubbed.
+#
+# Run: bash scanner/tests/test_datadog_json_payloads.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_DIR="$SCRIPT_DIR/../lib"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $label"; ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected: $(printf '%q' "$expected")"
+    echo "    actual:   $(printf '%q' "$actual")"
+    ((TEST_FAILED++))
+  fi
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  SKIP: python3 not available — datadog JSON payload test skipped"
+  echo ""
+  echo "=== Results: 0 passed, 0 failed (skipped) ==="
+  exit 0
+fi
+
+# Color codes + vars the sourced libs consult
+RED="" GREEN="" YELLOW="" CYAN="" DIM="" NC="" BOLD="" BLUE="" MAGENTA=""
+FORMAT="json"; QUIET=1; SEVERITY="all"; VERSION="test"
+
+# datadog.sh's header notes it is sourced AFTER output.sh (for _json_escape_str)
+# and checks.sh (for run_with_timeout) — replicate that order here.
+source "$LIB_DIR/output.sh"
+source "$LIB_DIR/checks.sh"
+source "$LIB_DIR/datadog.sh"
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+SCAN_DIR="$tmpdir"
+capture="$tmpdir/captured"
+mkdir -p "$capture"
+
+# ── Network stubs: capture each outbound JSON payload (the deleted-after-POST
+# files) so we can assert on the exact bytes that would be sent. ───────────────
+# intake.json goes out via `run_with_timeout ... curl ... -d @"$dd_dir/intake.json"`.
+run_with_timeout() {
+  cp "$SCAN_DIR/.claudesec-datadog/intake.json" "$capture/intake.json" 2>/dev/null || true
+  return 0
+}
+curl() { return 0; }
+# query.json / signals-query.json are passed as the 4th arg (data_file). Return
+# non-zero so the caller writes its valid {"data":[]} fallback (keeps the
+# end-of-function sanitizer's input valid).
+datadog_api_request_with_retry() {
+  local data_file="${4:-}"
+  if [[ -n "$data_file" && -f "$data_file" ]]; then
+    cp "$data_file" "$capture/$(basename "$data_file")" 2>/dev/null || true
+  fi
+  return 1
+}
+
+export DD_API_KEY="dummy-key" DD_APP_KEY="dummy-app-key"
+# Hostile env: DD_ENV attempts structural key injection; DD_SERVICE carries a
+# quote + backslash; a newline is thrown in for the C0 path.
+export DD_SERVICE=$'svc"\\x' DD_ENV=$'e" ,"injected":"1\nline2'
+
+collect_datadog_dashboard_artifacts >/dev/null 2>&1
+
+# ── intake.json ────────────────────────────────────────────────────────────
+echo ""
+echo "=== intake.json: valid JSON + no structural injection ==="
+assert_eq "intake.json captured" "true" \
+  "$([[ -f "$capture/intake.json" ]] && echo true || echo false)"
+assert_eq "intake.json is valid JSON" "0" \
+  "$(python3 -m json.tool "$capture/intake.json" >/dev/null 2>&1; echo $?)"
+# The injected key name must NOT appear as a real top-level key — it must be
+# trapped inside the "env" string value.
+intake_check="$(python3 - "$capture/intake.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1], encoding="utf-8"))
+top = set(d.keys())
+ok = "injected" not in top and d.get("env") == 'e" ,"injected":"1\nline2' and d.get("service") == 'svc"\\x'
+sys.stdout.write("OK" if ok else "BAD:%s" % sorted(top))
+PY
+)"
+assert_eq "intake.json: no injected key, env/service round-trip" "OK" "$intake_check"
+
+# ── query.json ─────────────────────────────────────────────────────────────
+echo ""
+echo "=== query.json: valid JSON with hostile query string ==="
+assert_eq "query.json captured" "true" \
+  "$([[ -f "$capture/query.json" ]] && echo true || echo false)"
+assert_eq "query.json is valid JSON" "0" \
+  "$(python3 -m json.tool "$capture/query.json" >/dev/null 2>&1; echo $?)"
+query_check="$(python3 - "$capture/query.json" <<'PY'
+import json, sys
+d = json.load(open(sys.argv[1], encoding="utf-8"))
+q = d.get("filter", {}).get("query", "")
+# The hostile service value must survive inside the query string, not break out.
+sys.stdout.write("OK" if 'svc"\\x' in q and "injected" not in d and "injected" not in d.get("filter", {}) else "BAD")
+PY
+)"
+assert_eq "query.json: hostile service contained in query string" "OK" "$query_check"
+
+# ==============================================================================
+echo ""
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+[[ "$TEST_FAILED" -eq 0 ]] || exit 1

--- a/scanner/tests/test_output_functions.sh
+++ b/scanner/tests/test_output_functions.sh
@@ -731,6 +731,24 @@ TOTAL_CHECKS=3; PASSED=0; FAILED=0; WARNINGS=0; SKIPPED=3
 js_skip="$(print_json_summary 1 2>&1)"
 assert_contains "print_json_summary: skipped=total score 0" "$js_skip" '"score": 0'
 
+# Hostile scan_directory: a scan-target path containing a double-quote,
+# backslash, or tab must NOT break the --format json output (Risk #1, 2026-07-27
+# JSON-escaping audit — print_json_summary interpolated $SCAN_DIR raw, the same
+# invalid-JSON class the append_json control-char escaper fixed in #359). Assert
+# the whole object parses AND scan_directory round-trips byte-for-byte.
+if command -v python3 >/dev/null 2>&1; then
+  _reset_state
+  TOTAL_CHECKS=1; PASSED=1; FAILED=0; WARNINGS=0; SKIPPED=0
+  OLD_SCAN_DIR="$SCAN_DIR"
+  SCAN_DIR=$'/tmp/pro"ject\\x\ttab'
+  js_hostile="$(print_json_summary 1 2>&1)"
+  assert_eq "print_json_summary: hostile scan_directory -> valid JSON" "0" \
+    "$(printf '%s' "$js_hostile" | python3 -m json.tool >/dev/null 2>&1; echo $?)"
+  hostile_sd="$(printf '%s' "$js_hostile" | python3 -c 'import sys,json; sys.stdout.write(json.load(sys.stdin)["scan_directory"])' 2>/dev/null)"
+  assert_eq "print_json_summary: scan_directory round-trips" $'/tmp/pro"ject\\x\ttab' "$hostile_sd"
+  SCAN_DIR="$OLD_SCAN_DIR"
+fi
+
 # ==============================================================================
 # Test Group 13: save_scan_history
 # ==============================================================================


### PR DESCRIPTION
## Summary

Fixes **Risk #1 & #2** from the 2026-07-27 JSON-escaping audit — two hand-built
JSON emitters that interpolated free-form values raw, the same invalid-JSON
class the `append_json` control-char escaper fixed in #359 but on paths that
never went through `_json_escape_str`:

| Risk | Site | Fix |
|------|------|-----|
| #1 MEDIUM | `output.sh` `print_json_summary` (`--format json`) — `$SCAN_DIR` raw in `"scan_directory"` | escape `VERSION` + `SCAN_DIR` via `_json_escape_str` |
| #2 MEDIUM | `datadog.sh` intake/query payload heredocs — `$dd_service`/`$dd_env`/`$dd_query` raw | escape via `_json_escape_str` (already in scope; URL `dd_tags` left as separate surface) |

A scan-target path like `/tmp/pro"ject` (Risk #1) or `DD_ENV='a" ,"injected":"1'`
(Risk #2) previously emitted **invalid — or structurally key-injected — JSON**.

**Risk #3** (`scan-tools.sh` `url_effective`) intentionally left as-is: the audit
confirmed its blast radius is contained by `_safe_load_json`'s try/except (no
injection reaches the `json.dumps`-rebuilt final report).

## Test plan
- [x] `shellcheck --severity=error` clean on both libs + tests
- [x] **Empirically reproduced** both bugs on `origin/main`, confirmed fixed
- [x] `test_output_functions.sh` → hostile `scan_directory` valid JSON + round-trip (**206 passed**)
- [x] `test_datadog_json_payloads.sh` (new) → captures intake/query payloads inside stubbed network calls (they are `rm -f`'d after POST), asserts valid JSON + no structural injection under hostile `DD_SERVICE`/`DD_ENV` (**6 passed**)
- [x] **Mutation-verified**: reverting the escape fails the new assertions (output 2 fail, datadog 4 fail)
- [x] `pytest scanner/lib` coverage **99.14%** (≥99 floor); CI guard suite 324 passed (incl. `no_code_injection_regression`)
- [x] New datadog test registered in `lint.yml` `scanner-unit-tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)