### PR TITLE
chore: ignore accidental CLI-flag redirect artifacts at repo root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,9 @@ run-all.sh
 tmp-*.svg
 tmp-*.png
 
+# Accidental CLI-flag redirect artifacts (e.g. a stray `claudesec ... > --help`)
+/--*
+
 # MCP / Orchestration (local tool configs)
 .mcp.json
 .claudesec-sources/


### PR DESCRIPTION
## Summary

A stray `--help` file (244 KB dashboard HTML, `generator v0.7.2`) was found untracked in the working tree — the residue of an accidental `claudesec ... > --help` redirect. Removed it and added a **root-anchored `/--*`** guard to `.gitignore` so flag-named redirect artifacts (`--help`, `--version`, …) can never surface in `git status` again.

- Root-anchored (`/--*`) so only repo-root stray files match; nothing nested is affected.
- No repo-tracked file starts with `--`, so the pattern has zero collision risk.

## Test plan
- [x] `git check-ignore -v -- ./--help` → matches `.gitignore:/--*`
- [x] Recreated a stray `--help` → no longer appears in `git status`
- [x] gitleaks pre-push CLEAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)