### PR TITLE
fix(scanner): harden dashboard onclick JS-string + javascript: href (XSS)

### DIFF
--- a/scanner/lib/dashboard-gen.py
+++ b/scanner/lib/dashboard-gen.py
@@ -41,7 +41,7 @@ from dashboard_utils import (  # noqa: F401
     DatadogLogEntry, DatadogSummary, DatadogSeveritySummary, DatadogLogsData,
     GitHubContentItem, RepoFocusFile, RepoFocusData,
     MicrosoftBestPracticeSource, MicrosoftBestPracticesData,
-    h, _is_env_truthy, _is_best_practice_file,
+    h, safe_url, _is_env_truthy, _is_best_practice_file,
     _resolve_source_filter, _normalized_source_filter, _trust_token_from_level,
     comp_slug, sev_badge,
 )
@@ -261,7 +261,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
             if nr and nr not in ref_links:
                 ref_links.append(nr)
         for rl in ref_links:
-            gh_table += f'<a href="{h(rl)}" target="_blank" rel="noopener" class="ref-link">📖 Reference</a> '
+            gh_table += f'<a href="{h(safe_url(rl))}" target="_blank" rel="noopener" class="ref-link">📖 Reference</a> '
         gh_table += "</div></td></tr>"
 
 
@@ -345,7 +345,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
                     if _hub_url not in ref_links:
                         ref_links.insert(0, _hub_url)
             for rl in ref_links:
-                detail.append(f'<a href="{h(rl)}" target="_blank" rel="noopener" class="ref-link">Reference</a> ')
+                detail.append(f'<a href="{h(safe_url(rl))}" target="_blank" rel="noopener" class="ref-link">Reference</a> ')
             detail.append("</div></td></tr>")
             parts.append("".join(detail))
         return "".join(parts)
@@ -383,13 +383,20 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
         scanner_cat_labels.append(meta["label"] if meta else cat)
     scanner_cat_count = len(scanner_cat_labels)
 
+    # Emit the category value into a data-* attribute (quoted-attribute context,
+    # where h() is sufficient) and let the delegated data-action handler read it
+    # via dataset — NOT an inline onclick JS-string, where an h()-escaped quote
+    # is decoded back to a live delimiter by the HTML attribute tokenizer and
+    # breaks out of the switchTab('overview', '...') call (XSS via the raw
+    # finding `category` field). `switchTab` + `data-scroll` is the same
+    # delegation the template already uses for its tab links.
     scanner_cat_links_html = ""
     for cat in scanner_cats_seen:
         meta = CATEGORY_META.get(cat)
         label = meta["label"] if meta else cat
-        scanner_cat_links_html += f'<a href="#" class="scope-cat-link" onclick="switchTab(\'overview\',\'scanner-cat-{h(cat)}\');return false;">{h(label)}</a>'
+        scanner_cat_links_html += f'<a href="#" class="scope-cat-link" data-action="switchTab" data-arg="overview" data-scroll="scanner-cat-{h(cat)}">{h(label)}</a>'
     cat_count_html = (
-        f'<a href="#" class="scope-cat-count" onclick="switchTab(\'overview\',\'scanner-cat-{h(scanner_cats_seen[0])}\');return false;">{scanner_cat_count} categories</a>'
+        f'<a href="#" class="scope-cat-count" data-action="switchTab" data-arg="overview" data-scroll="scanner-cat-{h(scanner_cats_seen[0])}">{scanner_cat_count} categories</a>'
         if scanner_cats_seen
         else f'<span class="scope-cat-count">{scanner_cat_count} categories</span>'
     )

--- a/scanner/lib/dashboard-template.html
+++ b/scanner/lib/dashboard-template.html
@@ -1428,7 +1428,7 @@ document.addEventListener('click',function(e){
   var arg=btn.dataset.arg;
 
   if(action==='close-setup-overlay'){if(e.target===btn)closeSetup();return;}
-  if(action==='switchTab'){switchTab(arg,btn.dataset.scroll||undefined);return;}
+  if(action==='switchTab'){switchTab(arg,btn.dataset.scroll||undefined);e.preventDefault();return;}
   if(action==='switchProvTab'){switchProvTab(arg);return;}
   if(action==='scroll-top'){window.scrollTo({top:0,behavior:'smooth'});return;}
   if(action==='scroll-to'){

--- a/scanner/lib/dashboard_utils.py
+++ b/scanner/lib/dashboard_utils.py
@@ -183,6 +183,35 @@ def h(s):
     )
 
 
+# Schemes permitted in an href/src the dashboard emits for externally-sourced
+# reference URLs (GitHub findings, Prowler OCSF remediation.references, ...).
+_SAFE_URL_SCHEMES = ("http://", "https://", "mailto:")
+
+
+def safe_url(u):
+    """Return ``u`` only if it is safe to place in an ``href``; else ``"#"``.
+
+    ``h()`` HTML-escapes but does NOT validate the URL scheme, so an
+    externally-sourced reference of ``javascript:alert(1)`` (or ``data:`` /
+    ``vbscript:``) survives ``h()`` and executes on click. This gate allows
+    only http/https/mailto absolute URLs, protocol-relative (``//host``) and
+    same-document/relative links (fragment ``#``, ``/``, ``./``, ``../``, or any
+    value with no scheme, i.e. no ``:`` before the first ``/``); everything else
+    collapses to ``"#"``. Apply BEFORE ``h()``: ``h(safe_url(u))``.
+    """
+    s = str(u).strip()
+    low = s.lower()
+    if low.startswith(_SAFE_URL_SCHEMES):
+        return s
+    # protocol-relative or same-document/relative links carry no scheme.
+    if s.startswith(("#", "/", "./", "../")):
+        return s
+    first_segment = s.split("/", 1)[0]
+    if ":" not in first_segment:
+        return s  # scheme-less relative path (e.g. "docs/x.html")
+    return "#"
+
+
 _ALLOWED_FETCH_HOSTS = {"raw.githubusercontent.com", "github.com", "api.github.com"}
 
 

--- a/scanner/tests/test_dashboard_utils_safe_url.py
+++ b/scanner/tests/test_dashboard_utils_safe_url.py
@@ -1,0 +1,107 @@
+"""
+Unit tests for dashboard_utils.safe_url() — the href URL-scheme gate.
+
+safe_url neutralizes `javascript:` / `data:` / `vbscript:` (and any other
+non-http(s)/mailto scheme) reference URLs that survive h() (which only
+HTML-escapes) and would execute on click in an <a href> context. Externally
+sourced reference URLs (GitHub findings, Prowler OCSF remediation.references)
+flow to the ref-link render sites in dashboard-gen.py, so this gate is applied
+as h(safe_url(u)) there.
+
+Authored for both pytest and `python3 -m unittest` discovery. stdlib-only.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+from dashboard_utils import safe_url  # noqa: E402
+
+
+ALLOWED = [
+    "https://github.com/owner/repo",
+    "http://example.test/a",
+    "mailto:security@example.test",
+    "#frag",
+    "/relative/path",
+    "./sibling.html",
+    "../parent.html",
+    "docs/guide.html",   # scheme-less relative path
+    "//cdn.example.test/x",  # protocol-relative (http/https-equivalent)
+]
+
+BLOCKED = [
+    "javascript:alert(1)",
+    "JaVaScRiPt:alert(1)",   # case-insensitive
+    "  javascript:alert(1)",  # leading whitespace
+    "java\tscript:alert(1)",  # embedded control char in scheme
+    "data:text/html,<script>alert(1)</script>",
+    "vbscript:msgbox(1)",
+    "file:///etc/passwd",
+]
+
+
+class TestSafeUrl(unittest.TestCase):
+    def test_allowed_urls_pass_through_unchanged(self):
+        for u in ALLOWED:
+            self.assertEqual(safe_url(u), u, f"should allow: {u!r}")
+
+    def test_blocked_schemes_collapse_to_hash(self):
+        for u in BLOCKED:
+            self.assertEqual(safe_url(u), "#", f"should block: {u!r}")
+
+    def test_non_string_input_is_coerced(self):
+        # str(12345) has no scheme -> treated as a scheme-less relative value.
+        self.assertEqual(safe_url(12345), "12345")
+
+    def test_javascript_scheme_never_survives_with_h(self):
+        # The real render pattern is h(safe_url(u)); a javascript: URL must not
+        # reach the href as an executable scheme.
+        from dashboard_utils import h
+        self.assertEqual(h(safe_url("javascript:alert(document.cookie)")), "#")
+
+
+class TestDashboardGenHardeningPins(unittest.TestCase):
+    """Source-level regression pins for the dashboard-gen.py XSS hardening:
+    the scanner-category scope links must NOT reintroduce an inline
+    onclick JS-string that interpolates the (raw) finding category, and the
+    externally-sourced reference links must keep their safe_url() scheme gate."""
+
+    @property
+    def _src(self):
+        path = os.path.join(os.path.dirname(__file__), "..", "lib", "dashboard-gen.py")
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+
+    def test_no_inline_onclick_switchtab_with_category(self):
+        # The Finding-3 vector: onclick="switchTab('overview','scanner-cat-{h(cat)}')"
+        # — an h()-escaped quote decodes back to a live delimiter in inline JS.
+        self.assertNotIn("onclick=\"switchTab('overview','scanner-cat-", self._src)
+
+    def test_scope_cat_links_use_data_action_delegation(self):
+        self.assertIn('data-action="switchTab" data-arg="overview" data-scroll="scanner-cat-', self._src)
+
+    def test_reference_links_go_through_safe_url(self):
+        # Finding-4: href must gate the scheme via safe_url(), never raw h(rl).
+        self.assertIn("href=\"{h(safe_url(rl))}\"", self._src)
+        self.assertNotIn("href=\"{h(rl)}\"", self._src)
+
+
+# Bare test_* functions so pytest (function collection) also runs them.
+def test_safe_url_allows_https():
+    assert safe_url("https://x.test/y") == "https://x.test/y"
+
+
+def test_safe_url_blocks_javascript():
+    assert safe_url("javascript:alert(1)") == "#"
+
+
+def test_safe_url_allows_fragment_and_relative():
+    assert safe_url("#top") == "#top"
+    assert safe_url("docs/x.html") == "docs/x.html"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes the two remaining **exploitable** findings from the dashboard-renderer XSS
audit (the CRITICAL provider-name finding was fixed in #365; Finding 5 — the
`.replace()` template collision — is LOW/unconfirmed and left as-is).

### Finding 3 (HIGH) — `onclick` inline-JS-string breakout via raw `category`
`dashboard-gen.py` built `onclick="switchTab('overview','scanner-cat-{h(cat)}')"`.
`cat` is the raw finding `category`; `h()` escapes `'`→`&#x27;`, but the HTML
attribute tokenizer **decodes it back to a live `'`** before the inline JS is
compiled, so `x');alert(1)//` breaks out. Moved the value into `data-*`
attributes consumed by the template's **existing delegated click handler**
(`data-action="switchTab" data-arg="overview" data-scroll="scanner-cat-{h(cat)}"`)
— a quoted-attribute context where `h()` **is** sufficient and nothing is
`eval`'d. Added `e.preventDefault()` to that handler's `switchTab` branch so the
`<a href="#">` links don't jump to top (a no-op for the existing
button/div/span `switchTab` elements).

### Finding 4 (MEDIUM) — `javascript:` scheme accepted in `href`
Reference links did `href="{h(rl)}"` where `rl` comes from GitHub findings /
Prowler OCSF `remediation.references`. `h()` never validates the scheme, so
`javascript:alert(1)` executed on click. Added `dashboard_utils.safe_url()`
(allow http/https/mailto + protocol-relative + fragment/relative; everything
else → `"#"`) and render `h(safe_url(rl))`.

## Test plan
- [x] `safe_url` unit matrix — allowed vs blocked schemes incl. case / leading-whitespace / embedded-control-char obfuscation (`JaVaScRiPt:`, `  javascript:`, `java\tscript:`, `data:`, `vbscript:`, `file:`) → `#`; http/https/mailto/`//`/`#`/relative pass
- [x] Source-pin regression: scope links use `data-action` (not inline `onclick` with the category); ref-links keep the `safe_url` gate. **Mutation-verified** (reverting either fails the pins)
- [x] Dual pytest + `unittest` runner; `scanner/lib` pytest **99.15%** (≥99), 1553 passed
- [x] Offline dashboard generation smoke **36/36** (generator still emits valid HTML); CI guards unaffected (18/18)
- [ ] ⚠️ Browser behavior of the delegated `switchTab`/`preventDefault` path **not** verified headlessly — the change reuses the template's already-shipped delegation harness (identical to its tab links), so risk is low, but a browser click-through is the definitive check.

Depends on nothing; complements #365 (different files). Follow-up: verify the site CSP is enforced end-to-end in a browser (would independently neutralize these vectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)