### PR TITLE
test(ci): mutation self-tests + HTML-comment stripping for the catalog meta-guards (#297)

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -63,8 +63,8 @@ All guards follow the same rules (see the existing files for reference):
 | `scanner/tests/test_ci_codeowners_invariants.py` | `.github/CODEOWNERS` keeps security-sensitive paths code-owner gated | every required pattern (`*`, `.github/workflows/`, `.github/CODEOWNERS`, `hooks/`, `scanner/`, `scripts/`, `templates/`, `Dockerfile*`, `docker-compose*.yml`) is present AND has a non-empty `@owner`; the global `*` default must have an owner — else those paths merge with NO code-owner review (`require_code_owner_reviews=true` only fires on a matched, owned pattern) | #248 |
 | `scanner/tests/test_ci_no_ere_pipe_regression.py` | No literal `\|` in an ERE context in `scanner/checks/**` + `scanner/lib/**` `.sh` | flags `\|` (literal-pipe, NOT alternation) inside `grep -[qnrlc]*E`, the `_code_grep`/`files_contain`/`file_contains` helpers, and bash `[[ =~ ]]` — the silent detection-breaking bug class fixed in #221/#223/#224; two intentional literals (`code/injection.sh` `\|safe`, `solutions.sh` `curl\|sh`) are allowlisted and asserted still present | #244, #246 |
 | `scanner/tests/test_ci_prowler_provider_guard_ordering.py` | `_prowler_provider_available` precedes `_prowler_report` per provider (`scanner/checks/prowler/integration.sh`) | within each provider section of the Provider Scans block, `min(guard line) < min(report line)` — reordering would silently regress the #238 build-parity fix (lean image would emit a misleading auth warning instead of an accurate "not in this build" skip); promotes the shell-level `#241` assertion into the pytest CI gate. `integration.sh` is pure bash, so guard/report call detection strips trailing comments with `strip_inline_comment_sh`: a decoy `echo x;#_prowler_provider_available "…"` must not lend its early line number to `min(guard)` and mask a real guard that now sits after the report | #242 |
-| `scanner/tests/test_ci_catalog_completeness.py` | Completeness of this catalog vs the on-disk guard suite | every `scanner/tests/test_ci_*.py` file has its repo-relative path listed in this catalog (presence) — a new guard added without a Catalog row is silent documentation drift that makes the inventory understate coverage; the meta-guard documents itself so the invariant is uniform | #254 |
-| `scanner/tests/test_ci_catalog_no_ghost_rows.py` | No ghost rows in this catalog vs the on-disk guard suite | every concrete `scanner/tests/test_ci_<name>.py` path cited in this catalog resolves to a real file (existence) — the reverse of the completeness guard: a renamed/deleted guard left in the table is a ghost row that makes the inventory overstate coverage. Together the two guards verify a 1:1 catalog↔suite mapping | #255 |
+| `scanner/tests/test_ci_catalog_completeness.py` | Completeness of this catalog vs the on-disk guard suite | every `scanner/tests/test_ci_*.py` file has its repo-relative path listed in this catalog (presence) — a new guard added without a Catalog row is silent documentation drift that makes the inventory understate coverage; the meta-guard documents itself so the invariant is uniform. HTML-comment-stripped, so a row parked in `<!-- ... -->` (invisible when rendered, the Markdown comment-evasion form) does NOT satisfy the presence check. Mutation self-tests | #254 |
+| `scanner/tests/test_ci_catalog_no_ghost_rows.py` | No ghost rows in this catalog vs the on-disk guard suite | every concrete `scanner/tests/test_ci_<name>.py` path cited in this catalog resolves to a real file (existence) — the reverse of the completeness guard: a renamed/deleted guard left in the table is a ghost row that makes the inventory overstate coverage. Together the two guards verify a 1:1 catalog↔suite mapping. HTML-comment-stripped, the opposite direction from the completeness guard: a row parked in `<!-- ... -->` claims no coverage, so flagging it as a ghost would be a false alarm — a test pins that a commented ghost still does not mask a live one. Mutation self-tests | #255 |
 | `scanner/tests/test_ci_branch_protection_codified.py` | Codified branch protection (`scripts/sync-repo-protection.sh`) + its nightly notifier (`protection-drift-watch.yml`) | the desired state keeps `DESIRED_CONTEXTS=["Lint","Security Scan Gate"]` (both required checks — an exact two-sided pin: dropping a context un-requires that aggregator, and silently *adding* a third required context is equally caught, proven by appended+prepended mutation self-tests), `DESIRED_ENFORCE_ADMINS="true"` (admins not exempt — no force-push to main), `strict`/`require_code_owner_reviews` true, `set -euo pipefail`, and the default-arm dry-run; the `DRIFT DETECTED` marker contract holds on both producer (script) and consumer (`grep -q`) sides; the watch keeps `schedule:` + tooling-error `exit 1` and its `on:` block never gains a `pull_request(_target)` trigger (scheduled notifier, must not become a required PR check). Protects the #250/#251 codification | #256 |
 | `scanner/tests/test_ci_dependabot_config.py` | `.github/dependabot.yml` update coverage + alpine version freeze | all four ecosystems stay declared (`github-actions`, `npm`, `pip`, `docker`) so no surface silently stops getting update PRs (OWASP CICD-SEC-3); the `docker` `ignore` keeps the `alpine` `semver-minor`+`semver-major` freeze that holds alpine on its py3.12 minor line — loosening it would let Dependabot propose the bump that ships py3.14 and crashes prowler (pydantic v1, incident #220). Distinct from `test_ci_dependabot_automerge.py` (guards the *workflow*, not this *config*) | #256 |
 | `scanner/tests/test_ci_prowler_version_pinned.py` | prowler install pin in `Dockerfile` | prowler is installed via an exact `==` pin through the `PROWLER_VERSION` build arg (version-shaped value), never a bare unpinned `pip install ... prowler`. An unpinned spec silently backtracks to ancient prowler 3.11.3 (pydantic v1) on a newer Python and crashes at runtime (incident #237). Pins the *pinning*, so a lockstep version bump stays green | #258 |
@@ -312,6 +312,30 @@ The meta-guard deliberately exempts the two shapes that are not inert: negative
 line-anchored regexes (`(?m)^\s*token`), which a `#`-commented copy cannot
 satisfy — three guards rely on that form correctly and are not flagged.
 
+**Catalog meta-guards hardened (this PR — closes the last non-deferred Class 2
+item):**
+
+`test_ci_catalog_completeness.py` and `test_ci_catalog_no_ghost_rows.py` shipped
+with **no mutation self-test** — they only ever ran against the real catalog, so
+a parser regression would have gone unnoticed and both would have passed
+vacuously. Detectors are now extracted to module level (`missing_rows`,
+`cited_paths` / `ghost_rows`) and exercised on synthetic input: undocumented
+guard, ghost row, prose glob, duplicate citations, empty catalog.
+
+Both also scanned the catalog RAW. Markdown has no `#` comment, so `<!-- ... -->`
+is the escape hatch, and a row parked inside one renders as nothing while still
+satisfying a substring check — a guard could vanish from the published inventory
+with `catalog_completeness` green. Both now route through a shared
+`strip_html_comments` in `_ci_guard_util.py`. The strip cuts **both ways, and
+both are correct**: it makes `completeness` STRICTER (a hidden row no longer
+satisfies presence) and `no_ghost_rows` more LENIENT (a commented row claims no
+coverage, so flagging it would be a false alarm) — with a test pinning that a
+commented ghost still does not mask a live one. An unclosed `<!--` degrades to
+no-strip rather than blanking the document, which would fail every consumer at
+once.
+
+Non-vacuous: neutering `strip_html_comments` fails 3 of the new tests.
+
 **Backlog (Class 2 — matcher-completeness / enumeration gaps; require a
 deliberate, unusual edit rather than a comment-out, so lower natural-regression
 risk — triaged as follow-up, not blocking):**
@@ -326,9 +350,6 @@ risk — triaged as follow-up, not blocking):**
 - `test_ci_cross_os_non_required.py` — `FORBIDDEN_IN_LINT` is a fixed 4-string
   enumeration (bypassed by `macos-14`/`windows-2022` labels); collision check
   omits the `"Lint"` required context.
-- `test_ci_catalog_completeness.py` / `test_ci_catalog_no_ghost_rows.py` — no
-  shipped mutation self-test; catalog_completeness also does not strip Markdown
-  `<!-- -->` comments (low severity).
 - `test_ci_injection_surface.py` — **known scanner limitation** (bounded by the
   stdlib-only / no-PyYAML constraint): an untrusted `${{ }}` split across two
   physical lines inside a block scalar is not reassembled; its runtime

--- a/scanner/tests/_ci_guard_util.py
+++ b/scanner/tests/_ci_guard_util.py
@@ -162,6 +162,24 @@ def strip_inline_comment_sh(line: str) -> str:
     return line
 
 
+def strip_html_comments(text: str) -> str:
+    """`text` with HTML/Markdown comments (`<!-- ... -->`, possibly multi-line)
+    removed.
+
+    Markdown has no `#` comment, so the `strip_comment_lines` family does not
+    apply to the docs the catalog meta-guards scan. `<!-- -->` is the equivalent
+    escape hatch: a catalog row parked inside one is invisible when rendered but
+    still satisfies a raw substring presence check, so a guard could be dropped
+    from the published inventory while `test_ci_catalog_completeness` stays
+    green (the comment-evasion class of ADR-001 §1, in Markdown).
+
+    An UNCLOSED `<!--` is left intact rather than eating the rest of the file:
+    the pattern requires a closing `-->`, so a stray opener degrades to
+    no-strip (under-strip, a false NEGATIVE for that one row) instead of
+    blanking the document (which would make every consumer fail at once)."""
+    return re.sub(r"<!--.*?-->", "", text, flags=re.DOTALL)
+
+
 def top_level_jobs(text: str) -> list:
     """The job keys under a workflow's top-level `jobs:` map (2-space-indented
     `name:` lines), in document order. Stops at the dedent to the next top-level

--- a/scanner/tests/test__ci_guard_util.py
+++ b/scanner/tests/test__ci_guard_util.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _ci_guard_util import (  # noqa: E402
     extract_on_block,
     strip_comment_lines,
+    strip_html_comments,
     strip_inline_comment,
     strip_inline_comment_sh,
     top_level_jobs,
@@ -138,6 +139,35 @@ class TestTopLevelJobs(unittest.TestCase):
 class TestStripCommentLines(unittest.TestCase):
     def test_drops_whole_line_comments_only(self):
         self.assertEqual(strip_comment_lines("a\n# c\n  b"), "a\n  b")
+
+
+
+class TestStripHtmlComments(unittest.TestCase):
+    """Markdown has no `#` comment; `<!-- -->` is the escape hatch the catalog
+    meta-guards must see through."""
+
+    def test_single_line_comment_removed(self):
+        self.assertEqual(strip_html_comments("a <!-- hidden --> b"), "a  b")
+
+    def test_multiline_comment_removed(self):
+        self.assertEqual(strip_html_comments("a <!--\nx\ny\n--> b"), "a  b")
+
+    def test_multiple_comments_removed_independently(self):
+        self.assertEqual(strip_html_comments("<!--x-->A<!--y-->B"), "AB")
+
+    def test_non_greedy_does_not_swallow_between_comments(self):
+        # A greedy `.*` would eat `KEEP` along with both comments.
+        self.assertIn("KEEP", strip_html_comments("<!--a-->KEEP<!--b-->"))
+
+    def test_unclosed_opener_is_left_intact(self):
+        # Under-strip beats blanking the document: a stray `<!--` must not eat
+        # the rest of the file and make every consumer fail at once.
+        self.assertEqual(
+            strip_html_comments("live row\n<!-- dangling"), "live row\n<!-- dangling"
+        )
+
+    def test_text_without_comments_is_unchanged(self):
+        self.assertEqual(strip_html_comments("plain text"), "plain text")
 
 
 if __name__ == "__main__":

--- a/scanner/tests/test_ci_catalog_completeness.py
+++ b/scanner/tests/test_ci_catalog_completeness.py
@@ -24,14 +24,30 @@ the measured coverage gate.
 OWASP CICD-SEC-1 (Insufficient Flow Control) / NIST SSDF (SP 800-218) PO.3, PW.4.
 """
 
+import sys
 import unittest
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_html_comments  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TESTS_DIR = REPO_ROOT / "scanner" / "tests"
 CATALOG_REL = "docs/devsecops/ci-config-regression-guards.md"
 CATALOG = REPO_ROOT / CATALOG_REL
+
+
+def missing_rows(catalog_text: str, guard_names) -> list:
+    """Guard file names with no row in `catalog_text`, HTML-comment-stripped.
+
+    Stripping `<!-- ... -->` first is load-bearing: Markdown has no `#` comment,
+    so an HTML comment is the escape hatch. A row parked in one renders as
+    nothing — the published inventory silently loses the guard — while a raw
+    substring scan still finds the path and reports green. That is the Markdown
+    form of the comment-evasion class the rest of the suite defends against."""
+    active = strip_html_comments(catalog_text)
+    return [name for name in guard_names if f"scanner/tests/{name}" not in active]
 
 
 class TestCiCatalogCompleteness(unittest.TestCase):
@@ -57,11 +73,7 @@ class TestCiCatalogCompleteness(unittest.TestCase):
         )
 
     def test_every_guard_listed_in_catalog(self):
-        missing = [
-            name
-            for name in self.guard_files
-            if f"scanner/tests/{name}" not in self.catalog_text
-        ]
+        missing = missing_rows(self.catalog_text, self.guard_files)
         self.assertEqual(
             missing,
             [],
@@ -72,6 +84,57 @@ class TestCiCatalogCompleteness(unittest.TestCase):
             "Landed) for each new guard so the inventory stays the single source "
             "of truth.",
         )
+
+
+
+class TestCatalogCompletenessDetector(unittest.TestCase):
+    """Mutation self-tests — the guard shipped without any, so a parser
+    regression would have gone unnoticed (Class 2 backlog item)."""
+
+    _NAMES = ["test_ci_alpha.py", "test_ci_beta.py"]
+    _ROWS = (
+        "| `scanner/tests/test_ci_alpha.py` | a | a | #1 |\n"
+        "| `scanner/tests/test_ci_beta.py` | b | b | #2 |\n"
+    )
+
+    def test_documented_guards_are_not_missing(self):
+        self.assertEqual(missing_rows(self._ROWS, self._NAMES), [])
+
+    def test_undocumented_guard_is_detected(self):
+        self.assertEqual(
+            missing_rows(self._ROWS, self._NAMES + ["test_ci_gamma.py"]),
+            ["test_ci_gamma.py"],
+            "A guard with no catalog row was NOT detected.",
+        )
+
+    def test_row_parked_in_an_html_comment_does_not_count(self):
+        mutant = self._ROWS.replace(
+            "| `scanner/tests/test_ci_beta.py` | b | b | #2 |",
+            "<!-- | `scanner/tests/test_ci_beta.py` | b | b | #2 | -->",
+        )
+        self.assertEqual(
+            missing_rows(mutant, self._NAMES),
+            ["test_ci_beta.py"],
+            "A row hidden inside an HTML comment satisfied the presence check — "
+            "the rendered inventory drops the guard while the check reads green.",
+        )
+
+    def test_multiline_html_comment_is_stripped(self):
+        mutant = (
+            "| `scanner/tests/test_ci_alpha.py` | a | a | #1 |\n"
+            "<!--\nparked for later:\n"
+            "| `scanner/tests/test_ci_beta.py` | b | b | #2 |\n-->\n"
+        )
+        self.assertEqual(missing_rows(mutant, self._NAMES), ["test_ci_beta.py"])
+
+    def test_unclosed_comment_marker_does_not_blank_the_catalog(self):
+        # Degrades to no-strip rather than eating the document, which would make
+        # every guard look undocumented at once.
+        mutant = self._ROWS + "<!-- note without a closer\n"
+        self.assertEqual(missing_rows(mutant, self._NAMES), [])
+
+    def test_empty_catalog_reports_every_guard(self):
+        self.assertEqual(missing_rows("", self._NAMES), self._NAMES)
 
 
 if __name__ == "__main__":

--- a/scanner/tests/test_ci_catalog_no_ghost_rows.py
+++ b/scanner/tests/test_ci_catalog_no_ghost_rows.py
@@ -24,8 +24,12 @@ measured coverage gate.
 """
 
 import re
+import sys
 import unittest
 from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import strip_html_comments  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -37,11 +41,27 @@ CATALOG = REPO_ROOT / CATALOG_REL
 CITED_PATH_RE = re.compile(r"scanner/tests/test_ci_[A-Za-z0-9_]+\.py")
 
 
+def cited_paths(catalog_text: str) -> list:
+    """Concrete guard paths cited in the catalog's ACTIVE text, sorted+deduped.
+
+    HTML comments are stripped first. A row parked in `<!-- ... -->` renders as
+    nothing, so it claims no coverage and must not be reported as a ghost — this
+    is the opposite direction from `test_ci_catalog_completeness.py`, where the
+    same strip makes the check STRICTER (a hidden row stops satisfying a
+    presence check). Same primitive, both directions correct."""
+    return sorted(set(CITED_PATH_RE.findall(strip_html_comments(catalog_text))))
+
+
+def ghost_rows(catalog_text: str, repo_root: Path) -> list:
+    """Cited guard paths with no file on disk."""
+    return [rel for rel in cited_paths(catalog_text) if not (repo_root / rel).is_file()]
+
+
 class TestCiCatalogNoGhostRows(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         text = CATALOG.read_text(encoding="utf-8") if CATALOG.is_file() else ""
-        cls.cited = sorted(set(CITED_PATH_RE.findall(text)))
+        cls.cited = cited_paths(text)
 
     def test_catalog_exists(self):
         self.assertTrue(
@@ -69,6 +89,47 @@ class TestCiCatalogNoGhostRows(unittest.TestCase):
             + "\nA renamed/deleted guard left a ghost row — the inventory now "
             "overstates coverage. Update or remove the Catalog row.",
         )
+
+
+
+class TestGhostRowDetector(unittest.TestCase):
+    """Mutation self-tests — this guard shipped without any (Class 2 backlog)."""
+
+    _REAL = "scanner/tests/test_ci_catalog_no_ghost_rows.py"   # this file
+    _GHOST = "scanner/tests/test_ci_definitely_not_a_real_guard.py"
+
+    def test_real_path_is_not_a_ghost(self):
+        self.assertEqual(ghost_rows(f"| `{self._REAL}` | x | y | #1 |", REPO_ROOT), [])
+
+    def test_deleted_guard_row_is_detected(self):
+        self.assertEqual(
+            ghost_rows(f"| `{self._GHOST}` | x | y | #1 |", REPO_ROOT),
+            [self._GHOST],
+            "A catalog row naming a nonexistent guard file was NOT detected — "
+            "the inventory would overstate coverage.",
+        )
+
+    def test_prose_glob_is_not_treated_as_a_path(self):
+        self.assertEqual(cited_paths("see `scanner/tests/test_ci_*.py` for all"), [])
+
+    def test_commented_out_ghost_is_not_reported(self):
+        # A row inside an HTML comment renders as nothing, so it claims no
+        # coverage — reporting it as a ghost would be a false alarm.
+        self.assertEqual(
+            ghost_rows(f"<!-- | `{self._GHOST}` | x | y | #1 | -->", REPO_ROOT),
+            [],
+        )
+
+    def test_commented_ghost_does_not_mask_a_live_one(self):
+        text = (
+            f"<!-- | `{self._GHOST}` | old | | -->\n"
+            f"| `{self._GHOST}` | live row | y | #2 |\n"
+        )
+        self.assertEqual(ghost_rows(text, REPO_ROOT), [self._GHOST])
+
+    def test_duplicate_citations_collapse(self):
+        text = f"`{self._REAL}` and again `{self._REAL}`"
+        self.assertEqual(cited_paths(text), [self._REAL])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes the **last non-deferred Class 2 backlog item** from the #297 quarterly
audit. (The remaining `test_ci_injection_surface.py` entry is a deliberate
non-fix — bounded by the stdlib-only / no-PyYAML constraint and tracked rather
than half-closed with a fragile heuristic.)

### 1. The meta-guards had no mutation self-test

`test_ci_catalog_completeness.py` and `test_ci_catalog_no_ghost_rows.py` only
ever ran against the real catalog. A parser regression would have made them pass
**vacuously** — the exact failure mode the rest of this suite exists to prevent.
Detectors are extracted to module level (`missing_rows`; `cited_paths` /
`ghost_rows`) and exercised on synthetic input: undocumented guard, ghost row,
prose glob, duplicate citations, empty catalog.

### 2. Both scanned the catalog raw

Markdown has no `#` comment, so `<!-- ... -->` is the escape hatch. A row parked
inside one **renders as nothing** — the published inventory silently loses the
guard — while a raw substring scan still finds the path and reports green. That
is the Markdown form of the comment-evasion class. Both guards now route through
a new shared `strip_html_comments` in `_ci_guard_util.py`.

The strip cuts **both ways, and both directions are correct**:

| Guard | Effect | Why correct |
|---|---|---|
| `catalog_completeness` | **stricter** | a hidden row no longer satisfies the presence check |
| `catalog_no_ghost_rows` | more **lenient** | a commented row claims no coverage, so flagging it as a ghost would be a false alarm |

A test pins that a commented ghost still does **not** mask a live one, so the
leniency cannot be abused.

An unclosed `<!--` degrades to **no-strip** rather than blanking the document —
under-strip (one row missed) beats making every consumer fail at once.

## Test plan

- [x] **Non-vacuous** — neutering `strip_html_comments` to `return text` fails
      3 of the new tests (2 in completeness, 1 in no-ghost-rows); restored, all
      18 pass.
- [x] 6 helper unit tests in `test__ci_guard_util.py`, including non-greedy
      behaviour between two comments and the unclosed-opener case.
- [x] Full suite `CLAUDESEC_DASHBOARD_OFFLINE=1 pytest scanner/tests/` →
      **1699 passed, 5 skipped**
- [x] Dual-runner OK under `python3 -m unittest`
- [x] `markdownlint` clean; catalog rows updated and the Class 2 bullet removed
- [x] stdlib-only, no PyYAML, no `scanner/lib` import

Refs: OWASP CICD-SEC-1; NIST SSDF PO.3/PW.4. Addresses #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)