### PR TITLE
fix(scanner): gate href schemes at policies + audit-points/MS/SaaS source sinks (XSS DiD)

### DIFF
--- a/scanner/lib/dashboard-gen.py
+++ b/scanner/lib/dashboard-gen.py
@@ -584,7 +584,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
                 _isms_colors = ["var(--accent)", "#0984e3", "#00b894", "#f39c12", "#e17055", "#6c5ce7", "#fd79a8", "#00cec9"]
                 for _pi, _pol in enumerate(_policies):
                     _color = _isms_colors[_pi % len(_isms_colors)]
-                    _url = h(_pol.get("url", ""))
+                    _url = h(safe_url(_pol.get("url", "")))
                     _name = h(_pol.get("name", ""))
                     _ch = _pol.get("total_chapters", 0)
                     _ar = _pol.get("total_articles", 0)
@@ -611,7 +611,7 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
                             if _ach != _cur_ch:
                                 _cur_ch = _ach
                                 policies_html += f'<div style="font-size:11px;font-weight:700;color:var(--accent);margin:6px 0 3px">{h(_ach)}</div>'
-                            policies_html += f'<div style="font-size:11px;color:var(--muted);padding:1px 0">{_a.get("num", "")}. {h(_a.get("title", ""))}</div>'
+                            policies_html += f'<div style="font-size:11px;color:var(--muted);padding:1px 0">{h(_a.get("num", ""))}. {h(_a.get("title", ""))}</div>'
                         policies_html += '</div>'
                     policies_html += '</div>'
                 policies_html += '</div>'

--- a/scanner/lib/dashboard_html_audit_points.py
+++ b/scanner/lib/dashboard_html_audit_points.py
@@ -16,6 +16,7 @@ if _LIB_DIR not in sys.path:
 
 from dashboard_utils import (
     h,
+    safe_url,
     AUDIT_POINTS_REPO,
 )
 
@@ -86,7 +87,7 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
             audit_points_html += '<span class="ap-product-chevron">▶</span>'
             audit_points_html += '</div>'
             audit_points_html += '<div class="ap-product-body">'
-            audit_points_html += f'<a href="{h(tree_url)}" target="_blank" rel="noopener" class="ap-product-github-link">Open on GitHub ↗</a>'
+            audit_points_html += f'<a href="{h(safe_url(tree_url))}" target="_blank" rel="noopener" class="ap-product-github-link">Open on GitHub ↗</a>'
             for idx, f in enumerate(files, start=1):
                 url = f.get("url") or f.get("raw_url") or "#"
                 fname = f.get("name", "")
@@ -95,7 +96,7 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
                 audit_points_html += f'<div class="bp-audit-item-row" data-ap-id="{h(cb_id)}">'
                 audit_points_html += f'<input type="checkbox" class="ap-checkbox" data-ap-id="{h(cb_id)}" data-change="apToggleCheck">'
                 audit_points_html += f'<span class="bp-audit-index">{idx}</span>'
-                audit_points_html += f'<a href="{h(url)}" target="_blank" rel="noopener" class="bp-audit-link">{h(fname)}</a>'
+                audit_points_html += f'<a href="{h(safe_url(url))}" target="_blank" rel="noopener" class="bp-audit-link">{h(fname)}</a>'
                 if ext:
                     audit_points_html += f'<span class="bp-audit-ext">.{h(ext)}</span>'
                 audit_points_html += "</div>"
@@ -108,7 +109,7 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
             audit_points_html = audit_points_html or _bp_intro
         title = "All products" if detected_products else "QueryPie Audit Points"
         audit_points_html += f'<div class="card bp-audit-section" style="margin-bottom:1rem"><div class="card-title" style="display:flex;align-items:center;gap:.5rem">{h(title)} <span class="badge" style="font-size:.65rem">{len(all_products)} products · {total_items} items</span></div><div style="padding:.75rem 1rem">'
-        audit_points_html += f'<p style="color:var(--muted);font-size:.82rem;margin-bottom:.75rem">SaaS/DevSecOps audit checklists from <a href="{h(repo_url)}" target="_blank" rel="noopener" style="color:var(--accent)">querypie/audit-points</a>. Click a product to expand.</p>'
+        audit_points_html += f'<p style="color:var(--muted);font-size:.82rem;margin-bottom:.75rem">SaaS/DevSecOps audit checklists from <a href="{h(safe_url(repo_url))}" target="_blank" rel="noopener" style="color:var(--accent)">querypie/audit-points</a>. Click a product to expand.</p>'
         for prod in all_products:
             pname = prod.get("name", "")
             is_detected = pname in detected_products
@@ -127,7 +128,7 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
             audit_points_html += '<span class="ap-product-chevron">▶</span>'
             audit_points_html += '</div>'
             audit_points_html += '<div class="ap-product-body">'
-            audit_points_html += f'<a href="{h(tree_url)}" target="_blank" rel="noopener" class="ap-product-github-link">Open on GitHub ↗</a>'
+            audit_points_html += f'<a href="{h(safe_url(tree_url))}" target="_blank" rel="noopener" class="ap-product-github-link">Open on GitHub ↗</a>'
             for idx, f in enumerate(files[:50], start=1):
                 url = f.get("url") or f.get("raw_url") or "#"
                 fname = f.get("name", "")
@@ -136,12 +137,12 @@ def build_audit_points_querypie_html(audit_points_data, audit_points_detected) -
                 audit_points_html += f'<div class="bp-audit-item-row" data-ap-id="{h(cb_id)}">'
                 audit_points_html += f'<input type="checkbox" class="ap-checkbox" data-ap-id="{h(cb_id)}" data-change="apToggleCheck">'
                 audit_points_html += f'<span class="bp-audit-index">{idx}</span>'
-                audit_points_html += f'<a href="{h(url)}" target="_blank" rel="noopener" class="bp-audit-link">{h(fname)}</a>'
+                audit_points_html += f'<a href="{h(safe_url(url))}" target="_blank" rel="noopener" class="bp-audit-link">{h(fname)}</a>'
                 if ext:
                     audit_points_html += f'<span class="bp-audit-ext">.{h(ext)}</span>'
                 audit_points_html += "</div>"
             if len(files) > 50:
-                audit_points_html += f'<div style="padding:.3rem .5rem;font-size:.78rem;color:var(--muted)">… and {len(files) - 50} more in <a href="{h(tree_url)}" target="_blank" rel="noopener" style="color:var(--accent)">GitHub folder</a></div>'
+                audit_points_html += f'<div style="padding:.3rem .5rem;font-size:.78rem;color:var(--muted)">… and {len(files) - 50} more in <a href="{h(safe_url(tree_url))}" target="_blank" rel="noopener" style="color:var(--accent)">GitHub folder</a></div>'
             audit_points_html += "</div></div>"
         if audit_points_data.get("fetched_at"):
             audit_points_html += f'<p style="font-size:.72rem;color:var(--muted);margin-top:.75rem">Cache updated: {h(audit_points_data["fetched_at"][:19])}</p>'

--- a/scanner/lib/dashboard_html_audit_sources.py
+++ b/scanner/lib/dashboard_html_audit_sources.py
@@ -16,6 +16,7 @@ if _LIB_DIR not in sys.path:
 
 from dashboard_utils import (
     h,
+    safe_url,
     TRUST_LEVEL_ORDER,
     MS_INCLUDE_SCUBAGEAR_ENV,
     MS_SOURCE_FILTER_ENV,
@@ -109,14 +110,14 @@ def build_ms_sources_html(ms_best_practices_data) -> str:
                 audit_points_html += f'<div class="card ms-source-entry" data-trust-token="{h(trust_token)}" style="margin-bottom:.75rem;padding:0"><div class="card-title" data-action="toggleMsSrc" style="cursor:pointer;user-select:none;display:flex;align-items:center;gap:.5rem"><input type="checkbox" class="ap-checkbox ms-src-checkbox" data-ap-id="{h(src_id)}" data-change="apToggleCheckMs" data-action="stop"> ▸ {h(label)} <span class="trust-badge {h(trust_class)}">{h(trust_level)}</span>{archive_tag} <span style="font-size:.75rem;color:var(--muted);font-weight:400">({len(files)} files)</span></div>'
                 audit_points_html += '<div class="ms-src-body" style="padding:.75rem 1rem">'
                 audit_points_html += f'<div style="color:var(--muted);font-size:.82rem;margin-bottom:.45rem">{h(reason)}</div>'
-                audit_points_html += f'<a href="{h(repo_url)}" target="_blank" rel="noopener" style="color:var(--accent);font-size:.85rem">Open repository</a>'
+                audit_points_html += f'<a href="{h(safe_url(repo_url))}" target="_blank" rel="noopener" style="color:var(--accent);font-size:.85rem">Open repository</a>'
                 if updated:
                     audit_points_html += f'<span style="font-size:.75rem;color:var(--muted);margin-left:.5rem">Updated: {h(updated[:10])}</span>'
                 for fidx, f in enumerate(files[:25]):
                     url = f.get("url") or f.get("raw_url") or "#"
                     fname = f.get("path") or f.get("name") or "file"
                     file_id = f"{src_id}-f{fidx}"
-                    audit_points_html += f'<div class="bp-audit-item-row" style="margin-top:.35rem"><input type="checkbox" class="ap-checkbox ms-file-checkbox" data-ap-id="{h(file_id)}" data-change="apToggleCheckMs"><a href="{h(url)}" target="_blank" rel="noopener" class="mono bp-audit-link" style="font-size:.8rem;color:var(--text)">{h(fname)}</a></div>'
+                    audit_points_html += f'<div class="bp-audit-item-row" style="margin-top:.35rem"><input type="checkbox" class="ap-checkbox ms-file-checkbox" data-ap-id="{h(file_id)}" data-change="apToggleCheckMs"><a href="{h(safe_url(url))}" target="_blank" rel="noopener" class="mono bp-audit-link" style="font-size:.8rem;color:var(--text)">{h(fname)}</a></div>'
                 if len(files) > 25:
                     audit_points_html += f'<div style="margin-top:.5rem;color:var(--muted);font-size:.78rem">… and {len(files) - 25} more files</div>'
                 audit_points_html += "</div></div>"
@@ -174,14 +175,14 @@ def build_saas_sources_html(saas_bp_data) -> str:
                 audit_points_html += f'<div class="card ms-source-entry" style="margin-bottom:.75rem;padding:0"><div class="card-title" data-action="toggleMsSrc" style="cursor:pointer;user-select:none;display:flex;align-items:center;gap:.5rem"><input type="checkbox" class="ap-checkbox saas-src-checkbox" data-ap-id="{h(src_id)}" data-change="apToggleCheckSaas" data-action="stop"> ▸ {h(label)} <span class="trust-badge {h(trust_class)}">{h(trust_level)}</span> <span style="font-size:.75rem;color:var(--muted);font-weight:400">({len(files)} files)</span></div>'
                 audit_points_html += '<div class="ms-src-body" style="padding:.75rem 1rem">'
                 audit_points_html += f'<div style="color:var(--muted);font-size:.82rem;margin-bottom:.45rem">{h(reason)}</div>'
-                audit_points_html += f'<a href="{h(repo_url)}" target="_blank" rel="noopener" style="color:var(--accent);font-size:.85rem">Open repository ↗</a>'
+                audit_points_html += f'<a href="{h(safe_url(repo_url))}" target="_blank" rel="noopener" style="color:var(--accent);font-size:.85rem">Open repository ↗</a>'
                 if focus:
                     audit_points_html += f'<div style="color:var(--muted);font-size:.78rem;margin-top:.35rem">Focus paths: <code>{h(focus)}</code></div>'
                 for fidx, fl in enumerate(files[:25]):
                     url = fl.get("url") or fl.get("raw_url") or "#"
                     fname = fl.get("path") or fl.get("name") or "file"
                     file_id = f"{src_id}-f{fidx}"
-                    audit_points_html += f'<div class="bp-audit-item-row" style="margin-top:.35rem"><input type="checkbox" class="ap-checkbox saas-file-checkbox" data-ap-id="{h(file_id)}" data-change="apToggleCheckSaas"><a href="{h(url)}" target="_blank" rel="noopener" class="mono bp-audit-link" style="font-size:.8rem;color:var(--text)">{h(fname)}</a></div>'
+                    audit_points_html += f'<div class="bp-audit-item-row" style="margin-top:.35rem"><input type="checkbox" class="ap-checkbox saas-file-checkbox" data-ap-id="{h(file_id)}" data-change="apToggleCheckSaas"><a href="{h(safe_url(url))}" target="_blank" rel="noopener" class="mono bp-audit-link" style="font-size:.8rem;color:var(--text)">{h(fname)}</a></div>'
                 audit_points_html += "</div></div>"
         audit_points_html += "</div>"
     else:

--- a/scanner/tests/test_dashboard_utils_safe_url.py
+++ b/scanner/tests/test_dashboard_utils_safe_url.py
@@ -63,6 +63,15 @@ class TestSafeUrl(unittest.TestCase):
         self.assertEqual(h(safe_url("javascript:alert(document.cookie)")), "#")
 
 
+def _read_lib_source(filename):
+    """Read a scanner/lib/*.py file, dropping full-line ``#`` comments so a
+    commented-out example cannot satisfy a positive source-pin assertion."""
+    path = os.path.join(os.path.dirname(__file__), "..", "lib", filename)
+    with open(path, encoding="utf-8") as fh:
+        lines = fh.read().splitlines()
+    return "\n".join(ln for ln in lines if not ln.lstrip().startswith("#"))
+
+
 class TestDashboardGenHardeningPins(unittest.TestCase):
     """Source-level regression pins for the dashboard-gen.py XSS hardening:
     the scanner-category scope links must NOT reintroduce an inline
@@ -71,9 +80,7 @@ class TestDashboardGenHardeningPins(unittest.TestCase):
 
     @property
     def _src(self):
-        path = os.path.join(os.path.dirname(__file__), "..", "lib", "dashboard-gen.py")
-        with open(path, encoding="utf-8") as fh:
-            return fh.read()
+        return _read_lib_source("dashboard-gen.py")
 
     def test_no_inline_onclick_switchtab_with_category(self):
         # The Finding-3 vector: onclick="switchTab('overview','scanner-cat-{h(cat)}')"
@@ -87,6 +94,50 @@ class TestDashboardGenHardeningPins(unittest.TestCase):
         # Finding-4: href must gate the scheme via safe_url(), never raw h(rl).
         self.assertIn("href=\"{h(safe_url(rl))}\"", self._src)
         self.assertNotIn("href=\"{h(rl)}\"", self._src)
+
+    def test_policies_card_url_goes_through_safe_url(self):
+        # Policies card (.claudesec-assets/policies.json, Google-Drive-derived):
+        # the 원문↗ href value must gate the scheme via safe_url() before h().
+        self.assertIn('h(safe_url(_pol.get("url", "")))', self._src)
+        self.assertNotIn('_url = h(_pol.get("url", ""))', self._src)
+
+    def test_policies_article_num_is_html_escaped(self):
+        # The article number is interpolated into HTML text and must pass h().
+        self.assertIn('{h(_a.get("num", ""))}', self._src)
+        self.assertNotIn('">{_a.get("num", "")}. ', self._src)
+
+
+class TestAuditSourceHrefHardeningPins(unittest.TestCase):
+    """Source-level regression pins for the audit-points / MS / SaaS source
+    href sinks (GitHub-API-derived URLs). Every externally-sourced href must
+    keep its safe_url() scheme gate: h(safe_url(url)), never raw h(url).
+    Mirrors the #366 hardening applied to the reference links."""
+
+    def _assert_all_hrefs_gated(self, filename, var_names):
+        src = _read_lib_source(filename)
+        for var in var_names:
+            # The safe_url()-gated form must be present ...
+            self.assertIn(
+                'href="{h(safe_url(%s))}"' % var,
+                src,
+                f"{filename}: href for {var!r} must go through safe_url()",
+            )
+            # ... and the un-gated form must NOT reappear.
+            self.assertNotIn(
+                'href="{h(%s)}"' % var,
+                src,
+                f"{filename}: raw h({var}) href would reintroduce a scheme-injection sink",
+            )
+
+    def test_audit_points_hrefs_gated(self):
+        self._assert_all_hrefs_gated(
+            "dashboard_html_audit_points.py", ("tree_url", "url", "repo_url")
+        )
+
+    def test_audit_sources_hrefs_gated(self):
+        self._assert_all_hrefs_gated(
+            "dashboard_html_audit_sources.py", ("repo_url", "url")
+        )
 
 
 # Bare test_* functions so pytest (function collection) also runs them.


### PR DESCRIPTION
## Summary

Retrospective audit after the XSS fix-series (#361–#366) found the scanner-target surface fully escaped, but **3 dashboard `href` sinks** still emit externally-sourced URLs through `h()` alone — missing the `safe_url()` scheme gate that #366 applied everywhere else. `h()` HTML-escapes but does **not** validate the URL scheme, so `javascript:` / `data:` / `vbscript:` survives `h()` and executes on click in an `<a href>` context.

This is a **LOW / defense-in-depth parity** fix: these sinks are fed by semi-trusted data (internal-operator `.claudesec-assets/policies.json`, GitHub-API-derived source URLs), not the primary scanner-target surface, but they should carry the same gate for consistency and DiD.

### Sinks hardened — all now `h(safe_url(u))`, consistent with #366
- `scanner/lib/dashboard-gen.py` — policies card `원문↗` href (`.claudesec-assets/policies.json`, Google-Drive-derived). Also HTML-escape the article number (`{_a.get("num","")}` → `{h(_a.get("num",""))}`) interpolated into HTML text.
- `scanner/lib/dashboard_html_audit_points.py` — `tree_url` / file `url` / `repo_url` hrefs (GitHub-API-derived). Added `safe_url` import.
- `scanner/lib/dashboard_html_audit_sources.py` — MS + SaaS `repo_url` / file `url` hrefs (GitHub-API-derived). Added `safe_url` import.

The static literal `https://github.com/querypie/audit-points` (empty-state fallback) is not interpolated and was left untouched.

### Regression guard
Extended `scanner/tests/test_dashboard_utils_safe_url.py`:
- `TestDashboardGenHardeningPins` — 2 new pins: policies href goes through `safe_url()`; article number goes through `h()`.
- `TestAuditSourceHrefHardeningPins` (new) — pins `h(safe_url(...))` and forbids the raw `h(url)` form for every audit-points / MS / SaaS href var, so a future edit that drops the gate fails CI.

The #364 bash-sink guard (`test_ci_no_raw_output_interpolation.py`) covers only the 3 bash sinks by design; these Python href sinks were previously unguarded. Guard is stdlib-only, reads the `.py` files as text, and strips full-line `#` comments so a commented-out example cannot satisfy a positive pin. No `scanner/lib` network import.

## Test plan
All offline (`export CLAUDESEC_DASHBOARD_OFFLINE=1`):

- `python3 -m pytest scanner/ --cov=scanner/lib --cov-fail-under=99 -q` → **1568 passed, 5 skipped; coverage 99.15%** (≥99 floor).
- `bash scanner/tests/test_generate_html_dashboard.sh` → **36 passed, 0 failed**.
- Functional proof: rendered audit-points + MS-sources builders with `javascript:`/`vbscript:` URLs → every href collapsed to `href="#"`; `h(safe_url("javascript:..."))=="#"` on the policies path.
- **Fail-injection**: reverting one added `safe_url()` gate (`repo_url` in `dashboard_html_audit_sources.py`) made the new guard fail with `raw h(repo_url) href would reintroduce a scheme-injection sink` — confirming the guard bites; then restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)