### PR TITLE
chore(ci): pin and audit the workflow-fork-guard PyYAML install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -134,6 +134,10 @@ jobs:
           python3 -m pip install --upgrade 'pip>=26.1'
           python3 -m pip install --upgrade pip-audit
           python3 -m pip install -r requirements-ci.txt
+          # Bring the workflow-fork-guard job's pinned PyYAML into the audited
+          # environment — it used to be installed only in that job, where nothing
+          # ever audited it.
+          python3 -m pip install -r requirements-fork-guard.txt
       - name: Run pip-audit
         # CVE-2026-4539: pygments <=2.19.2 local ReDoS — no fix available yet
         # CVE-2026-3219: pip 26.0.1 tar+ZIP confusion — no fix version published yet
@@ -604,7 +608,11 @@ jobs:
         with:
           python-version: "3.13"
       - name: Install PyYAML
-        run: pip install --no-deps 'pyyaml>=6.0,<7'
+        # Exact pin lives in requirements-fork-guard.txt (kept out of
+        # requirements-ci.txt on purpose — see that file's header) so the version
+        # is a reviewable diff, Dependabot tracks it, and the `pip-audit` job
+        # covers it. Was `'pyyaml>=6.0,<7'`: a floating range resolved at job time.
+        run: python3 -m pip install --no-deps -r requirements-fork-guard.txt
       - name: Audit pull_request_target workflows for fork-guard
         run: python3 scripts/check-pull-request-target-guard.py
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -132,6 +132,15 @@ jobs:
         run: |
           # Upgrade pip first to clear CVE-2026-6357 (fix in pip 26.1)
           python3 -m pip install --upgrade 'pip>=26.1'
+          # setuptools from the runner's tool cache (79.0.1) carries
+          # PYSEC-2026-3447 — MANIFEST.in exclusions match without Unicode
+          # normalization, so an NFD filename can slip into a published sdist.
+          # Not reachable here (this repo builds no sdist), but `--strict` fails on
+          # any known vuln in the audited environment and a fix version exists, so
+          # upgrade rather than suppress. This surfaced only when the audit's
+          # `requirements.*\.txt` path gate finally fired: pip-audit was `skipped`
+          # on every recent run, so the environment had drifted unnoticed.
+          python3 -m pip install --upgrade 'setuptools>=83.0.0'
           python3 -m pip install --upgrade pip-audit
           python3 -m pip install -r requirements-ci.txt
           # Bring the workflow-fork-guard job's pinned PyYAML into the audited

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -28,7 +28,9 @@ All guards follow the same rules (see the existing files for reference):
   job (`python3 -m pytest scanner/tests/`).
 - **Stdlib-only**: regex / line scanning, **no PyYAML** — it is not in
   `requirements-ci.txt`, so `import yaml` would fail in CI. (The
-  `workflow-fork-guard` job installs PyYAML separately for its own script.)
+  `workflow-fork-guard` job installs PyYAML separately for its own script, from
+  its own pinned `requirements-fork-guard.txt` — kept out of `requirements-ci.txt`
+  precisely so this premise stays true.)
 - **No `scanner/lib` import**: guards add tests without touching the measured
   coverage, so they never move the 99% `scanner/lib` floor.
 - **Direction-explicit semantics**: floors use `>=` (ratcheting a floor *up*

--- a/requirements-fork-guard.txt
+++ b/requirements-fork-guard.txt
@@ -1,0 +1,27 @@
+# Sole dependency of scripts/check-pull-request-target-guard.py, installed by the
+# `workflow-fork-guard` job in .github/workflows/lint.yml.
+#
+# WHY A SEPARATE FILE (do not merge into requirements-ci.txt)
+#   Every `scanner/tests/test_ci_*.py` guard is deliberately stdlib-only and
+#   documents "no PyYAML — absent from requirements-ci.txt" as the reason. Adding
+#   PyYAML there would make that premise false and let a guard silently start
+#   parsing YAML with a library the CI test job is not supposed to have.
+#
+# WHY PINNED EXACTLY
+#   This was `pip install 'pyyaml>=6.0,<7'` — a floating range resolved at job
+#   time, so a new release entered CI with no review and no audit. An exact pin
+#   makes the version a reviewable diff, and Dependabot's `pip` ecosystem already
+#   watches `/` (see .github/dependabot.yml), so upgrades arrive as PRs.
+#
+# WHY NOT --require-hashes
+#   PyYAML ships per-interpreter binary wheels, so a hash set pins the file to one
+#   runner Python. `workflow-fork-guard` runs 3.13 and `pip-audit` runs 3.11 —
+#   a single hash list cannot satisfy both, and the sdist fallback needs a Cython
+#   build. The exploitable gap here was version drift, which the pin closes;
+#   file-level immutability is provided by PyPI itself.
+#
+# AUDIT COVERAGE
+#   The `pip-audit` job installs this file alongside requirements-ci.txt so the
+#   pinned version is covered by `pip-audit --strict`. That job is path-gated on
+#   `requirements.*\.txt`, so editing this file re-runs the audit.
+pyyaml==6.0.3


### PR DESCRIPTION
`workflow-fork-guard` installed its only dependency as:

```yaml
run: pip install --no-deps 'pyyaml>=6.0,<7'
```

A floating range resolved at job time, so any new 6.x release entered CI with no review — and **nothing ever audited it**: the `pip-audit` job installs `requirements-ci.txt` only, and PyYAML is deliberately absent from that file.

## Changes

- **Exact pin** moves to a new `requirements-fork-guard.txt` (`pyyaml==6.0.3`), so the version is a reviewable diff and Dependabot's `pip` ecosystem (already watching `/`) raises upgrades as PRs.
- **Audit coverage**: the `pip-audit` job installs that file too, bringing the pinned version under `pip-audit --strict`. That job is path-gated on `requirements.*\.txt` (verified against the `changes` job filter at `lint.yml:92`), so editing the pin re-runs the audit.
- **Kept OUT of `requirements-ci.txt` on purpose.** ~40 `test_ci_*.py` guards are stdlib-only and cite *"no PyYAML — absent from requirements-ci.txt"* as the reason `import yaml` cannot creep in. Adding it there would falsify that premise. The convention doc now states the separation explicitly.

## Why not `--require-hashes`

Recorded in the file header rather than left implicit: PyYAML ships per-interpreter binary wheels, so a hash set pins the file to one runner Python — `workflow-fork-guard` runs 3.13 while `pip-audit` runs 3.11, and the sdist fallback needs a Cython build. The exploitable gap here was **version drift**, which the pin closes; per-file immutability comes from PyPI. (Direct binary downloads in this repo — trivy, gitleaks — *are* checksum-pinned, where a single artifact makes that tractable.)

## Verification (executed)

Fresh venv on Python 3.13:

```console
$ pip install --no-deps -r requirements-fork-guard.txt
$ python -c "import yaml,sys;print(sys.version.split()[0], yaml.__version__)"
3.13.12 6.0.3
$ python scripts/check-pull-request-target-guard.py
OK: 1 pull_request_target workflow(s) audited, all jobs fork-guarded.
$ echo $?
0
```

- `lint.yml` parses; both edited steps re-read to confirm the intended commands.
- `pytest scanner/tests/` → 1699 passed, 5 skipped.
- `markdownlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)