### PR TITLE
fix(scanner): percent-encode Datadog ddtags URL query values

### DIFF
--- a/scanner/lib/datadog.sh
+++ b/scanner/lib/datadog.sh
@@ -139,6 +139,29 @@ datadog_api_request_with_retry() {
   return 1
 }
 
+# Percent-encode a string for safe use as a URL query VALUE (RFC 3986): the
+# unreserved set (A-Z a-z 0-9 . ~ _ -) passes through, every other byte becomes
+# %HH. Pure bash (no curl/python subprocess) so it works offline and needs no
+# extra dependency. Byte-wise via LC_ALL=C, with a signed-byte guard (`ord < 0`)
+# so multibyte/high bytes encode correctly on every bash the scanner supports
+# (>= 4.3, the nameref floor). Writes the result to the global _URL_ENCODED.
+_URL_ENCODED=""
+_url_encode() {
+  local s="$1" out="" i c ord
+  local LC_ALL=C
+  for (( i=0; i<${#s}; i++ )); do
+    c="${s:i:1}"
+    case "$c" in
+      [a-zA-Z0-9.~_-]) out+="$c" ;;
+      *) printf -v ord '%d' "'$c"
+         (( ord < 0 )) && (( ord += 256 ))
+         printf -v c '%%%02X' "$ord"
+         out+="$c" ;;
+    esac
+  done
+  _URL_ENCODED="$out"
+}
+
 collect_datadog_dashboard_artifacts() {
   local datadog_enabled="${CLAUDESEC_DATADOG_FETCH_CLOUD_SECURITY:-1}"
   [[ "$datadog_enabled" == "0" ]] && return 0
@@ -166,7 +189,16 @@ collect_datadog_dashboard_artifacts() {
   run_id="local-$(date +%s)"
   local dd_service="${DD_SERVICE:-claudesec}"
   local dd_env="${DD_ENV:-local}"
-  local dd_tags="service:${dd_service},env:${dd_env},ci_pipeline_id:${run_id}"
+  # Percent-encode the env-derived VALUES before splicing them into the ddtags
+  # URL query below. The key:value / comma separators of the ddtags syntax stay
+  # literal, but the values themselves are encoded, so a DD_SERVICE / DD_ENV
+  # containing `&`, a space, `#`, or `"` (from the CI environment) cannot append
+  # spurious query parameters or otherwise break the outbound intake URL.
+  local dd_service_u dd_env_u run_id_u
+  _url_encode "$dd_service"; dd_service_u="$_URL_ENCODED"
+  _url_encode "$dd_env";     dd_env_u="$_URL_ENCODED"
+  _url_encode "$run_id";     run_id_u="$_URL_ENCODED"
+  local dd_tags="service:${dd_service_u},env:${dd_env_u},ci_pipeline_id:${run_id_u}"
   local dd_query="service:${dd_service} env:${dd_env} ci_pipeline_id:${run_id}"
 
   # JSON-escape the config/env-derived values before embedding them in the

--- a/scanner/tests/test_datadog_json_payloads.sh
+++ b/scanner/tests/test_datadog_json_payloads.sh
@@ -36,6 +36,30 @@ assert_eq() {
   fi
 }
 
+assert_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" == *"$needle"* ]]; then
+    echo "  PASS: $label"; ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected to contain: $(printf '%q' "$needle")"
+    echo "    actual:              $(printf '%q' "$haystack")"
+    ((TEST_FAILED++))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" haystack="$2" needle="$3"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  PASS: $label"; ((TEST_PASSED++))
+  else
+    echo "  FAIL: $label"
+    echo "    expected NOT to contain: $(printf '%q' "$needle")"
+    echo "    actual:                  $(printf '%q' "$haystack")"
+    ((TEST_FAILED++))
+  fi
+}
+
 if ! command -v python3 >/dev/null 2>&1; then
   echo "  SKIP: python3 not available — datadog JSON payload test skipped"
   echo ""
@@ -63,7 +87,10 @@ mkdir -p "$capture"
 # ── Network stubs: capture each outbound JSON payload (the deleted-after-POST
 # files) so we can assert on the exact bytes that would be sent. ───────────────
 # intake.json goes out via `run_with_timeout ... curl ... -d @"$dd_dir/intake.json"`.
+# Also record the full arg list so we can assert on the ddtags URL query built
+# into the intake POST (the injection surface fixed by _url_encode).
 run_with_timeout() {
+  printf '%s\n' "$*" > "$capture/intake-args.txt"
   cp "$SCAN_DIR/.claudesec-datadog/intake.json" "$capture/intake.json" 2>/dev/null || true
   return 0
 }
@@ -121,6 +148,25 @@ sys.stdout.write("OK" if 'svc"\\x' in q and "injected" not in d and "injected" n
 PY
 )"
 assert_eq "query.json: hostile service contained in query string" "OK" "$query_check"
+
+# ── ddtags URL query (percent-encoding) ──────────────────────────────────────
+# The intake POST URL is `.../v1/input?ddtags=service:<svc>,env:<env>,...`. The
+# env-derived values must be percent-encoded so a DD_SERVICE/DD_ENV containing a
+# space, ", or & cannot break the URL or append spurious query parameters.
+echo ""
+echo "=== ddtags URL query: env values percent-encoded ==="
+intake_args="$(cat "$capture/intake-args.txt" 2>/dev/null || true)"
+# DD_SERVICE=$'svc"\\x' -> svc%22%5Cx ; DD_ENV contains a space and a " -> %20 %22
+assert_contains "ddtags: structural prefix present"        "$intake_args" "ddtags=service:"
+assert_contains "ddtags: DD_SERVICE quote/backslash encoded" "$intake_args" "service:svc%22%5Cx"
+assert_contains "ddtags: DD_ENV space encoded (%20)"       "$intake_args" "%20"
+assert_contains "ddtags: DD_ENV quote encoded (%22)"       "$intake_args" "%22"
+# The raw hostile chars must NOT appear literally inside the ddtags value: a raw
+# space would end the URL, a raw " could break shell/HTTP handling. Isolate the
+# ddtags token (up to the next whitespace) and assert it is clean.
+ddtags_token="$(printf '%s\n' "$intake_args" | grep -oE 'ddtags=[^ ]*' | head -1)"
+assert_not_contains "ddtags: no raw double-quote in value"  "$ddtags_token" '"'
+assert_not_contains "ddtags: no raw backslash in value"     "$ddtags_token" '\'
 
 # ==============================================================================
 echo ""


### PR DESCRIPTION
## Summary

Follow-up to the **#361 sec-review**, which flagged the URL-embedded `dd_tags` as
a separate un-addressed surface (the JSON payloads were fixed in #361).

`collect_datadog_dashboard_artifacts` posts the intake event to:

```
.../v1/input?ddtags=service:<svc>,env:<env>,ci_pipeline_id:<id>
```

with the env-derived values (`DD_SERVICE` / `DD_ENV`) spliced **raw** into the URL
query. A value containing `&`, a space, `#`, or `"` (these come from the CI
environment) could append spurious query parameters or break the outbound URL.

### Fix
- New pure-bash `_url_encode` helper: RFC 3986 unreserved set passes through, every other byte → `%HH` (byte-wise via `LC_ALL=C` with a signed-byte guard so high/multibyte bytes encode correctly on every bash ≥4.3, the scanner's nameref floor). No curl/python subprocess — works offline.
- `dd_service`/`dd_env`/`run_id` percent-encoded before building `dd_tags`. The `key:value`/comma separators stay literal (tag syntax); only values are encoded, so a value can inject neither a new tag nor a new query parameter.
- URL-only surface; the JSON payloads (#361) are unchanged.

## Test plan
- [x] `shellcheck --severity=error` clean
- [x] `_url_encode` unit-checked: `a&b c#d"e`→`a%26b%20c%23d%22e`, `x,y:z`→`x%2Cy%3Az`, `küber`→`k%C3%BCber` (UTF-8), identical on bash **3.2 and 5.3**
- [x] `test_datadog_json_payloads.sh` extended: captures the intake POST args, asserts hostile `DD_SERVICE`/`DD_ENV` appear `%`-encoded (`%22 %20 %5C`) with no raw quote/backslash in the ddtags token (**12 passed**, both bash versions)
- [x] **Mutation-verified**: reverting to raw values fails 5 assertions
- [x] CI guards pass (incl. `no_code_injection_regression`); test already registered in `lint.yml` (added in #361)

🤖 Generated with [Claude Code](https://claude.com/claude-code)