### PR TITLE
fix(scanner): HTML-escape Prowler provider name in dashboard (stored XSS)

### DIFF
--- a/scanner/lib/dashboard_html_builders.py
+++ b/scanner/lib/dashboard_html_builders.py
@@ -232,7 +232,12 @@ def _build_provider_cards(prov_summary):
     prov_labels = PROVIDER_LABELS_SHORT
     for pname, pdata in sorted(prov_summary.items()):
         icon = prov_icons.get(pname, "☁")
-        label = prov_labels.get(pname, pname)
+        # HTML-escape: an unknown provider falls back to the raw slug, which is
+        # derived from the OCSF artifact FILENAME (dashboard_data_loader) and can
+        # carry HTML metacharacters (< > " ' &) — stored XSS in this Overview
+        # card without escaping. Known slugs map to static ASCII labels, so h()
+        # is a no-op for them. Python analog of the output_prowler.sh fix (#362).
+        label = h(prov_labels.get(pname, pname))
         ptotal = pdata["total_fail"] + pdata["total_pass"]
         pfail = pdata["total_fail"]
         pcrit = pdata["critical"]

--- a/scanner/lib/dashboard_html_sections.py
+++ b/scanner/lib/dashboard_html_sections.py
@@ -106,7 +106,7 @@ def _build_prov_table(prov_summary) -> str:
                 "low": 0,
             }
         seen.add(pname)
-        label = _prov_labels.get(pname, pname)
+        label = h(_prov_labels.get(pname, pname))
         subtab = _subtab_map.get(pname)
         onclick = (
             f' onclick="switchProvTab(\'{h(subtab)}\')" style="cursor:pointer"'
@@ -122,7 +122,7 @@ def _build_prov_table(prov_summary) -> str:
     for pname, pdata in sorted(prov_summary.items()):
         if pname in seen:
             continue
-        label = _prov_labels.get(pname, pname)
+        label = h(_prov_labels.get(pname, pname))
         subtab = _subtab_map.get(pname)
         onclick = (
             f' onclick="switchProvTab(\'{h(subtab)}\')" style="cursor:pointer"'

--- a/scanner/tests/test_dashboard_builders_unit.py
+++ b/scanner/tests/test_dashboard_builders_unit.py
@@ -510,3 +510,15 @@ def test_prov_table_googleworkspace_zero_shows_not_run():
     html = _build_prov_table({"googleworkspace": {"total_fail": 0, "total_pass": 0,
                                                    "critical": 0, "high": 0, "medium": 0, "low": 0}})
     assert "prov-row-no-data" in html
+
+
+def test_prov_table_unknown_provider_name_html_escaped():
+    """An unknown provider name (extras loop, from an OCSF FILENAME) carrying
+    HTML metacharacters must be HTML-escaped in the summary table cell — stored
+    XSS regression (Python analog of the output_prowler.sh #362 fix)."""
+    payload = '<img src=x onerror=alert(1)>'
+    html = _build_prov_table({payload: {"total_fail": 1, "total_pass": 0,
+                                        "critical": 0, "high": 0,
+                                        "medium": 0, "low": 0}})
+    assert "<img src=x" not in html
+    assert "&lt;img src=x onerror=alert(1)&gt;" in html

--- a/scanner/tests/test_dashboard_html_builders_pure.py
+++ b/scanner/tests/test_dashboard_html_builders_pure.py
@@ -389,6 +389,19 @@ def test_provider_cards_aws_entry_rendered():
     assert "☁" in html
 
 
+def test_provider_cards_unknown_provider_name_html_escaped():
+    """An unknown provider name (from an OCSF FILENAME) carrying HTML
+    metacharacters must be HTML-escaped, not rendered raw — stored-XSS
+    regression (Python analog of the output_prowler.sh #362 fix)."""
+    payload = '<img src=x onerror=alert(1)>'
+    html = builders._build_provider_cards({
+        payload: {"total_fail": 1, "total_pass": 0, "critical": 0,
+                  "high": 0, "medium": 0, "low": 0},
+    })
+    assert "<img src=x" not in html
+    assert "&lt;img src=x onerror=alert(1)&gt;" in html
+
+
 def test_provider_cards_critical_badge_rendered():
     """Provider with critical>0 renders the pcs-crit badge."""
     html = builders._build_provider_cards({


### PR DESCRIPTION
## Summary

Fixes the **CRITICAL** finding of the dashboard-renderer XSS audit — the
Python-side analog of the `output_prowler.sh` fix (#362).

`_build_provider_cards` (`dashboard_html_builders.py`) and `_build_prov_table`
(`dashboard_html_sections.py`) interpolate the provider name straight into a
`<div class="prov-card-name">` / `<td>` cell. For an **unknown** provider,
`prov_labels.get(pname, pname)` falls back to the **raw slug**, which
`dashboard_data_loader` derives from the **OCSF artifact filename** (glob of
`.claudesec-prowler/*.ocsf.json`, no allowlist — the analyzer keys on the
filename, not a valid schema).

A crafted file `<img src=x onerror=alert(1)>.ocsf.json` (any content) injects an
**auto-firing `<img onerror>`** into the Overview tab → **stored XSS**.

### Fix
Wrap the label in `h()` at all three prov-label render sites (both extras loops
+ the display-order loop, which shares the same `.get(pname, pname)` fallback).
Known slugs → static ASCII labels, so `h()` is a no-op for them; the
provider-labels sync guard is unaffected.

## Test plan
- [x] **Empirically reproduced**: crafted `<img>` provider name renders SAFE (raw absent, entity-encoded present) in both functions
- [x] Regression tests in `test_dashboard_html_builders_pure.py` + `test_dashboard_builders_unit.py`; **mutation-verified** (reverting `h()` fails them)
- [x] `scanner/lib` pytest **99.14%** (≥99 floor), 1549 passed
- [x] `py_compile` clean

## Follow-ups from the same audit (separate — need a design decision / CSP verification)
- **HIGH** `dashboard-gen.py:390` — `h()`-escaped `'` decoded back to a live delimiter inside an inline `onclick` JS-string, breakable via the raw finding `category` field (needs data-action delegation, not just escaping)
- **MEDIUM** `dashboard-gen.py:264/348` — `href` reference links accept `javascript:` scheme (`h()` doesn't validate scheme)
- **LOW/unconfirmed** `dashboard_template.py` — naive whole-document `.replace()` placeholder-collision
- The site CSP (`script-src 'nonce-…' 'strict-dynamic'`, no `'unsafe-inline'`) may already block the onclick/`javascript:` execution vectors — but not the markup/phishing-injection impact; **unverified** without a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)