### PR TITLE
test(scanner): clear CodeQL FP on host-string test assertions

### DIFF
--- a/scanner/tests/test_dashboard_html_builders_pure.py
+++ b/scanner/tests/test_dashboard_html_builders_pure.py
@@ -532,7 +532,10 @@ def test_target_posture_shows_identifier_when_env_set():
                                             "dns": {"ips": []}, "tls": {"grade": "A"},
                                             "http": {"status": 200}}]}
         })
-    assert "example.com" in html
+    # Assert the fully-delimited rendered table cell, not a bare host
+    # substring — this is checking rendered HTML output, not validating a
+    # URL/host (avoids the py/incomplete-url-substring-sanitization heuristic).
+    assert '<td class="mono">example.com</td>' in html
 
 
 def test_target_posture_renders_dns_count():

--- a/scanner/tests/test_dashboard_html_network_unit.py
+++ b/scanner/tests/test_dashboard_html_network_unit.py
@@ -85,7 +85,10 @@ def test_config_section_populated_targets_rendered():
     """Populated CLAUDESEC_NETWORK_SCAN_TARGETS is rendered in output."""
     with _env(CLAUDESEC_NETWORK_SCAN_TARGETS="example.com:443"):
         html, _, net_targets, _ = build_network_config_section()
-    assert "example.com:443" in html
+    # Assert the fully-delimited rendered element, not a bare host:port
+    # substring — this is checking rendered HTML output, not validating a
+    # URL/host (avoids the py/incomplete-url-substring-sanitization heuristic).
+    assert ">example.com:443</div>" in html
     assert net_targets == "example.com:443"
 
 


### PR DESCRIPTION
## Summary

Clears two pre-existing CodeQL default-setup false positives (rule
`py/incomplete-url-substring-sanitization`, HIGH, open since April 2026):

- `scanner/tests/test_dashboard_html_builders_pure.py` — `assert "example.com" in html`
- `scanner/tests/test_dashboard_html_network_unit.py` — `assert "example.com:443" in html`

Both are test assertions checking that a host string appears in **rendered
dashboard HTML output** — not a URL being sanitized. CodeQL's heuristic
misfires on the `"<literal>" in <var>` shape and assumes `var` is a URL
under an incomplete substring check.

### Fix

Rewrote each assertion to check the fully HTML-delimited fragment that
actually appears in the rendered output (verified by printing the real
`html` value locally), instead of a bare host/host:port substring:

- `assert "example.com" in html` → `assert '<td class="mono">example.com</td>' in html`
- `assert "example.com:443" in html` → `assert ">example.com:443</div>" in html`

This preserves the original test intent (the host string is rendered in
the output) while no longer matching the `py/incomplete-url-substring-sanitization`
pattern, since the checked literal is now clearly a delimited HTML element,
not a bare URL/host under validation.

No production code was touched — only these two test assertions (plus
inline comments explaining why).

## Test plan

- [x] `export CLAUDESEC_DASHBOARD_OFFLINE=1`
- [x] `python3 -m pytest scanner/tests/test_dashboard_html_builders_pure.py scanner/tests/test_dashboard_html_network_unit.py -q` → 160 passed
- [x] `python3 -m pytest scanner/ -q` → 1564 passed, 5 skipped (pre-existing skips, unrelated)
- [ ] CodeQL check on this PR clears `py/incomplete-url-substring-sanitization` on both lines (verify once PR analysis run completes — CodeQL only re-runs per-PR for default setup)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>