### PR TITLE
fix(scanner): complete onclick→data-action migration for CSP-dead dashboard controls

### DIFF
--- a/scanner/lib/dashboard-gen.py
+++ b/scanner/lib/dashboard-gen.py
@@ -209,7 +209,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
             env_connected += 1
             env_html += (
                 f'<button class="env-pill env-on" '
-                f'onclick="openSetup(\'{h(e["setup_id"])}\')">'
+                f'data-action="openSetup" data-arg="{h(e["setup_id"])}">'
                 f'<span class="ep-icon">{e["icon"]}</span>'
                 f'<span class="ep-name">{h(e["name"])}</span>'
                 f'<span class="ep-st on">●</span>'
@@ -218,7 +218,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
         else:
             env_html += (
                 f'<button class="env-pill env-off" '
-                f'onclick="openSetup(\'{h(e["setup_id"])}\')">'
+                f'data-action="openSetup" data-arg="{h(e["setup_id"])}">'
                 f'<span class="ep-icon">{e["icon"]}</span>'
                 f'<span class="ep-name">{h(e["name"])}</span>'
                 f'<span class="ep-st off">○</span>'
@@ -243,8 +243,8 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
         repos_shown = repos[:5]
         repos_html = ", ".join(f"<code>{h(r)}</code>" for r in repos_shown)
         if len(repos) > 5:
-            repos_html += f' <span class="res-toggle" onclick="var s=this.nextElementSibling;s.style.display=s.style.display===\'none\'?\'inline\':\'none\';this.textContent=this.textContent.indexOf(\'+\')>=0?\'hide\':\'... +{len(repos)-5} more\'" style="color:var(--accent);cursor:pointer;font-weight:600">... +{len(repos) - 5} more</span><span style="display:none">, ' + ", ".join(f"<code>{h(r)}</code>" for r in repos[5:]) + "</span>"
-        gh_table += f'<tr class="expandable" onclick="toggleRow(this)"><td>{sev_badge(sev)}</td><td class="mono">{h(check)}</td><td>{h(items[0]["title"])} <span class="cnt">({len(items)})</span></td><td>{repos_html}</td></tr>'
+            repos_html += f' <span class="res-toggle" data-action="toggleRepoOverflow" data-more-label="... +{len(repos) - 5} more" style="color:var(--accent);cursor:pointer;font-weight:600">... +{len(repos) - 5} more</span><span style="display:none">, ' + ", ".join(f"<code>{h(r)}</code>" for r in repos[5:]) + "</span>"
+        gh_table += f'<tr class="expandable" data-action="toggleRow"><td>{sev_badge(sev)}</td><td class="mono">{h(check)}</td><td>{h(items[0]["title"])} <span class="cnt">({len(items)})</span></td><td>{repos_html}</td></tr>'
         en = get_check_en(check)
         desc = items[0].get("desc") or items[0].get("title") or ""
         native_rem = (items[0].get("native_remediation") or "").strip()
@@ -278,7 +278,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
             return -(top_sev * 1000 + len(_items))
         for check, items in sorted(by_check.items(), key=_check_sort_key):
             sev = items[0]["severity"]
-            parts.append(f'<tr class="expandable" onclick="toggleRow(this)"><td>{sev_badge(sev)}</td><td class="mono">{h(check)}</td><td>{h(items[0]["title"])} <span class="cnt">({len(items)})</span></td></tr>')
+            parts.append(f'<tr class="expandable" data-action="toggleRow"><td>{sev_badge(sev)}</td><td class="mono">{h(check)}</td><td>{h(items[0]["title"])} <span class="cnt">({len(items)})</span></td></tr>')
             en = get_check_en(check)
             desc = items[0].get("desc") or items[0].get("title") or ""
             # Use Prowler native remediation as fallback when CHECK_EN_MAP has no match
@@ -320,7 +320,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
                     detail.append(f"<li{hidden}><code>{h(r['name'])}</code>{extra_html}</li>")
                 if len(resources) > SHOW_LIMIT:
                     overflow_count = len(resources) - SHOW_LIMIT
-                    detail.append(f'<li class="res-toggle" onclick="var p=this.parentNode;p.querySelectorAll(\'.res-overflow\').forEach(function(e){{e.style.display=e.style.display===\'none\'?\'list-item\':\'none\'}});this.textContent=this.textContent.indexOf(\'+\')>=0?\'Hide {overflow_count} resources\':\'+ {overflow_count} more resources\'" style="color:var(--accent);cursor:pointer;font-weight:600">+ {overflow_count} more resources</li>')
+                    detail.append(f'<li class="res-toggle" data-action="toggleResOverflow" data-more-label="+ {overflow_count} more resources" data-hide-label="Hide {overflow_count} resources" style="color:var(--accent);cursor:pointer;font-weight:600">+ {overflow_count} more resources</li>')
                 detail.append("</ul></div>")
             # Reference links: primary + native refs
             ref_links = []
@@ -467,7 +467,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
         + (scanner_cat_links_html if scanner_cat_links_html else h(scanner_cat_text))
         + "</div>"
         + f'<div style="margin-top:.25rem"><strong style="color:var(--text)">Scan root:</strong> <code class="scan-root-path" title="{h(scan_dir)}">{h(scan_root_short)}</code>{scan_root_badge}</div>'
-        + '<div style="margin-top:.4rem;display:flex;flex-wrap:wrap;gap:.75rem;align-items:center"><a href="#scanner-section" onclick="document.getElementById(\'scanner-section\').scrollIntoView({behavior:\'smooth\'});return false;" style="color:var(--accent);text-decoration:underline;font-weight:600">View scanner results ↓</a><label style="display:flex;align-items:center;gap:.35rem"><span style="color:var(--text);font-weight:600">Prowler summary</span><select class="scope-select" onchange="openProwlerFromOverview(this)">'
+        + '<div style="margin-top:.4rem;display:flex;flex-wrap:wrap;gap:.75rem;align-items:center"><a href="#scanner-section" data-action="scroll-to" data-target="scanner-section" style="color:var(--accent);text-decoration:underline;font-weight:600">View scanner results ↓</a><label style="display:flex;align-items:center;gap:.35rem"><span style="color:var(--text);font-weight:600">Prowler summary</span><select class="scope-select" data-change="openProwler">'
         + prowler_selector_options_html
         + "</select></label></div>"
         + "</div>"
@@ -522,7 +522,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
         fc = dom["fail_count"]
         status_cls = "arch-ov-fail" if fc > 0 else "arch-ov-pass"
         arch_overview_html += (
-            f'<div class="arch-ov-card {status_cls}" onclick="switchTab(\'arch\',\'arch-dom-{idx}\')">'
+            f'<div class="arch-ov-card {status_cls}" data-action="switchTab" data-arg="arch" data-scroll="arch-dom-{h(idx)}">'
             f'<div class="arch-ov-icon">{dom["icon"]}</div>'
             f'<div class="arch-ov-name">{h(dom["name"])}</div>'
             f'<div class="arch-ov-count">{fc}</div>'
@@ -542,7 +542,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
     trivy_total = trivy_crit + trivy_high + trivy_med + trivy_low
     net_summary_html = '<div class="net-ov-row">'
     net_summary_html += (
-        f'<div class="net-ov-card" onclick="switchTab(\'networktools\')">'
+        f'<div class="net-ov-card" data-action="switchTab" data-arg="networktools">'
         f'<div class="net-ov-icon">🔍</div>'
         f'<div class="net-ov-body"><div class="net-ov-title">Trivy CVEs</div>'
         f'<div class="net-ov-nums">'
@@ -556,13 +556,13 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
         net_summary_html += '<span class="net-ov-none">—</span>'
     net_summary_html += '</div></div></div>'
     net_summary_html += (
-        f'<div class="net-ov-card" onclick="switchTab(\'networktools\')">'
+        f'<div class="net-ov-card" data-action="switchTab" data-arg="networktools">'
         f'<div class="net-ov-icon">🌐</div>'
         f'<div class="net-ov-body"><div class="net-ov-title">Nmap scans</div>'
         f'<div class="net-ov-nums"><span class="net-ov-big">{nmap_count}</span></div></div></div>'
     )
     net_summary_html += (
-        f'<div class="net-ov-card" onclick="switchTab(\'networktools\')">'
+        f'<div class="net-ov-card" data-action="switchTab" data-arg="networktools">'
         f'<div class="net-ov-icon">🔒</div>'
         f'<div class="net-ov-body"><div class="net-ov-title">TLS/SSL scans</div>'
         f'<div class="net-ov-nums"><span class="net-ov-big">{ssl_count}</span></div></div></div>'
@@ -590,7 +590,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
                     _ar = _pol.get("total_articles", 0)
                     _isms = " · ".join(h(c) for c in _pol.get("isms_controls", []))
                     policies_html += f'<div style="border:1px solid var(--border);border-left:3px solid {_color};border-radius:10px;overflow:hidden;cursor:pointer" '
-                    policies_html += "onclick=\"var d=this.querySelector('.pol-det');if(d.style.display==='none'){d.style.display='block'}else{d.style.display='none'}\">"
+                    policies_html += 'data-action="togglePolDet">'
                     policies_html += f'<div style="display:flex;align-items:center;gap:8px;padding:12px 14px;background:var(--card2)">'
                     policies_html += f'<span style="font-size:16px">📄</span>'
                     policies_html += f'<div style="flex:1"><div style="font-size:13px;font-weight:700">{_name}</div>'
@@ -599,7 +599,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
                         policies_html += f' · ISMS: {_isms}'
                     policies_html += '</div></div>'
                     if _url:
-                        policies_html += f'<a href="{_url}" target="_blank" rel="noopener" onclick="event.stopPropagation()" style="font-size:10px;color:var(--accent);text-decoration:underline">원문↗</a>'
+                        policies_html += f'<a href="{_url}" target="_blank" rel="noopener" data-action="stop" style="font-size:10px;color:var(--accent);text-decoration:underline">원문↗</a>'
                     policies_html += '</div>'
                     # Article list (collapsed)
                     _articles = _pol.get("articles", [])

--- a/scanner/lib/dashboard-template.html
+++ b/scanner/lib/dashboard-template.html
@@ -594,7 +594,7 @@ body{font-family:var(--font-sans);background:
       <span class="meta-pill">Scan {{NOW}}</span>
       <span class="meta-pill">{{DURATION}}s</span>
     </div>
-    <button class="theme-toggle print-btn" onclick="window.print()" title="Print / Export PDF" aria-label="Print dashboard">&#x1F5A8;</button>
+    <button class="theme-toggle print-btn" data-action="print" title="Print / Export PDF" aria-label="Print dashboard">&#x1F5A8;</button>
     <button class="theme-toggle" id="themeToggleBtn" title="Toggle theme" aria-label="Toggle theme">🌓</button>
   </div>
 </header>
@@ -1449,6 +1449,52 @@ document.addEventListener('click',function(e){
     if(catEl)catEl.scrollIntoView({behavior:'smooth',block:'start'});
     return;
   }
+  if(action==='stop'){return;}
+  if(action==='print'){window.print();return;}
+  if(action==='openSetup'){openSetup(arg);return;}
+  if(action==='toggleOwasp'){toggleOwasp(btn);return;}
+  if(action==='toggleArch'){toggleArch(btn);return;}
+  if(action==='toggleComp'){toggleComp(btn);return;}
+  if(action==='toggleApProduct'){if(btn.parentElement)btn.parentElement.classList.toggle('open');return;}
+  if(action==='toggleMsSrc'){
+    var msBody=btn.parentElement&&btn.parentElement.querySelector('.ms-src-body');
+    if(msBody)msBody.style.display=(msBody.style.display==='none'?'':'none');
+    return;
+  }
+  if(action==='togglePolDet'){
+    var pd=btn.querySelector('.pol-det');
+    if(pd)pd.style.display=(pd.style.display==='none'?'block':'none');
+    return;
+  }
+  if(action==='applyMsSourcePresetFilter'){applyMsSourcePresetFilter(btn);return;}
+  if(action==='toggleRepoOverflow'){
+    var sib=btn.nextElementSibling;
+    if(sib)sib.style.display=(sib.style.display==='none'?'inline':'none');
+    btn.textContent=(btn.textContent.indexOf('+')>=0?'hide':(btn.dataset.moreLabel||'more'));
+    return;
+  }
+  if(action==='toggleResOverflow'){
+    var par=btn.parentNode;
+    if(par)par.querySelectorAll('.res-overflow').forEach(function(el){el.style.display=(el.style.display==='none'?'list-item':'none')});
+    btn.textContent=(btn.textContent.indexOf('+')>=0?(btn.dataset.hideLabel||'Hide'):(btn.dataset.moreLabel||'more'));
+    return;
+  }
+});
+/* Event delegation for change events (checkboxes, selects) */
+document.addEventListener('change',function(e){
+  var el=e.target.closest('[data-change]');
+  if(!el)return;
+  var action=el.dataset.change;
+  if(action==='apToggleCheck'){apToggleCheck(el);return;}
+  if(action==='apToggleCheckMs'){apToggleCheck(el);msUpdateProgress();return;}
+  if(action==='apToggleCheckSaas'){apToggleCheck(el);saasUpdateProgress();return;}
+  if(action==='openProwler'){openProwlerFromOverview(el);return;}
+});
+/* Event delegation for input events (search box) */
+document.addEventListener('input',function(e){
+  var el=e.target.closest('[data-input]');
+  if(!el)return;
+  if(el.dataset.input==='apFilterProducts'){apFilterProducts(el.value);return;}
 });
 /* Keyboard navigation for tabs */
 document.getElementById('mainTabs').addEventListener('keydown',function(e){

--- a/scanner/lib/dashboard_html_arch.py
+++ b/scanner/lib/dashboard_html_arch.py
@@ -51,7 +51,7 @@ def _build_arch_html(arch_domains) -> str:
                 dot_cls = "cov-on" if has_data else "cov-off"
                 coverage_dots += f'<span class="cov-dot {dot_cls}" title="{h(slab)}">{h(slab[:3])}</span>'
             coverage_dots += '</span>'
-        arch_html += f'<div class="arch-header" onclick="toggleArch(this)"><span class="arch-icon">{dom["icon"]}</span><span class="arch-name">{h(dom["name"])}</span>{coverage_dots}<span class="arch-stat"><span class="arch-fail">{dom["fail_count"]} failed</span></span><span class="arch-arrow">▸</span></div>'
+        arch_html += f'<div class="arch-header" data-action="toggleArch"><span class="arch-icon">{dom["icon"]}</span><span class="arch-name">{h(dom["name"])}</span>{coverage_dots}<span class="arch-stat"><span class="arch-fail">{dom["fail_count"]} failed</span></span><span class="arch-arrow">▸</span></div>'
         arch_html += '<div class="arch-body">'
         summary = dom.get("summary", "")
         action = dom.get("action", "")
@@ -70,13 +70,13 @@ def _build_arch_html(arch_domains) -> str:
             arch_html += '<div class="arch-links"><span class="arch-links-label">Related items</span>'
             for oid in links.get("owasp", []):
                 oname = owasp_names.get(oid, oid)
-                arch_html += f'<button class="arch-link-chip arch-owasp" onclick="switchTab(\'bestpractices\',\'owasp-{oid}\')" title="OWASP {oid}">{oid}</button>'
+                arch_html += f'<button class="arch-link-chip arch-owasp" data-action="switchTab" data-arg="bestpractices" data-scroll="owasp-{h(oid)}" title="OWASP {h(oid)}">{h(oid)}</button>'
             for fw, ctrl in links.get("compliance", []):
                 cid = comp_slug(fw)
-                arch_html += f'<button class="arch-link-chip arch-comp" onclick="switchTab(\'bestpractices\',\'{cid}\')" title="{h(fw)} {h(ctrl)}">{ctrl}</button>'
+                arch_html += f'<button class="arch-link-chip arch-comp" data-action="switchTab" data-arg="bestpractices" data-scroll="{h(cid)}" title="{h(fw)} {h(ctrl)}">{h(ctrl)}</button>'
             for scat in links.get("scanner", []):
                 slab = scanner_labels.get(scat, scat)
-                arch_html += f'<button class="arch-link-chip arch-scanner" onclick="switchTab(\'overview\',\'scanner-cat-{scat}\')" title="Scanner {slab}">{slab}</button>'
+                arch_html += f'<button class="arch-link-chip arch-scanner" data-action="switchTab" data-arg="overview" data-scroll="scanner-cat-{h(scat)}" title="Scanner {h(slab)}">{h(slab)}</button>'
             arch_html += "</div>"
         if dom["findings"]:
             for ff in dom["findings"][:8]:

--- a/scanner/lib/dashboard_html_audit_points.py
+++ b/scanner/lib/dashboard_html_audit_points.py
@@ -63,7 +63,7 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
             audit_points_html += f'<span style="font-size:.78rem;color:var(--muted)">No products detected in this repo · {all_count} products available · run <code>claudesec scan -c saas</code></span>'
         audit_points_html += "</div>"
         # Search bar
-        audit_points_html += '<input type="text" class="ap-search" placeholder="Search products or checklist items..." onkeyup="apFilterProducts(this.value)">'
+        audit_points_html += '<input type="text" class="ap-search" placeholder="Search products or checklist items..." data-input="apFilterProducts">'
         # Progress bar
         audit_points_html += '<div class="ap-progress-label"><span id="ap-progress-label">0 / 0 reviewed</span><span id="ap-progress-pct">0%</span></div>'
         audit_points_html += '<div class="ap-progress-bar"><div id="ap-progress-fill" class="ap-progress-fill" style="width:0%"></div></div>'
@@ -79,7 +79,7 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
             icon = _ap_icons.get(pname, "📋")
             tree_url = prod.get("tree_url") or f"{repo_url}/tree/main/{urllib.parse.quote(pname)}"
             audit_points_html += f'<div class="ap-product-card open" data-product="{h(pname.lower())}">'
-            audit_points_html += f'<div class="ap-product-header" onclick="this.parentElement.classList.toggle(\'open\')">'
+            audit_points_html += '<div class="ap-product-header" data-action="toggleApProduct">'
             audit_points_html += f'<span class="ap-product-icon">{icon}</span>'
             audit_points_html += f'<span class="ap-product-name">{h(pname)}</span>'
             audit_points_html += f'<span class="ap-product-count">{len(files)} items</span>'
@@ -93,7 +93,7 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
                 ext = fname.rsplit(".", 1)[-1] if "." in fname else ""
                 cb_id = f"ap-{pname}-{idx}".lower().replace(" ", "-")
                 audit_points_html += f'<div class="bp-audit-item-row" data-ap-id="{h(cb_id)}">'
-                audit_points_html += f'<input type="checkbox" class="ap-checkbox" data-ap-id="{h(cb_id)}" onchange="apToggleCheck(this)">'
+                audit_points_html += f'<input type="checkbox" class="ap-checkbox" data-ap-id="{h(cb_id)}" data-change="apToggleCheck">'
                 audit_points_html += f'<span class="bp-audit-index">{idx}</span>'
                 audit_points_html += f'<a href="{h(url)}" target="_blank" rel="noopener" class="bp-audit-link">{h(fname)}</a>'
                 if ext:
@@ -117,7 +117,7 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
             tree_url = prod.get("tree_url") or f"{repo_url}/tree/main/{urllib.parse.quote(pname)}"
             open_cls = ""
             audit_points_html += f'<div class="ap-product-card{open_cls}" data-product="{h(pname.lower())}">'
-            audit_points_html += f'<div class="ap-product-header" onclick="this.parentElement.classList.toggle(\'open\')">'
+            audit_points_html += '<div class="ap-product-header" data-action="toggleApProduct">'
             audit_points_html += f'<span class="ap-product-icon">{icon}</span>'
             audit_points_html += f'<span class="ap-product-name">{h(pname)}'
             if is_detected:
@@ -134,7 +134,7 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
                 ext = fname.rsplit(".", 1)[-1] if "." in fname else ""
                 cb_id = f"ap-{pname}-{idx}".lower().replace(" ", "-")
                 audit_points_html += f'<div class="bp-audit-item-row" data-ap-id="{h(cb_id)}">'
-                audit_points_html += f'<input type="checkbox" class="ap-checkbox" data-ap-id="{h(cb_id)}" onchange="apToggleCheck(this)">'
+                audit_points_html += f'<input type="checkbox" class="ap-checkbox" data-ap-id="{h(cb_id)}" data-change="apToggleCheck">'
                 audit_points_html += f'<span class="bp-audit-index">{idx}</span>'
                 audit_points_html += f'<a href="{h(url)}" target="_blank" rel="noopener" class="bp-audit-link">{h(fname)}</a>'
                 if ext:

--- a/scanner/lib/dashboard_html_audit_sources.py
+++ b/scanner/lib/dashboard_html_audit_sources.py
@@ -44,7 +44,7 @@ def build_ms_sources_html(ms_best_practices_data) -> str:
         preset_default = "official,gov"
     else:
         preset_default = "all"
-    audit_points_html += f'<div style="padding:0 1.25rem"><div class="source-filter-chips" data-active-filter="{h(source_filter)}"><button class="source-filter-chip{(" active" if preset_default == "all" else "")}" data-filter="all" onclick="applyMsSourcePresetFilter(this)">all</button><button class="source-filter-chip{(" active" if preset_default == "official,gov" else "")}" data-filter="official,gov" onclick="applyMsSourcePresetFilter(this)">official,gov</button><button class="source-filter-chip{(" active" if preset_default == "none" else "")}" data-filter="none" onclick="applyMsSourcePresetFilter(this)">none</button><span class="ms-source-filter-status" style="font-size:.75rem;color:var(--muted)">Active env filter: {h(source_filter)}</span></div></div>'
+    audit_points_html += f'<div style="padding:0 1.25rem"><div class="source-filter-chips" data-active-filter="{h(source_filter)}"><button class="source-filter-chip{(" active" if preset_default == "all" else "")}" data-filter="all" data-action="applyMsSourcePresetFilter">all</button><button class="source-filter-chip{(" active" if preset_default == "official,gov" else "")}" data-filter="official,gov" data-action="applyMsSourcePresetFilter">official,gov</button><button class="source-filter-chip{(" active" if preset_default == "none" else "")}" data-filter="none" data-action="applyMsSourcePresetFilter">none</button><span class="ms-source-filter-status" style="font-size:.75rem;color:var(--muted)">Active env filter: {h(source_filter)}</span></div></div>'
     if ms_sources:
         audit_points_html += '<div style="padding:1rem 1.25rem"><p style="color:var(--muted);margin-bottom:.45rem">Curated GitHub sources for Microsoft platform hardening and security baseline guidance.</p>'
         if source_filter != "all":
@@ -106,7 +106,7 @@ def build_ms_sources_html(ms_best_practices_data) -> str:
                     else ""
                 )
                 src_id = f"ms-{product}-{label}".lower().replace(" ", "-").replace("/", "-").replace("(", "").replace(")", "")
-                audit_points_html += f'<div class="card ms-source-entry" data-trust-token="{h(trust_token)}" style="margin-bottom:.75rem;padding:0"><div class="card-title" onclick="this.parentElement.querySelector(\'.ms-src-body\').style.display=this.parentElement.querySelector(\'.ms-src-body\').style.display==\'none\'?\'\':\'none\'" style="cursor:pointer;user-select:none;display:flex;align-items:center;gap:.5rem"><input type="checkbox" class="ap-checkbox ms-src-checkbox" data-ap-id="{h(src_id)}" onchange="apToggleCheck(this);msUpdateProgress()" onclick="event.stopPropagation()"> ▸ {h(label)} <span class="trust-badge {h(trust_class)}">{h(trust_level)}</span>{archive_tag} <span style="font-size:.75rem;color:var(--muted);font-weight:400">({len(files)} files)</span></div>'
+                audit_points_html += f'<div class="card ms-source-entry" data-trust-token="{h(trust_token)}" style="margin-bottom:.75rem;padding:0"><div class="card-title" data-action="toggleMsSrc" style="cursor:pointer;user-select:none;display:flex;align-items:center;gap:.5rem"><input type="checkbox" class="ap-checkbox ms-src-checkbox" data-ap-id="{h(src_id)}" data-change="apToggleCheckMs" data-action="stop"> ▸ {h(label)} <span class="trust-badge {h(trust_class)}">{h(trust_level)}</span>{archive_tag} <span style="font-size:.75rem;color:var(--muted);font-weight:400">({len(files)} files)</span></div>'
                 audit_points_html += '<div class="ms-src-body" style="padding:.75rem 1rem">'
                 audit_points_html += f'<div style="color:var(--muted);font-size:.82rem;margin-bottom:.45rem">{h(reason)}</div>'
                 audit_points_html += f'<a href="{h(repo_url)}" target="_blank" rel="noopener" style="color:var(--accent);font-size:.85rem">Open repository</a>'
@@ -116,7 +116,7 @@ def build_ms_sources_html(ms_best_practices_data) -> str:
                     url = f.get("url") or f.get("raw_url") or "#"
                     fname = f.get("path") or f.get("name") or "file"
                     file_id = f"{src_id}-f{fidx}"
-                    audit_points_html += f'<div class="bp-audit-item-row" style="margin-top:.35rem"><input type="checkbox" class="ap-checkbox ms-file-checkbox" data-ap-id="{h(file_id)}" onchange="apToggleCheck(this);msUpdateProgress()"><a href="{h(url)}" target="_blank" rel="noopener" class="mono bp-audit-link" style="font-size:.8rem;color:var(--text)">{h(fname)}</a></div>'
+                    audit_points_html += f'<div class="bp-audit-item-row" style="margin-top:.35rem"><input type="checkbox" class="ap-checkbox ms-file-checkbox" data-ap-id="{h(file_id)}" data-change="apToggleCheckMs"><a href="{h(url)}" target="_blank" rel="noopener" class="mono bp-audit-link" style="font-size:.8rem;color:var(--text)">{h(fname)}</a></div>'
                 if len(files) > 25:
                     audit_points_html += f'<div style="margin-top:.5rem;color:var(--muted);font-size:.78rem">… and {len(files) - 25} more files</div>'
                 audit_points_html += "</div></div>"
@@ -171,7 +171,7 @@ def build_saas_sources_html(saas_bp_data) -> str:
                 trust_class = {"Vendor Official": "trust-ms", "CNCF Official": "trust-ms", "Government": "trust-gov", "Community": "trust-community"}.get(trust_level, "trust-community")
                 src_id = f"saas-{product}-{label}".lower().replace(" ", "-").replace("/", "-").replace("(", "").replace(")", "")
                 focus = ", ".join(src.get("focus_paths", []))
-                audit_points_html += f'<div class="card ms-source-entry" style="margin-bottom:.75rem;padding:0"><div class="card-title" onclick="this.parentElement.querySelector(\'.ms-src-body\').style.display=this.parentElement.querySelector(\'.ms-src-body\').style.display==\'none\'?\'\':\'none\'" style="cursor:pointer;user-select:none;display:flex;align-items:center;gap:.5rem"><input type="checkbox" class="ap-checkbox saas-src-checkbox" data-ap-id="{h(src_id)}" onchange="apToggleCheck(this);saasUpdateProgress()" onclick="event.stopPropagation()"> ▸ {h(label)} <span class="trust-badge {h(trust_class)}">{h(trust_level)}</span> <span style="font-size:.75rem;color:var(--muted);font-weight:400">({len(files)} files)</span></div>'
+                audit_points_html += f'<div class="card ms-source-entry" style="margin-bottom:.75rem;padding:0"><div class="card-title" data-action="toggleMsSrc" style="cursor:pointer;user-select:none;display:flex;align-items:center;gap:.5rem"><input type="checkbox" class="ap-checkbox saas-src-checkbox" data-ap-id="{h(src_id)}" data-change="apToggleCheckSaas" data-action="stop"> ▸ {h(label)} <span class="trust-badge {h(trust_class)}">{h(trust_level)}</span> <span style="font-size:.75rem;color:var(--muted);font-weight:400">({len(files)} files)</span></div>'
                 audit_points_html += '<div class="ms-src-body" style="padding:.75rem 1rem">'
                 audit_points_html += f'<div style="color:var(--muted);font-size:.82rem;margin-bottom:.45rem">{h(reason)}</div>'
                 audit_points_html += f'<a href="{h(repo_url)}" target="_blank" rel="noopener" style="color:var(--accent);font-size:.85rem">Open repository ↗</a>'
@@ -181,7 +181,7 @@ def build_saas_sources_html(saas_bp_data) -> str:
                     url = fl.get("url") or fl.get("raw_url") or "#"
                     fname = fl.get("path") or fl.get("name") or "file"
                     file_id = f"{src_id}-f{fidx}"
-                    audit_points_html += f'<div class="bp-audit-item-row" style="margin-top:.35rem"><input type="checkbox" class="ap-checkbox saas-file-checkbox" data-ap-id="{h(file_id)}" onchange="apToggleCheck(this);saasUpdateProgress()"><a href="{h(url)}" target="_blank" rel="noopener" class="mono bp-audit-link" style="font-size:.8rem;color:var(--text)">{h(fname)}</a></div>'
+                    audit_points_html += f'<div class="bp-audit-item-row" style="margin-top:.35rem"><input type="checkbox" class="ap-checkbox saas-file-checkbox" data-ap-id="{h(file_id)}" data-change="apToggleCheckSaas"><a href="{h(url)}" target="_blank" rel="noopener" class="mono bp-audit-link" style="font-size:.8rem;color:var(--text)">{h(fname)}</a></div>'
                 audit_points_html += "</div></div>"
         audit_points_html += "</div>"
     else:

--- a/scanner/lib/dashboard_html_builders.py
+++ b/scanner/lib/dashboard_html_builders.py
@@ -77,7 +77,7 @@ def _build_scanner_section(findings_list):
         for aidx in SCANNER_TO_ARCH.get(cat, []):
             if aidx < len(ARCH_DOMAINS):
                 d = ARCH_DOMAINS[aidx]
-                arch_links += f'<button class="arch-link-chip arch-sm" onclick="switchTab(\'arch\',\'arch-dom-{aidx}\')" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
+                arch_links += f'<button class="arch-link-chip arch-sm" data-action="switchTab" data-arg="arch" data-scroll="arch-dom-{h(aidx)}" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
         arch_row = (
             f'<div class="scanner-arch-links"><span class="arch-links-label">Related architecture</span>{arch_links}</div>'
             if arch_links
@@ -242,7 +242,7 @@ def _build_provider_cards(prov_summary):
         pfail = pdata["total_fail"]
         pcrit = pdata["critical"]
         phigh = pdata["high"]
-        prov_cards += '<div class="prov-card" onclick="switchTab(\'prowler\')">'
+        prov_cards += '<div class="prov-card" data-action="switchTab" data-arg="prowler">'
         prov_cards += f'<div class="prov-card-icon">{icon}</div><div class="prov-card-name">{label}</div>'
         prov_cards += f'<div class="prov-card-num">{pfail}<span class="prov-card-total">/{ptotal}</span></div><div class="prov-card-sev">'
         if pcrit > 0:
@@ -346,9 +346,9 @@ def _build_target_posture_table(net_data):
                         detail += f'<div style="margin-top:.35rem">… and {len(issues) - 20} more</div>'
                 detail += "</div>"
 
-            onclick = ' onclick="toggleRow(this)"' if detail else ""
+            row_attr = ' data-action="toggleRow"' if detail else ""
             row_cls = ' class="expandable"' if detail else ""
-            html += f'<tr{row_cls}{onclick}><td class="mono">{h(label)}</td><td>{dns_cnt}</td><td class="mono">{h(tls_grade)}</td><td class="mono">{h(str(http_status))}</td><td class="mono">{h(hsts_txt)}</td><td class="mono">{h(csp_q)}</td><td class="r">{issue_cnt}</td></tr>'
+            html += f'<tr{row_cls}{row_attr}><td class="mono">{h(label)}</td><td>{dns_cnt}</td><td class="mono">{h(tls_grade)}</td><td class="mono">{h(str(http_status))}</td><td class="mono">{h(hsts_txt)}</td><td class="mono">{h(csp_q)}</td><td class="r">{issue_cnt}</td></tr>'
             if detail:
                 html += f'<tr class="row-detail"><td colspan="7"><div class="detail-panel">{detail}</div></td></tr>'
         html += "</tbody></table></div></div>"

--- a/scanner/lib/dashboard_html_compliance.py
+++ b/scanner/lib/dashboard_html_compliance.py
@@ -40,14 +40,14 @@ def _build_compliance_html(compliance_map) -> str:
         for aidx in COMP_FW_TO_ARCH.get(framework, []):
             if aidx < len(ARCH_DOMAINS):
                 d = ARCH_DOMAINS[aidx]
-                comp_arch_html += f'<button class="arch-link-chip arch-sm" onclick="switchTab(\'arch\',\'arch-dom-{aidx}\')" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
+                comp_arch_html += f'<button class="arch-link-chip arch-sm" data-action="switchTab" data-arg="arch" data-scroll="arch-dom-{h(aidx)}" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
         comp_arch_row = (
             f'<div class="comp-arch-links"><span class="arch-links-label">Related architecture</span>{comp_arch_html}</div>'
             if comp_arch_html
             else ""
         )
         na_stat_html = f' / <span class="cs-na">{na_c} n/a</span>' if na_c > 0 else ""
-        comp_html += f'<div class="comp-section" id="{comp_id}"><div class="comp-title" onclick="toggleComp(this)">{h(framework)} <span class="comp-stat"><span class="cs-pass">{pass_c} pass</span> / <span class="cs-fail">{fail_c} fail</span>{na_stat_html}</span><span class="comp-arrow">▸</span></div>'
+        comp_html += f'<div class="comp-section" id="{comp_id}"><div class="comp-title" data-action="toggleComp">{h(framework)} <span class="comp-stat"><span class="cs-pass">{pass_c} pass</span> / <span class="cs-fail">{fail_c} fail</span>{na_stat_html}</span><span class="comp-arrow">▸</span></div>'
         if comp_arch_row:
             comp_html += comp_arch_row
         comp_html += '<div class="comp-body"><table><thead><tr><th>Control</th><th>Name</th><th>Status</th><th>Related</th><th>Summary · Remediation</th></tr></thead><tbody>'

--- a/scanner/lib/dashboard_html_overview.py
+++ b/scanner/lib/dashboard_html_overview.py
@@ -237,7 +237,7 @@ def build_priority_queue_html(
                 ),
                 "chips": chips,
                 "footer": "Jump to top findings",
-                "onclick": "document.getElementById('top-findings-section').scrollIntoView({behavior:'smooth'});",
+                "attrs": 'data-action="scroll-to" data-target="top-findings-section"',
             }
         )
     else:
@@ -249,7 +249,7 @@ def build_priority_queue_html(
                 "body": "Use the remaining items to tighten coverage, medium findings, and operational hygiene.",
                 "chips": ["Urgent backlog clear"],
                 "footer": "Review medium and warning findings",
-                "onclick": "document.getElementById('scanner-section').scrollIntoView({behavior:'smooth'});",
+                "attrs": 'data-action="scroll-to" data-target="scanner-section"',
             }
         )
 
@@ -265,7 +265,7 @@ def build_priority_queue_html(
                 ),
                 "chips": visibility_gaps[:3],
                 "footer": "Open environment and network setup",
-                "onclick": "switchTab('networktools');",
+                "attrs": 'data-action="switchTab" data-arg="networktools"',
             }
         )
     else:
@@ -277,7 +277,7 @@ def build_priority_queue_html(
                 "body": "Environment, cloud, and telemetry inputs are present, so prioritization is based on a broader signal set.",
                 "chips": ["Coverage baseline met"],
                 "footer": "Inspect coverage details",
-                "onclick": "document.getElementById('scanner-section').scrollIntoView({behavior:'smooth'});",
+                "attrs": 'data-action="scroll-to" data-target="scanner-section"',
             }
         )
 
@@ -292,10 +292,10 @@ def build_priority_queue_html(
                 ),
                 "chips": focus_items[:3],
                 "footer": "Open the dominant area",
-                "onclick": (
-                    "switchTab('prowler');"
+                "attrs": (
+                    'data-action="switchTab" data-arg="prowler"'
                     if top_provider and (not top_scanner_categories or top_provider[2] >= top_scanner_categories[0][1])
-                    else "document.getElementById('scanner-section').scrollIntoView({behavior:'smooth'});"
+                    else 'data-action="scroll-to" data-target="scanner-section"'
                 ),
             }
         )
@@ -308,14 +308,14 @@ def build_priority_queue_html(
                 "body": "When findings are low, the next wins come from best-practice adoption, design review, and missing telemetry setup.",
                 "chips": ["Architecture", "Code security", "Network tooling"],
                 "footer": "Review guidance surfaces",
-                "onclick": "switchTab('bestpractices');",
+                "attrs": 'data-action="switchTab" data-arg="bestpractices"',
             }
         )
 
     html = '<div class="priority-grid">'
     for card in cards:
         html += (
-            f'<button class="priority-card priority-{h(card["tone"])}" onclick="{card["onclick"]}" type="button">'
+            f'<button class="priority-card priority-{h(card["tone"])}" {card["attrs"]} type="button">'
             f'<div class="priority-kicker">{h(card["kicker"])}</div>'
             f'<div class="priority-title">{h(card["title"])}</div>'
             f'<div class="priority-body">{h(card["body"])}</div>'
@@ -390,10 +390,10 @@ def _build_top_findings(findings_list, all_findings):
             if cnt > 1
             else ""
         )
-        tab_click = (
-            "switchTab('overview','scanner-section')"
+        tab_attrs = (
+            'data-action="switchTab" data-arg="overview" data-scroll="scanner-section"'
             if str(ff["provider"]) == "Scanner"
-            else "switchTab('prowler')"
+            else 'data-action="switchTab" data-arg="prowler"'
         )
         severity_text = str(ff["severity"])
         provider_text = str(ff["provider"])
@@ -403,7 +403,7 @@ def _build_top_findings(findings_list, all_findings):
         resource_text = str(ff.get("resource") or "")
         res_html = f'<div class="tf-resource"><span class="tf-res-label">Location:</span> <code>{h(resource_text[:80])}</code></div>' if resource_text else ""
         action_html = f'<div class="tf-action"><span class="tf-act-label">Action:</span> {h(en["action"][:120])}</div>'
-        top_findings_html += f'<div class="top-finding" onclick="{tab_click}"><div class="tf-badge">{sev_badge(severity_text)}</div><div class="tf-body"><div class="tf-check"><code>{h(check_text)}</code><span class="tf-prov">{h(provider_text.upper())}</span>{cnt_html}</div><div class="tf-msg">{h(message_text[:150])}</div>{res_html}{action_html}</div></div>'
+        top_findings_html += f'<div class="top-finding" {tab_attrs}><div class="tf-badge">{sev_badge(severity_text)}</div><div class="tf-body"><div class="tf-check"><code>{h(check_text)}</code><span class="tf-prov">{h(provider_text.upper())}</span>{cnt_html}</div><div class="tf-msg">{h(message_text[:150])}</div>{res_html}{action_html}</div></div>'
     if not top_findings_html:
         top_findings_html = '<div class="top-finding" style="border-color:var(--border)"><div class="tf-body" style="color:var(--muted);font-size:.9rem">No critical or high findings from the scanner or Prowler in this scan. Check the Scanner and Prowler CSPM tabs for full results.</div></div>'
     return top_findings_html

--- a/scanner/lib/dashboard_html_owasp.py
+++ b/scanner/lib/dashboard_html_owasp.py
@@ -31,7 +31,7 @@ def _build_owasp_html(owasp_map):
         count = len(findings)
         status_cls = "pass" if count == 0 else "fail"
         out += f'<div class="owasp-item {status_cls}" id="owasp-{oid}">'
-        out += f'<div class="owasp-header" onclick="toggleOwasp(this)"><span class="owasp-id">{oid}</span><span class="owasp-name">{h(ow["name"])}</span><span class="owasp-count">{count}</span><span class="owasp-arrow">▸</span></div>'
+        out += f'<div class="owasp-header" data-action="toggleOwasp"><span class="owasp-id">{oid}</span><span class="owasp-name">{h(ow["name"])}</span><span class="owasp-count">{count}</span><span class="owasp-arrow">▸</span></div>'
         arch_idx_list = OWASP_TO_ARCH.get(
             oid, OWASP_TO_ARCH.get(oid.split(":")[0] if ":" in oid else oid, [])
         )
@@ -49,7 +49,7 @@ def _build_owasp_html(owasp_map):
             for i in arch_idx_list:
                 d = ARCH_DOMAINS[i] if i < len(ARCH_DOMAINS) else None
                 if d:
-                    out += f'<button class="arch-link-chip" onclick="switchTab(\'arch\',\'arch-dom-{i}\')" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
+                    out += f'<button class="arch-link-chip" data-action="switchTab" data-arg="arch" data-scroll="arch-dom-{h(i)}" title="{h(d["name"])}">{d["icon"]} {h(d["name"])}</button>'
             out += "</div>"
         if findings:
             out += '<div class="owasp-findings">'
@@ -70,7 +70,7 @@ def _build_owasp_html(owasp_map):
     out += '<p style="font-size:.82rem;color:var(--muted);margin-bottom:1rem">AI/LLM application security risks — <a href="https://genai.owasp.org/resource/owasp-top-10-for-llm-applications-2025/" target="_blank" style="color:var(--accent)">Official docs</a></p>'
     for llm in OWASP_LLM_2025:
         out += f'<div class="owasp-item" style="border-left:3px solid var(--accent)">'
-        out += f'<div class="owasp-header" onclick="toggleOwasp(this)"><span class="owasp-id" style="color:#f59e0b">{llm["id"]}</span><span class="owasp-name">{h(llm["name"])}</span><span class="owasp-arrow">▸</span></div>'
+        out += f'<div class="owasp-header" data-action="toggleOwasp"><span class="owasp-id" style="color:#f59e0b">{llm["id"]}</span><span class="owasp-name">{h(llm["name"])}</span><span class="owasp-arrow">▸</span></div>'
         summary = (llm.get("summary") or llm.get("desc") or "").strip()
         action = (
             llm.get("action")

--- a/scanner/lib/dashboard_html_sections.py
+++ b/scanner/lib/dashboard_html_sections.py
@@ -108,28 +108,28 @@ def _build_prov_table(prov_summary) -> str:
         seen.add(pname)
         label = h(_prov_labels.get(pname, pname))
         subtab = _subtab_map.get(pname)
-        onclick = (
-            f' onclick="switchProvTab(\'{h(subtab)}\')" style="cursor:pointer"'
+        row_attr = (
+            f' data-action="switchProvTab" data-arg="{h(subtab)}" style="cursor:pointer"'
             if subtab
             else ""
         )
         total_cells = pdata["total_fail"] + pdata["total_pass"]
         no_data = total_cells == 0 and pname in ("kubernetes", "googleworkspace")
         if no_data:
-            prov_table += f'<tr class="prov-row-no-data"{onclick}><td>{label} <span style="font-size:.7rem;color:var(--muted);font-weight:400" title="Add to prowler_providers in .claudesec.yml and configure credentials (kubeconfig / GOOGLE_WORKSPACE_CUSTOMER_ID)">— not run</span></td><td class="r">0</td><td class="r">0</td><td class="r">0</td><td class="r">0</td><td class="r">0</td><td class="r">0</td></tr>'
+            prov_table += f'<tr class="prov-row-no-data"{row_attr}><td>{label} <span style="font-size:.7rem;color:var(--muted);font-weight:400" title="Add to prowler_providers in .claudesec.yml and configure credentials (kubeconfig / GOOGLE_WORKSPACE_CUSTOMER_ID)">— not run</span></td><td class="r">0</td><td class="r">0</td><td class="r">0</td><td class="r">0</td><td class="r">0</td><td class="r">0</td></tr>'
         else:
-            prov_table += f'<tr{onclick}><td>{label}</td><td class="r">{total_cells}</td><td class="r" style="color:#f87171">{pdata["critical"]}</td><td class="r" style="color:#fca5a5">{pdata["high"]}</td><td class="r" style="color:#fde68a">{pdata["medium"]}</td><td class="r">{pdata["low"]}</td><td class="r" style="color:#22c55e">{pdata["total_pass"]}</td></tr>'
+            prov_table += f'<tr{row_attr}><td>{label}</td><td class="r">{total_cells}</td><td class="r" style="color:#f87171">{pdata["critical"]}</td><td class="r" style="color:#fca5a5">{pdata["high"]}</td><td class="r" style="color:#fde68a">{pdata["medium"]}</td><td class="r">{pdata["low"]}</td><td class="r" style="color:#22c55e">{pdata["total_pass"]}</td></tr>'
     for pname, pdata in sorted(prov_summary.items()):
         if pname in seen:
             continue
         label = h(_prov_labels.get(pname, pname))
         subtab = _subtab_map.get(pname)
-        onclick = (
-            f' onclick="switchProvTab(\'{h(subtab)}\')" style="cursor:pointer"'
+        row_attr = (
+            f' data-action="switchProvTab" data-arg="{h(subtab)}" style="cursor:pointer"'
             if subtab
             else ""
         )
-        prov_table += f'<tr{onclick}><td>{label}</td><td class="r">{pdata["total_fail"] + pdata["total_pass"]}</td><td class="r" style="color:#f87171">{pdata["critical"]}</td><td class="r" style="color:#fca5a5">{pdata["high"]}</td><td class="r" style="color:#fde68a">{pdata["medium"]}</td><td class="r">{pdata["low"]}</td><td class="r" style="color:#22c55e">{pdata["total_pass"]}</td></tr>'
+        prov_table += f'<tr{row_attr}><td>{label}</td><td class="r">{pdata["total_fail"] + pdata["total_pass"]}</td><td class="r" style="color:#f87171">{pdata["critical"]}</td><td class="r" style="color:#fca5a5">{pdata["high"]}</td><td class="r" style="color:#fde68a">{pdata["medium"]}</td><td class="r">{pdata["low"]}</td><td class="r" style="color:#22c55e">{pdata["total_pass"]}</td></tr>'
     return prov_table
 
 

--- a/scanner/tests/test_dashboard_gen_smoke.py
+++ b/scanner/tests/test_dashboard_gen_smoke.py
@@ -625,20 +625,22 @@ class DashboardGenSmokeTest(unittest.TestCase):
 
             html = output_file.read_text(encoding="utf-8")
 
-            # Env pills: all pills are <button> with onclick="openSetup(...)"
+            # Env pills: all pills are <button> with data-action="openSetup"
             self.assertIn("env-pill", html)
-            self.assertIn("openSetup(", html)
+            self.assertIn('data-action="openSetup"', html)
             # Both connected (env-on) and disconnected (env-off) use <button>
             self.assertIn("env-on", html) if "env-on" in html else None
             self.assertIn("env-off", html)
-            # onclick values must be HTML-escaped (no raw quotes that break attributes)
-            self.assertNotIn("openSetup('<script>", html)
+            # data-arg values must be HTML-escaped (no raw markup that breaks attributes)
+            self.assertNotIn('data-arg="<script>', html)
+            # CSP-safe delegation: no inline onclick opening the setup modal
+            self.assertNotIn('onclick="openSetup', html)
 
             # Prowler provider table: fixed providers shown even without data
             self.assertIn("K8s", html)
             self.assertIn("Google Workspace", html)
             self.assertIn("not run", html)  # no-data providers show "not run"
-            self.assertIn("switchProvTab(", html)
+            self.assertIn('data-action="switchProvTab"', html)
 
             # Scanner findings section renders
             self.assertIn("INFRA-001", html)

--- a/scanner/tests/test_dashboard_no_inline_handlers.py
+++ b/scanner/tests/test_dashboard_no_inline_handlers.py
@@ -1,0 +1,196 @@
+"""
+Regression guard: the dashboard must contain NO inline event-handler attributes
+(`onclick=`, `onchange=`, `onkeyup=`, ...).
+
+The dashboard ships a strict meta-CSP (`script-src 'nonce-…' 'strict-dynamic'`,
+no `'unsafe-inline'`), so any inline `on*=` handler is silently DEAD in the
+browser — the click/change/input never fires. All interactivity is instead wired
+through the document-level event-delegation dispatchers in
+`dashboard-template.html`, keyed on `data-action` / `data-change` / `data-input`.
+This guard fails loudly if an inline handler is reintroduced, in either:
+
+  1. the builder SOURCE (`scanner/lib/dashboard*.{py,html}`), or
+  2. the rendered markup of the builders that previously carried handlers
+     (audit-points / MS+SaaS sources / OWASP expanders).
+
+stdlib-only. No network. Passes under pytest and `python3 -m unittest`.
+
+OWASP A03 (Injection) / A05 (Security Misconfiguration): keeping the CSP strict
+and the handlers delegated preserves the XSS mitigation the CSP provides.
+"""
+
+import os
+import re
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LIB_DIR = REPO_ROOT / "scanner" / "lib"
+sys.path.insert(0, str(LIB_DIR))
+
+# Matches an inline HTML event-handler attribute: whitespace, then `on<name>`,
+# then `=`, then an opening quote. `content=`, `font=`, `data-*` etc. never begin
+# with the literal `on`, so they never match; `addEventListener('click'...)` has
+# no `=` after the handler name so it never matches either.
+INLINE_HANDLER_RE = re.compile(r"""\son[a-z]+\s*=\s*["']""", re.IGNORECASE)
+
+# Every builder source that emits dashboard markup.
+_SOURCE_FILES = [
+    "dashboard-template.html",
+    "dashboard-gen.py",
+    "dashboard_html_overview.py",
+    "dashboard_html_arch.py",
+    "dashboard_html_owasp.py",
+    "dashboard_html_compliance.py",
+    "dashboard_html_builders.py",
+    "dashboard_html_sections.py",
+    "dashboard_html_audit_points.py",
+    "dashboard_html_audit_sources.py",
+]
+
+
+def _strip_scripts_styles(text: str) -> str:
+    """Remove <script>/<style> blocks so JS/CSS bodies aren't scanned as attrs."""
+    text = re.sub(r"(?is)<script\b.*?</script>", "", text)
+    text = re.sub(r"(?is)<style\b.*?</style>", "", text)
+    return text
+
+
+def _strip_py_comments(text: str) -> str:
+    """Drop `#` line comments so prose like 'inline onclick' isn't flagged."""
+    return "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+
+
+def _render_builder_markup() -> str:
+    """Render the builders that previously carried inline handlers, on fixture
+    data, and return the concatenated HTML. Deterministic and offline: calls the
+    pure builder functions directly (no GitHub, no file IO)."""
+    from dashboard_html_audit_points import build_audit_points_querypie_html
+    from dashboard_html_audit_sources import (
+        build_ms_sources_html,
+        build_saas_sources_html,
+    )
+    from dashboard_html_owasp import _build_owasp_html
+
+    audit_points = {
+        "fetched_at": "2026-01-01T00:00:00Z",
+        "products": [
+            {
+                "name": "Jenkins",
+                "tree_url": "https://github.com/querypie/audit-points/tree/main/Jenkins",
+                "files": [
+                    {"name": "hardening.md", "url": "https://example.test/1"},
+                    {"name": "rbac.md", "url": "https://example.test/2"},
+                ],
+            }
+        ],
+    }
+    audit_points_detected = {"detected_products": ["Jenkins"], "items": []}
+
+    ms_data = {
+        "fetched_at": "2026-01-01T00:00:00Z",
+        "source_filter": "all",
+        "scubagear_enabled": False,
+        "sources": [
+            {
+                "product": "Windows",
+                "label": "Windows Security Baseline",
+                "repo": "microsoft/SecurityBaselines",
+                "repo_url": "https://github.com/microsoft/SecurityBaselines",
+                "trust_level": "Microsoft Official",
+                "reason": "Official baseline",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "files": [{"path": "win/baseline.md", "url": "https://example.test/w1"}],
+            }
+        ],
+    }
+
+    parts = [
+        build_audit_points_querypie_html(audit_points, audit_points_detected),
+        build_ms_sources_html(ms_data),
+        # Empty dict -> falls back to the default SAAS sources (still exercises
+        # the ms-source card-title / checkbox delegation branch).
+        build_saas_sources_html({}),
+        # Empty map -> still renders every static OWASP item header (toggleOwasp).
+        _build_owasp_html({}),
+    ]
+    return "".join(parts)
+
+
+class TestNoInlineHandlersInSource(unittest.TestCase):
+    def test_no_inline_handlers_in_builder_sources(self):
+        offenders = []
+        for name in _SOURCE_FILES:
+            path = LIB_DIR / name
+            self.assertTrue(path.is_file(), f"builder source missing: {path}")
+            scan = _strip_scripts_styles(path.read_text(encoding="utf-8"))
+            if name.endswith(".py"):
+                scan = _strip_py_comments(scan)
+            for m in INLINE_HANDLER_RE.finditer(scan):
+                offenders.append(f"{name}: ...{scan[max(0, m.start() - 20):m.end() + 5]!r}")
+        self.assertEqual(
+            offenders,
+            [],
+            "Inline event-handler attribute(s) found in dashboard builder "
+            "sources — these are DEAD under the strict CSP. Wire the control "
+            "through the data-action / data-change / data-input delegation in "
+            "dashboard-template.html instead:\n  " + "\n  ".join(offenders),
+        )
+
+
+class TestNoInlineHandlersInRenderedMarkup(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.markup = _render_builder_markup()
+        cls.body = _strip_scripts_styles(cls.markup)
+
+    def test_rendered_markup_has_no_inline_handlers(self):
+        offenders = [
+            self.body[max(0, m.start() - 30):m.end() + 10]
+            for m in INLINE_HANDLER_RE.finditer(self.body)
+        ]
+        self.assertEqual(
+            offenders,
+            [],
+            "Inline event-handler attribute(s) in RENDERED builder markup — "
+            "dead under the CSP:\n  " + "\n  ".join(repr(o) for o in offenders),
+        )
+
+    def test_rendered_markup_uses_delegation(self):
+        # Sanity: the render actually produced delegated controls (guards
+        # against a vacuous pass if a fixture stopped emitting markup). These
+        # are the exact handlers the CSP-dead-control migration recovered.
+        for token in (
+            'data-action="toggleApProduct"',
+            'data-input="apFilterProducts"',
+            'data-change="apToggleCheck"',
+            'data-action="toggleMsSrc"',
+            'data-action="applyMsSourcePresetFilter"',
+            'data-change="apToggleCheckMs"',
+            'data-action="stop"',
+            'data-action="toggleOwasp"',
+        ):
+            self.assertIn(
+                token,
+                self.markup,
+                f"expected delegated control {token} missing from render",
+            )
+
+
+# Bare test_* functions so pytest function-collection also runs the core checks.
+def test_source_has_no_inline_handlers():
+    for name in _SOURCE_FILES:
+        scan = _strip_scripts_styles((LIB_DIR / name).read_text(encoding="utf-8"))
+        if name.endswith(".py"):
+            scan = _strip_py_comments(scan)
+        assert not INLINE_HANDLER_RE.search(scan), f"inline handler in {name}"
+
+
+def test_rendered_markup_has_no_inline_handlers_fn():
+    body = _strip_scripts_styles(_render_builder_markup())
+    assert not INLINE_HANDLER_RE.search(body), "inline handler in rendered markup"
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
The dashboard meta-CSP (`script-src 'nonce-…' 'strict-dynamic'`, no `'unsafe-inline'`) correctly blocks inline event handlers, but ~48 controls still emitted inline `onclick`/`onchange`/`onkeyup` and were therefore **dead in any CSP-enforcing browser** — empirically confirmed in headless Chrome 150 (OWASP / Architecture / Compliance expanders, provider setup modal, in-content jump-links, print, provider row-clicks all non-functional). This completes the `data-action` delegation migration started in #366.

The CSP is left **strict and untouched** — the fix works *with* the strict policy, it does not weaken it.

## Changes
- **`dashboard-template.html`** — extend the document-level `click` dispatcher with cases: `stop` / `print` / `openSetup`(data-arg) / `toggleOwasp|Arch|Comp`(btn) / `toggleApProduct` / `toggleMsSrc` / `togglePolDet` / `applyMsSourcePresetFilter` / `toggleRepoOverflow` / `toggleResOverflow`; add delegated `change` (data-change: `apToggleCheck[/Ms/Saas]`, `openProwler`) and `input` (data-input: `apFilterProducts`) listeners; migrate the print button.
- **`dashboard-gen.py` + `dashboard_html_{overview,arch,owasp,compliance,builders,sections,audit_points,audit_sources}.py`** — convert all 48 remaining inline handlers to `data-action`/`data-change`/`data-input` (+`data-arg`/`data-scroll`). **`h()` escaping preserved** on every interpolated attribute value (quoted-attr context, #366 pattern). Overflow label text moved to `data-more-label`/`data-hide-label`.
- **NEW `scanner/tests/test_dashboard_no_inline_handlers.py`** — regression guard (stdlib-only, pytest + unittest dual-runner): source scan of all 10 builders+template for inline `on*=`, plus a direct-render assertion; fail-injection verified.
- Updated `test_dashboard_gen_smoke.py` to pin the new `data-action` markup (coverage preserved).

## Test plan
- [x] `python3 -m pytest scanner/ -q` → **1564 passed, 5 skipped** (offline)
- [x] Generated HTML has **0 inline handlers**; `script-src` stays strict (only pre-existing `style-src 'unsafe-inline'`)
- [x] Dashboard shell tests: `test_generate_html_dashboard.sh` 36, prowler-summary 24, provider-label 20 — all pass
- [x] New guard green under both pytest and `unittest`; FAILS when a handler is reintroduced
- [x] **Headless Chrome 150** (`--headless=new`, real generated dashboard + nonce'd harness + `securitypolicyviolation` listener): every formerly-dead control WORKS; 3 attack probes (inline onclick / `javascript:` href / nonce-less `<script>`) still BLOCKED; 0 self-violations

## Out of scope (pre-existing)
The QueryPie Audit-Points / MS-SaaS section has no `{{AUDIT_POINTS_HTML}}` placeholder in the template (absent on `main` too), so its now-migrated handlers aren't yet exercised in the live dashboard. Flagged for a possible follow-up to restore the placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)