### PR TITLE
fix(ci): close the sweep remainder + revive lint.yml's dead schedule arm

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,28 @@ on:
   # targeting `main` are unaffected, so the required contexts always
   # report. Pinned by scanner/tests/test_ci_pr_trigger_scope.py.
   pull_request:
+  # Weekly revalidation. SEVEN jobs below carry
+  # `|| github.event_name == 'schedule'` as their escape hatch from the `changes`
+  # path gate — and that arm could never evaluate true, because this workflow had
+  # no `schedule:` trigger at all (verified: 1118 historical runs, 654
+  # pull_request + 464 push, zero schedule). The consequence was measured:
+  # `npm-audit` had ZERO real executions for ~7 weeks / 117 main commits (its
+  # bucket, `package*.json`/`.nvmrc`, was last touched in e5b9bbb), and
+  # `pip-audit` was likewise dark until a requirements edit finally fired it and
+  # it failed immediately on accumulated tool-cache drift (setuptools
+  # PYSEC-2026-3447). A path gate is not a schedule: without this trigger, an
+  # advisory disclosed against a locked dependency tree is caught only when
+  # someone happens to edit that tree.
+  #
+  # Wednesday 05:00 UTC — off the existing cron slots (06:00 Mon cross-os,
+  # 09:00 Mon security-scan, 06:00/06:30 daily lighthouse/provenance) so the
+  # weekly full run does not pile onto another job's window.
+  #
+  # Merge safety: adding a trigger cannot block a merge. Required contexts are
+  # evaluated per-commit on pull requests, which are unaffected; this only adds
+  # runs on a schedule. Pinned by scanner/tests/test_ci_dead_schedule_arm.py.
+  schedule:
+    - cron: '0 5 * * 3'
 
 permissions:
   contents: read

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -61,9 +61,9 @@ All guards follow the same rules (see the existing files for reference):
 | `scanner/tests/test_ci_gate_topology.py` | Enforcement topology of `lint.yml` | every `uses:` is 40-hex SHA-pinned (OWASP A08) across all `.github/workflows/*.yml`/`*.yaml` **and** composite `.github/actions/**/action.yml` (a composite carries `steps[].uses`, and a tag pin planted there was unreachable — the directory was never globbed); every job is in `lint-gate.needs` or a tiny documented allowlist. The `uses:`, `jobs:`, `lint-gate:` and sibling-job keys are read bare OR quoted, and `? uses`/`? jobs`/`? needs` explicit-key forms fail closed — a quoted key hid an action ref from the SHA scan, and a quoted sibling job smuggled a foreign `needs:` entry into lint-gate's list | #201 (allowlist tightened in #203), #393 |
 | `scanner/tests/test_ci_security_gate.py` | `Security Scan Gate` + DAST signals | `security-scan-gate` keeps `name`, `if: always()`, `needs: ⊇ {changes, scan, lighthouse}`, pass-set `not in (success, skipped)`; `dast-baseline.yml` keeps its `pull_request` trigger; `dast-full-scan.yml` keeps its `schedule:` trigger | #205, #216 |
 | `scanner/tests/test_ci_required_jobs_exist.py` | Existence of security/enforcement jobs in `lint.yml` | `{gitleaks, pii-check, dependency-review, workflow-fork-guard, scanner-unit-tests, scanner-shell-coverage}` are all present — deleting a whole job is a silent control loss the topology guard cannot see | #215 |
-| `scanner/tests/test_ci_codeql_single_model.py` | Single CodeQL model (default setup only) | no workflow uses `github/codeql-action/init` or `/analyze` (a repo-level analysis would duplicate the default-setup model); `upload-sarif` is allowed (DAST SARIF upload, not analysis) | #215 |
-| `scanner/tests/test_ci_npm_publish.py` | npm release supply-chain integrity + auto-release wiring (`npm-publish.yml`) | every `npm publish` carries `--provenance` (SLSA attestation); workflow-level `permissions:` stays `contents: read` (job-level `id-token: write` + `contents: write` are not flagged); the publish job upgrades npm (`npm install -g npm`, OIDC needs >= 11.5.1 but Node 22 ships npm 10.x); the `on:` block keeps a push-to-`main` trigger (version-bump auto-publish) and a `contents: write` exists for pushing the `vX.Y.Z` tag | #216, #262 |
-| `scanner/tests/test_ci_cross_os_non_required.py` | Cross-OS live-runner workflow stays non-required | `cross-os-checks.yml` exists and keeps `workflow_dispatch` (standalone informational lane); `lint.yml` references none of `{cross-os, live-os-checks, macos-latest, windows-latest}` — so the costly/flaky macOS+Windows runs never become a required merge gate | #228 |
+| `scanner/tests/test_ci_codeql_single_model.py` | Single CodeQL model (default setup only) | no workflow uses `github/codeql-action/init` or `/analyze` (a repo-level analysis would duplicate the default-setup model); `upload-sarif` is allowed (DAST SARIF upload, not analysis). Scans workflows in BOTH extensions plus composite `action.yml` (a `codeql.yaml` or a composite invoking `init` is just as much a second model and neither was enumerated), reads the `uses:` key and its value bare OR quoted, and fails closed on `? uses` | #215, #394 |
+| `scanner/tests/test_ci_npm_publish.py` | npm release supply-chain integrity + auto-release wiring (`npm-publish.yml`) | every `npm publish` carries `--provenance` (SLSA attestation); workflow-level `permissions:` stays `contents: read` (job-level `id-token: write` + `contents: write` are not flagged) — the write-grant scan reads a quoted VALUE (`packages: "write"` returned an EMPTY grant list, so the scan reported nothing while the permission was live) and now runs BEFORE the whole-block anchor, because behind it the fixed scan could never be the reporter and its correctness was unobservable; the publish job upgrades npm (`npm install -g npm`, OIDC needs >= 11.5.1 but Node 22 ships npm 10.x); the `on:` block keeps a push-to-`main` trigger (version-bump auto-publish) and a `contents: write` exists for pushing the `vX.Y.Z` tag | #216, #262 |
+| `scanner/tests/test_ci_cross_os_non_required.py` | Cross-OS live-runner workflow stays non-required | `cross-os-checks.yml` exists and keeps `workflow_dispatch` (standalone informational lane); `lint.yml` references none of `{cross-os, live-os-checks, macos-latest, windows-latest}` — so the costly/flaky macOS+Windows runs never become a required merge gate. The `runs-on:`/matrix `os:` key is read bare OR quoted (`"runs-on": macos-14` selected the same runner past the bare-only regex), the job-name collision check accepts a quoted key AND a quoted value (`"name": "Lint"` masqueraded as the required context), and `? name`/`? runs-on` fail closed | #228, #394 |
 | `scanner/tests/test_ci_net005_fail_escalation.py` | NET-005 SSH-open-to-world FAIL escalation (`network/tls.sh`) | NET-005 keeps `fail "NET-005" ... "critical"` and an ERE `(0\.0\.0\.0/0.*22\|port.*22.*0\.0\.0\.0/0)` alternation; no `\|` literal-pipe regression (which silently downgraded it to WARN, fixed in #224) | #228 |
 | `scanner/tests/test_ci_dependabot_automerge.py` | Dependabot auto-arm safety (`dependabot-auto-merge.yml`, a `pull_request_target` write-token workflow) | keeps the fork guard (`actor==dependabot[bot]` AND `head.repo.full_name==github.repository`), the hard-exclude path arms (`Dockerfile*`/`.github`/`scanner`/`hooks`/`scripts`), the `semver-patch\|minor`-only update-type allowlist + `semver-major` exclude, the `pip\|docker\|github-actions` ecosystem allowlist, and `gh pr merge --auto`; forbids `--admin` (code-owner bypass) and the `pr review --approve` bot self-approve removed in #249 (OWASP CICD-SEC-1/-4). Every check — the aggregate validator AND the narrower per-invariant tests — runs against the bash-comment-stripped text (`strip_inline_comment_sh`), so an arm parked behind `;#` neither satisfies a REQUIRED token nor false-trips a FORBIDDEN one | #249, #250 |
 | `scanner/tests/test_ci_codeowners_invariants.py` | `.github/CODEOWNERS` keeps security-sensitive paths code-owner gated | every required pattern (`*`, `.github/workflows/`, `.github/CODEOWNERS`, `hooks/`, `scanner/`, `scripts/`, `templates/`, `Dockerfile*`, `docker-compose*.yml`) is present AND has a non-empty `@owner`; the global `*` default must have an owner — else those paths merge with NO code-owner review (`require_code_owner_reviews=true` only fires on a matched, owned pattern) | #248 |
@@ -97,6 +97,7 @@ All guards follow the same rules (see the existing files for reference):
 | `scanner/tests/test_ci_dashboard_control_smoke.py` | Dashboard control-liveness smoke stays hermetic, path-gated, and bounded (`dashboard-control-smoke.yml` + `scanner/tests/{dashboard-control-liveness.mjs,test_dashboard_control_liveness.sh}`) | the workflow sets `CLAUDESEC_DASHBOARD_OFFLINE=1` (else the generator makes live GitHub API calls and can hang the job — #190) AND the harness wrapper self-exports it too (belt-and-suspenders, not CI-env-dependent); the `changes` job exposes a `dashboard` output and the `smoke` job is path-gated `if: needs.changes.outputs.dashboard == 'true'` (docs-only PRs skip the browser smoke; intentionally NON-required, a simple path-gate not an `always()` aggregator — that pattern is reserved for required checks per the paths-ignore/#186 incident); the browser step carries a per-step `timeout-minutes` (a hung headless Chrome can't burn the job budget) — asserted inside the isolated `- name:` step block that invokes the harness, because unscoped it was satisfied by the workflow's JOB-level `timeout-minutes` keys and could not detect removal of the per-step cap (inert-guard class; mutation self-tests pin job-level and wrong-step caps) — and invokes the real harness wrapper; both harness files exist on disk (a workflow pointing at a deleted script is a silent no-op). Comment-stripped presence checks (OWASP CICD-SEC-1) | this PR |
 | `scanner/tests/test_ci_guard_assertion_scoping.py` | **Meta-guard** — no `test_ci_*.py` guard makes a POSITIVE presence assertion against the RAW, whole-file text of the artifact it protects | AST scan (stdlib `ast`, not text) of every guard file: `assertIn(tok, raw)` / `assertRegex(raw, pat)` / `assertTrue(tok in raw)` where the haystack is a name bound directly to `Path.read_text()` is an INERT assertion — commenting the control out leaves the token in the file, so the guard reads green while the control is dead, which is worse than no guard (a reviewer takes the green as proof). Exempts the two non-inert shapes: NEGATIVE assertions (raw scanning for a FORBIDDEN token only over-reports — a false alarm, never a bypass) and LINE-ANCHORED regexes (`(?m)^\s*token`, which a `#`-commented copy cannot satisfy). Regression-pin: the detected set must EQUAL `KNOWN_RAW_PRESENCE_ASSERTIONS`, currently **empty** — a new offender fails AND a stale exemption fails once its site is fixed. Generalizes the two inert guards #383 found by hand (`provenance_verify` `npm audit signatures`, `docker_image_size_gate` `exit 1`) into a check that runs on all 40 guards and on every new one. Under-reports by design (never false-blocks). Mutation self-tests | this PR |
 | `scanner/tests/test_ci_pr_trigger_scope.py` | The two REQUIRED workflows (`lint.yml` → `Lint`, `security-scan.yml` → `Security Scan Gate`) keep an UNSCOPED `pull_request:` trigger | no `branches:` / `branches-ignore:` and no workflow-level `paths:` / `paths-ignore:` under `pull_request:`. Two opposite failure directions of one root cause — a workflow-level trigger filter on a required check. `branches:` filters by the PR's BASE ref, so `branches: [main]` hid both required checks from stacked PRs entirely: PR #384 (base = a feature branch) got 3 checks with neither required context, the same branch retargeted to `main` (#385) got 28 — the change was unverifiable until its base merged. `paths-ignore:` is the #186 mode: the required check never reports for a PR that DOES target `main`, so protection blocks the merge forever. Not symmetric — removing `branches:` is strictly additive (PRs targeting `main` behave identically, so #186 cannot recur), adding `paths-ignore:` IS #186. Job-level gating with the `changes` job + an `always()` aggregator stays the sanctioned pattern. Scoped to the two required workflows only: `dast-baseline.yml` legitimately carries both filters and is out of scope. Block membership is by indentation under the `on:` → `pull_request:` key, so a sibling `push: branches:` cannot false-trip it and `pull_request_target:` is never matched; flow-style values on the key line are captured. Both the `pull_request:` key and each forbidden filter key are read bare OR quoted, and the explicit-key form fails closed — `"branches": [main]` silently restored the #384 loss past the bare-only regex. Mutation self-tests | #386, #393 |
+| `scanner/tests/test_ci_dead_schedule_arm.py` | Path-gated jobs keep a REAL periodic escape hatch | for every workflow, IF any job `if:` gates on the `schedule` event THEN the workflow's `on:` must declare `schedule:` — direction is CONSISTENCY, so removing the trigger while leaving the arms trips it, and so does adding an arm to a workflow with no trigger. `lint.yml` had SEVEN such arms and no `schedule:` trigger (verified over 1118 runs: 654 pull_request + 464 push, zero schedule), so `npm-audit` had ZERO real executions for ~7 weeks / 117 main commits and `pip-audit` accumulated `setuptools` PYSEC-2026-3447 unnoticed until an unrelated PR touched a requirements file and ate the failure. A `skipped` job reads as green, so nothing alerted. The arm is detected by CO-OCCURRENCE of `github.event_name` and a quoted `schedule` token on one line rather than by enumerating comparison shapes — the first attempt enumerated `==`, the reversed form and `contains(...)`, and the `contains` pattern immediately failed on `fromJSON('["schedule",…]')` because `[^)]*` cannot span the inner `)`. `? schedule` fails closed. Cadence is NOT checked (no policy set). Mutation self-tests, including the real pre-fix `lint.yml` | #394 |
 
 ### Related enforcement (not a pytest guard)
 
@@ -486,13 +487,62 @@ handles `"on"`/`'on'` and returns `""` for `? on`, which makes all four consumer
 RED. Non-YAML guards (Markdown, AST, CODEOWNERS, JSON, Dockerfile, bash) are
 structurally inapplicable, and shape C never occurs independently of shape B.
 
-**Remaining from the sweep (MEDIUM/LOW, follow-up):** `codeql_single_model`
-(`.yaml` glob + quoted `uses:`), `cross_os_non_required` (quoted `runs-on:`;
-quoted `"name": Lint` masquerade), and a genuine false negative in
-`npm_publish.test_top_level_permissions_is_least_privilege` — its write-grant regex
-misses a quoted VALUE (`packages: "write"`) and currently fails only by ACCIDENT,
-because `^\s*contents:\s*read\s*$` lacks `re.MULTILINE` so any second key trips it.
-Fix the intended check; do not rely on the accident.
+**Remaining from the sweep (MEDIUM/LOW):** all closed in #394 — see the next
+section. The sweep backlog is empty.
+
+**Sweep remainder + the dead-schedule-arm class (#394):**
+
+Closes the MEDIUM/LOW tail of the #393 sweep and one structurally different defect
+found alongside it.
+
+*Sweep remainder* — `codeql_single_model` (dual-extension + composite-action
+enumeration, quoted `uses:` key/value, `? uses` tripwire), `cross_os_non_required`
+(quoted `runs-on:`/`os:` key, quoted key AND value in the `"name": Lint`
+masquerade check, `? name`/`? runs-on` tripwire), and the `npm_publish` false
+negative. All verified before/after by execution:
+
+| Mutation | Before | After |
+|---|---|---|
+| `codeql-action/init` in a `codeql.yaml` | `2 passed` | `1 failed` |
+| quoted `"uses": codeql-action/init` | `2 passed` | `1 failed` |
+| quoted `"runs-on": macos-14` in `lint.yml` | `13 passed` | `1 failed` |
+| quoted `"name": Lint` masquerade | `13 passed` | `1 failed` |
+
+The `npm_publish` case needed **two** fixes, and the second only became visible by
+checking *which* assertion reported. Fixing the scan to read a quoted grant value
+(`packages: "write"` had produced an EMPTY grant list) left the test failing on the
+unrelated whole-block anchor instead — the precise message never appeared
+(`matches=0`). The scan was still unobservable, so the ordering was inverted: the
+write-grant scan now runs first and reports `packages: "write"` by name, while the
+anchor remains as a structural catch-all for additions the scan does not classify.
+**Lesson: "the test goes red" is not the same as "the fix is load-bearing" — check
+which assertion fires.**
+
+*Dead schedule arm* — a different class, and worse, because nothing ever went red.
+Path-gated jobs carry `|| github.event_name == 'schedule'` as their periodic
+escape hatch, but `lint.yml` had **no `schedule:` trigger at all** (verified over
+1118 runs: 654 `pull_request` + 464 `push`, zero `schedule`), so that arm could
+never be true for seven jobs. Measured: `npm-audit` had **zero** real executions
+for ~7 weeks / 117 `main` commits (bucket last touched in `e5b9bbb`), and
+`pip-audit` sat dark until a requirements edit fired it and it failed on the spot
+with accumulated runner drift (`setuptools` PYSEC-2026-3447) — a failure that
+looked like it belonged to the unrelated PR that surfaced it. A `skipped` job reads
+as green, so there was no signal to notice.
+
+Fixed with a weekly `schedule:` on `lint.yml` (Wednesday 05:00 UTC, off the
+existing cron slots), which cannot block a merge: required contexts are evaluated
+per-commit on pull requests and are unaffected. `test_ci_dead_schedule_arm.py`
+keeps the promise repo-wide — the trap is generic, and the next workflow to grow a
+schedule arm should not have to rediscover it.
+
+Its detector is worth noting as a small ADR-001 §4 rehearsal: the first version
+enumerated comparison shapes (`==`, the reversed form, `contains(...)`) and the
+`contains` pattern failed immediately on
+`contains(fromJSON('["schedule","push"]'), github.event_name)`, because `[^)]*`
+cannot span the `)` inside `fromJSON(...)`. Replaced by the invariant that actually
+holds for every spelling: **co-occurrence** of `github.event_name` and a quoted
+`schedule` token on one line. Over-reporting direction only (a stray `echo`
+mentioning both demands a trigger — a false alarm, never a bypass).
 
 **Backlog (Class 2 — matcher-completeness / enumeration gaps; require a
 deliberate, unusual edit rather than a comment-out, so lower natural-regression

--- a/scanner/tests/test_ci_codeql_single_model.py
+++ b/scanner/tests/test_ci_codeql_single_model.py
@@ -28,11 +28,15 @@ No network, no subprocess. Passes under pytest (the CI runner) and
 import re
 import sys
 import unittest
-from glob import glob
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import strip_inline_comment as _strip_comment  # noqa: E402
+from _ci_guard_util import (  # noqa: E402
+    explicit_key_lines,
+    strip_inline_comment as _strip_comment,
+    workflow_and_action_files,
+    yaml_key_pattern,
+)
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -40,8 +44,12 @@ WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
 
 # CodeQL *analysis* sub-actions that constitute a repo-level model. `upload-sarif`
 # is deliberately excluded — it only publishes third-party SARIF.
+# The `uses:` key is read bare OR quoted — `"uses": github/codeql-action/init@…`
+# resolves identically and slipped past the bare-only regex, letting a second
+# CodeQL model in with this guard green (2026-08-06 sweep). See yaml_key_pattern.
 ANALYSIS_ACTION_RE = re.compile(
-    r"uses:\s*github/codeql-action/(init|analyze)(?:[/@]|\s|$)"
+    rf"{yaml_key_pattern('uses')}:\s*[\"']?github/codeql-action/(init|analyze)"
+    r"(?:[/@]|\s|$)"
 )
 
 
@@ -53,7 +61,10 @@ class TestCodeqlSingleModel(unittest.TestCase):
         )
 
     def test_no_repo_level_codeql_analysis(self):
-        workflow_files = sorted(glob(str(WORKFLOW_DIR / "*.yml")))
+        # Workflows in BOTH extensions plus composite actions: a `codeql.yaml`
+        # or a composite `action.yml` invoking `codeql-action/init` is just as
+        # much a second model, and neither was enumerated before.
+        workflow_files = workflow_and_action_files()
         self.assertTrue(
             workflow_files,
             f"No workflow files found under {WORKFLOW_DIR} — path assumption broke",
@@ -73,6 +84,56 @@ class TestCodeqlSingleModel(unittest.TestCase):
             "model only). Remove the workflow, or if intentionally switching to a "
             "workflow-based model, delete this guard in the same PR:\n  "
             + "\n  ".join(violations),
+        )
+
+
+class TestCodeqlMatcherMutation(unittest.TestCase):
+    """Non-vacuity for the 2026-08-06 sweep fix: a quoted `uses:` key and the
+    explicit-key form must not smuggle a second CodeQL model past this guard."""
+
+    def test_fires_on_quoted_uses_key(self):
+        sha = "0" * 40
+        for line in (
+            f'      - "uses": github/codeql-action/init@{sha}',
+            f"      - 'uses': github/codeql-action/analyze@{sha}",
+            f"      - uses: github/codeql-action/init@{sha}",
+        ):
+            with self.subTest(line=line.strip()):
+                self.assertTrue(
+                    ANALYSIS_ACTION_RE.search(_strip_comment(line)),
+                    "Mutation FAILED: a quoted `uses` key hid a CodeQL analysis "
+                    "action, so a duplicate repo-level model would pass.",
+                )
+
+    def test_quiet_on_upload_sarif_and_comments(self):
+        sha = "0" * 40
+        for line in (
+            f"      - uses: github/codeql-action/upload-sarif@{sha}",
+            f"      # - uses: github/codeql-action/init@{sha}",
+        ):
+            with self.subTest(line=line.strip()):
+                self.assertFalse(
+                    ANALYSIS_ACTION_RE.search(_strip_comment(line)),
+                    "False positive: `upload-sarif` (third-party SARIF publishing, "
+                    "not analysis) or a commented-out line was flagged.",
+                )
+
+    def test_enumeration_covers_yaml_and_composite_actions(self):
+        found = workflow_and_action_files()
+        self.assertTrue(
+            [p for p in found if "/actions/" in p],
+            "Mutation FAILED: composite actions are not enumerated, so a "
+            "`codeql-action/init` inside one would be invisible here.",
+        )
+
+    def test_tripwire_flags_explicit_uses_key(self):
+        wf = "\n".join(
+            ["jobs:", "  j:", "    steps:", "      - ? uses", "        : github/codeql-action/init@x"]
+        )
+        self.assertTrue(
+            explicit_key_lines(wf, "uses"),
+            "tripwire FAILED: `? uses` / `: codeql-action/init` was not flagged, and "
+            "the analysis-action scan cannot read that value.",
         )
 
 

--- a/scanner/tests/test_ci_cross_os_non_required.py
+++ b/scanner/tests/test_ci_cross_os_non_required.py
@@ -27,8 +27,10 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _ci_guard_util import (  # noqa: E402
+    explicit_key_lines,
     strip_comment_lines,
     strip_inline_comment,
+    yaml_key_pattern,
 )
 
 # scanner/tests/this_file -> parents[2] == repo root
@@ -55,7 +57,12 @@ _OS_RUNNER_RE = re.compile(r"\b(?:macos|windows)-[a-z0-9.]+\b", re.IGNORECASE)
 # context is the only way to exclude them without also dropping real `<os>-<ver>`
 # labels, since a charset like `windows-1252` is indistinguishable by shape from a
 # version like `windows-2022` (ADR-001 §2 false-positive finding).
-_RUNNER_KEY_RE = re.compile(r"^(\s*)(?:runs-on|os)\s*:(.*)$")
+# The `runs-on:`/`os:` key is read bare OR quoted: `"runs-on": macos-14` selects
+# the same runner, and the bare-only regex let it become a REQUIRED merge gate
+# with this guard green (2026-08-06 sweep). See yaml_key_pattern.
+_RUNNER_KEY_RE = re.compile(
+    rf"^(\s*)(?:{yaml_key_pattern('runs-on')}|{yaml_key_pattern('os')})\s*:(.*)$"
+)
 _LIST_ITEM_RE = re.compile(r"^(\s*)-\s*(.+)$")
 
 # Required branch-protection contexts a cross-OS job name must NOT collide with.
@@ -157,11 +164,20 @@ class TestCrossOsWorkflowNonRequired(unittest.TestCase):
         # ("Lint" or "Security Scan Gate") would let it masquerade as a required
         # check — both must be checked (the audit found "Lint" was omitted).
         for ctx in REQUIRED_CONTEXTS:
+            # Key AND value may be quoted — `"name": "Lint"` is the same display
+            # name, so a bare-only pattern let the masquerade through.
             self.assertNotRegex(
                 self.cross,
-                rf"(?m)^\s*name:\s*{re.escape(ctx)}\s*$",
+                rf"""(?m)^\s*{yaml_key_pattern('name')}\s*:\s*["']?{re.escape(ctx)}["']?\s*$""",
                 f"A cross-OS job is named '{ctx}', colliding with a required "
                 "branch-protection context. Rename it.",
+            )
+            self.assertEqual(
+                explicit_key_lines(self.cross, "name", "runs-on"),
+                [],
+                "A `name:`/`runs-on:` key in cross-os-checks.yml uses YAML's "
+                "explicit-key form (`? key` / `: value`), which no matcher here "
+                "can read. Use the ordinary `key: value` form.",
             )
 
 

--- a/scanner/tests/test_ci_dead_schedule_arm.py
+++ b/scanner/tests/test_ci_dead_schedule_arm.py
@@ -1,0 +1,334 @@
+"""
+Regression guard: no workflow relies on a `schedule` arm it can never take.
+
+THE RISK (a gate that silently never runs)
+------------------------------------------
+Path-gated jobs in this repo take the form
+
+    if: needs.changes.outputs.<bucket> == 'true' || github.event_name == 'schedule'
+
+The second arm is the escape hatch: it is what guarantees a job whose bucket is
+rarely touched still gets revalidated periodically. If the workflow itself has no
+`schedule:` trigger, that arm can NEVER evaluate true, and the job runs only when
+its bucket happens to be edited. Nothing fails; the job just reports `skipped`
+forever, which reads as green.
+
+WHY IT IS NEEDED HERE (incident-backed bar)
+-------------------------------------------
+`lint.yml` had seven such jobs and NO `schedule:` trigger (verified over 1118
+historical runs: 654 `pull_request` + 464 `push`, zero `schedule`). Measured
+consequences:
+
+- `npm-audit`: ZERO real executions for ~7 weeks / 117 `main` commits — its
+  bucket (`package*.json` / `.nvmrc`) was last touched in `e5b9bbb`. A newly
+  disclosed advisory against the locked tree would have gone unnoticed
+  indefinitely.
+- `pip-audit`: likewise dark, until a `requirements-fork-guard.txt` edit finally
+  fired it and it failed on the spot with accumulated runner drift
+  (`setuptools` PYSEC-2026-3447) — a failure that looked like it belonged to the
+  unrelated PR that surfaced it.
+
+The fix was a weekly `schedule:` on `lint.yml`; this guard is what keeps the
+promise. It is deliberately repo-wide rather than `lint.yml`-specific: the trap is
+generic and the next workflow to grow a `schedule` arm should not have to
+rediscover it. Contrast `security-scan.yml`, which DOES carry
+`schedule: '0 9 * * 1'` — its arm is live and firing weekly. That is the shape
+this guard requires.
+
+WHAT IT CHECKS / DOES NOT
+-------------------------
+- Direction: **consistency**. For every workflow, IF any job's `if:` references
+  `github.event_name == 'schedule'` (or `contains(... 'schedule')`), THEN the
+  workflow's own `on:` block must declare `schedule:`. Removing the trigger while
+  leaving the arms, or adding an arm to a workflow with no trigger, both trip it.
+- It does NOT require a schedule where no job asks for one, and it does NOT check
+  the cron cadence — a schedule that exists but is wrong is a different question
+  and would need a policy this repo has not set.
+- The `on:` block is located with the shared `extract_on_block` (handles
+  bare/quoted `on:`); `schedule` and the job `if:` key are matched with
+  `yaml_key_pattern` so a quoted form counts as present. An `? schedule`
+  explicit-key form fails closed via `explicit_key_lines`, since the literal
+  `schedule:` never appears there for any matcher to find.
+- Scans workflows in BOTH extensions (composite actions have no `on:`, so
+  `workflow_and_action_files` is deliberately NOT used here).
+
+stdlib-only (regex/line scanning, no PyYAML — absent from requirements-ci.txt).
+No network, no subprocess. Passes under pytest (the CI runner) and
+`python3 -m unittest`. Does not import scanner/lib, so it never moves the
+measured coverage gate.
+"""
+
+import re
+import sys
+import unittest
+from glob import glob
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import (  # noqa: E402
+    explicit_key_lines,
+    extract_on_block,
+    strip_comment_lines,
+    yaml_key_pattern,
+)
+
+# scanner/tests/this_file -> parents[2] == repo root
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_DIR = REPO_ROOT / ".github" / "workflows"
+
+# A line gates on the schedule event when it references `github.event_name` AND a
+# quoted `schedule` token. Deliberately NOT an enumeration of comparison shapes:
+# a first attempt matched `== 'schedule'`, the reversed comparison, and
+# `contains(...)` separately, and the `contains` pattern immediately failed on
+# `contains(fromJSON('["schedule","push"]'), github.event_name)` because its
+# `[^)]*` could not span the `)` inside `fromJSON(...)`. Enumerating expression
+# syntax is the mistake ADR-001 §4 warns about; the *co-occurrence* is the real
+# invariant and it holds for every spelling, present and future.
+#
+# Error direction is safe: a line that merely mentions both (say an `echo`) causes
+# this guard to DEMAND a `schedule:` trigger — a false alarm a reviewer resolves in
+# seconds, never a silent bypass.
+_EVENT_NAME_RE = re.compile(r"github\.event_name")
+_SCHEDULE_TOKEN_RE = re.compile(r"""["']schedule["']""")
+
+
+def workflow_files() -> list:
+    """Workflow files in BOTH extensions (Actions honours `.yml` and `.yaml`)."""
+    return sorted(
+        glob(str(WORKFLOW_DIR / "*.yml")) + glob(str(WORKFLOW_DIR / "*.yaml"))
+    )
+
+
+def has_schedule_arm(text: str) -> bool:
+    """True if any line of `text` gates on the `schedule` event.
+
+    Comment lines are dropped first: a commented-out arm is not a live promise, so
+    demanding a trigger for it would be a false alarm. Matched per LINE, so an
+    unrelated `github.event_name` elsewhere in the file cannot pair up with a
+    `'schedule'` token far away."""
+    return any(
+        _EVENT_NAME_RE.search(ln) and _SCHEDULE_TOKEN_RE.search(ln)
+        for ln in strip_comment_lines(text).splitlines()
+    )
+
+
+def declares_schedule_trigger(text: str) -> bool:
+    """True if the workflow's top-level `on:` block declares `schedule:`.
+
+    Scoped to the `on:` block via `extract_on_block`, so a `schedule:` key nested
+    under something else (or the word appearing in a job name) does not count."""
+    on_block = extract_on_block(text)
+    return bool(
+        re.search(rf"(?m)^\s*{yaml_key_pattern('schedule')}\s*:", on_block)
+    )
+
+
+def dead_schedule_arm_workflows(paths=None) -> list:
+    """`(filename, reason)` for every workflow whose `schedule` arm can never fire."""
+    out = []
+    for path in paths if paths is not None else workflow_files():
+        text = Path(path).read_text(encoding="utf-8")
+        name = Path(path).name
+        if not has_schedule_arm(text):
+            continue
+        if explicit_key_lines(text, "schedule"):
+            out.append(
+                (name, "declares `schedule` with the explicit-key form (`? schedule`), "
+                        "which no matcher here can read — use `schedule:`")
+            )
+            continue
+        if not declares_schedule_trigger(text):
+            out.append(
+                (name, "a job `if:` gates on `github.event_name == 'schedule'` but the "
+                        "workflow has NO `schedule:` trigger, so that arm can never be "
+                        "true and the job runs only when its path bucket is touched")
+            )
+    return out
+
+
+class TestNoDeadScheduleArm(unittest.TestCase):
+    def test_workflow_dir_canary(self):
+        self.assertTrue(
+            workflow_files(),
+            f"No workflow files found under {WORKFLOW_DIR} — path assumption broke",
+        )
+
+    def test_every_schedule_arm_has_a_schedule_trigger(self):
+        offenders = [f"{name}: {reason}" for name, reason in dead_schedule_arm_workflows()]
+        self.assertEqual(
+            offenders,
+            [],
+            "Workflow(s) rely on a `schedule` arm that can never fire. Either add a "
+            "`schedule:` trigger to the workflow's `on:` block, or remove the dead "
+            "`|| github.event_name == 'schedule'` from the job `if:` so the gating is "
+            "honest about when the job actually runs:\n  " + "\n  ".join(offenders),
+        )
+
+    def test_lint_yml_keeps_its_weekly_schedule(self):
+        # The specific incident this guard was written for: lint.yml's seven
+        # path-gated jobs (npm-audit / pip-audit most acutely) depend on it.
+        lint = WORKFLOW_DIR / "lint.yml"
+        self.assertTrue(lint.is_file(), f"{lint} not found")
+        text = lint.read_text(encoding="utf-8")
+        self.assertTrue(
+            has_schedule_arm(text),
+            "lint.yml no longer has any `schedule`-gated job. If the path-gating "
+            "design changed, update this guard in the same PR.",
+        )
+        self.assertTrue(
+            declares_schedule_trigger(text),
+            "lint.yml lost its `schedule:` trigger. npm-audit and pip-audit then "
+            "revalidate ONLY when their path bucket is edited — npm-audit went ~7 "
+            "weeks / 117 commits without a single real execution the last time this "
+            "was the case, and pip-audit accumulated a real CVE unnoticed.",
+        )
+
+
+class TestDeadScheduleArmDetectorMutation(unittest.TestCase):
+    """Non-vacuity: the detector must FIRE on the arm-without-trigger shape and
+    stay QUIET on both correct shapes (trigger present; no arm at all)."""
+
+    _ARM_NO_TRIGGER = "\n".join(
+        [
+            "on:",
+            "  pull_request:",
+            "jobs:",
+            "  audit:",
+            "    if: needs.changes.outputs.npm_deps == 'true' || github.event_name == 'schedule'",
+            "    runs-on: ubuntu-latest",
+        ]
+    )
+    _ARM_WITH_TRIGGER = "\n".join(
+        [
+            "on:",
+            "  pull_request:",
+            "  schedule:",
+            "    - cron: '0 5 * * 3'",
+            "jobs:",
+            "  audit:",
+            "    if: needs.changes.outputs.npm_deps == 'true' || github.event_name == 'schedule'",
+        ]
+    )
+    _NO_ARM_NO_TRIGGER = "\n".join(
+        ["on:", "  pull_request:", "jobs:", "  build:", "    runs-on: ubuntu-latest"]
+    )
+
+    def _detect(self, text):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp, "wf.yml")
+            p.write_text(text, encoding="utf-8")
+            return dead_schedule_arm_workflows([str(p)])
+
+    def test_fires_on_arm_without_trigger(self):
+        self.assertTrue(
+            self._detect(self._ARM_NO_TRIGGER),
+            "Mutation FAILED: a job gating on the schedule event in a workflow with "
+            "no `schedule:` trigger was not flagged — the exact lint.yml defect.",
+        )
+
+    def test_quiet_when_trigger_present(self):
+        self.assertEqual(
+            self._detect(self._ARM_WITH_TRIGGER),
+            [],
+            "False positive: a workflow that DOES declare `schedule:` was flagged.",
+        )
+
+    def test_quiet_when_no_arm(self):
+        self.assertEqual(
+            self._detect(self._NO_ARM_NO_TRIGGER),
+            [],
+            "False positive: a workflow with no schedule-gated job was required to "
+            "have a `schedule:` trigger.",
+        )
+
+    def test_quoted_on_and_schedule_keys_count_as_present(self):
+        wf = "\n".join(
+            [
+                '"on":',
+                "  pull_request:",
+                '  "schedule":',
+                "    - cron: '0 5 * * 3'",
+                "jobs:",
+                "  audit:",
+                "    if: github.event_name == 'schedule'",
+            ]
+        )
+        self.assertEqual(
+            self._detect(wf),
+            [],
+            "False positive: a quoted `\"on\":`/`\"schedule\":` key was not "
+            "recognised, so a correctly-scheduled workflow was flagged.",
+        )
+
+    def test_commented_arm_does_not_demand_a_trigger(self):
+        wf = "\n".join(
+            [
+                "on:",
+                "  pull_request:",
+                "jobs:",
+                "  audit:",
+                "    # if: github.event_name == 'schedule'",
+                "    if: needs.changes.outputs.npm_deps == 'true'",
+            ]
+        )
+        self.assertEqual(
+            self._detect(wf),
+            [],
+            "False positive: a commented-out schedule arm is not a live promise and "
+            "must not require a trigger.",
+        )
+
+    def test_flags_explicit_key_schedule(self):
+        wf = "\n".join(
+            [
+                "on:",
+                "  pull_request:",
+                "  ? schedule",
+                "  : [{cron: '0 5 * * 3'}]",
+                "jobs:",
+                "  audit:",
+                "    if: github.event_name == 'schedule'",
+            ]
+        )
+        self.assertTrue(
+            self._detect(wf),
+            "tripwire FAILED: an explicit-key `? schedule` trigger was silently "
+            "accepted, but no matcher here can read it — fail closed instead.",
+        )
+
+    def test_detects_contains_style_arm(self):
+        wf = "\n".join(
+            [
+                "on:",
+                "  pull_request:",
+                "jobs:",
+                "  audit:",
+                "    if: contains(fromJSON('[\"schedule\",\"push\"]'), github.event_name)",
+            ]
+        )
+        self.assertTrue(
+            self._detect(wf),
+            "Mutation FAILED: a `contains(...)`-style schedule arm was not "
+            "recognised, so the same dead-arm shape escapes with a different "
+            "spelling.",
+        )
+
+    def test_real_workflows_scanned_not_empty(self):
+        # Guards against a silent path/parse break making the repo-wide test above
+        # pass vacuously: at least one real workflow must have a schedule arm.
+        armed = [
+            Path(p).name
+            for p in workflow_files()
+            if has_schedule_arm(Path(p).read_text(encoding="utf-8"))
+        ]
+        self.assertTrue(
+            armed,
+            "No workflow in this repo has a `schedule`-gated job — either the arms "
+            "were all removed (update this guard) or the scan broke.",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_ci_npm_publish.py
+++ b/scanner/tests/test_ci_npm_publish.py
@@ -115,15 +115,23 @@ class TestNpmPublishLeastPrivilege(unittest.TestCase):
             "least-privilege default was removed (GITHUB_TOKEN would fall back to "
             "broad default scopes).",
         )
-        self.assertRegex(
-            block,
-            r"^\s*contents:\s*read\s*$",
-            "Workflow-level permissions must keep `contents: read`.",
-        )
+        # ORDER MATTERS. The write-grant scan runs FIRST so that a broadened
+        # permission is reported by the check that actually diagnoses it.
+        #
+        # It used to run second, behind the whole-block anchor below, and that
+        # ordering hid a genuine false negative for as long as it existed: the scan
+        # `:\s*write\b` missed a QUOTED grant value (`packages: "write"` is the same
+        # grant to any YAML parser), so `write_grants` came back EMPTY while the
+        # permission was live. The test still failed — but on the anchor, i.e. by
+        # accident, with a message about block shape rather than about a write
+        # grant. Fixing the scan alone was not enough: with the anchor first, the
+        # scan could never be the reporter, so its correctness was unobservable in
+        # the integrated path (verified — the fixed scan's message did not appear).
+        # Both are now load-bearing and independently observable.
         write_grants = [
             ln.strip()
             for ln in block.splitlines()
-            if re.search(r":\s*write\b", _strip_comment(ln))
+            if re.search(r""":\s*["']?write\b""", _strip_comment(ln))
         ]
         self.assertEqual(
             write_grants,
@@ -132,6 +140,16 @@ class TestNpmPublishLeastPrivilege(unittest.TestCase):
             "(least-privilege regression — keep it `contents: read`; job-level "
             "`id-token: write` belongs under the publish job, not here):\n  "
             + "\n  ".join(write_grants),
+        )
+        # The missing `re.MULTILINE` here is deliberate: `^`/`$` anchor the WHOLE
+        # block, so this passes only when `contents: read` is its sole entry. That
+        # makes it a structural catch-all for any added key the write-grant scan
+        # above does not classify (a read-scope addition, a stray anchor, a typo).
+        self.assertRegex(
+            block,
+            r"^\s*contents:\s*read\s*$",
+            "Workflow-level permissions must keep `contents: read` as its ONLY "
+            "entry (this pattern intentionally anchors the whole block).",
         )
 
 
@@ -258,6 +276,46 @@ class TestAutoReleaseTriggerScoping(unittest.TestCase):
         scan = self._scan("    branches: [main]")
         self.assertIn("branches:", scan)
         self.assertRegex(scan, self._PATTERN)
+
+
+class TestWriteGrantScanMutation(unittest.TestCase):
+    """Non-vacuity for the 2026-08-06 sweep fix: the write-grant scan itself must
+    catch a QUOTED grant value. Before it, `packages: "write"` produced an empty
+    `write_grants` list — the scan reported no violation while the permission was
+    live, and only the (unrelated) whole-block anchor happened to fail."""
+
+    @staticmethod
+    def _write_grants(block):
+        return [
+            ln.strip()
+            for ln in block.splitlines()
+            if re.search(r""":\s*["']?write\b""", _strip_comment(ln))
+        ]
+
+    def test_fires_on_quoted_and_bare_write_grants(self):
+        for line in (
+            '  packages: "write"',
+            "  packages: 'write'",
+            "  packages: write",
+            '  id-token: "write"',
+        ):
+            with self.subTest(line=line.strip()):
+                self.assertTrue(
+                    self._write_grants(line),
+                    "Mutation FAILED: a quoted write grant was invisible to the "
+                    "write-grant scan — a least-privilege regression would be "
+                    "reported as no violation.",
+                )
+
+    def test_quiet_on_read_grants_and_comments(self):
+        for line in ("  contents: read", '  contents: "read"', "  # packages: write"):
+            with self.subTest(line=line.strip()):
+                self.assertEqual(
+                    self._write_grants(line),
+                    [],
+                    "False positive: a read grant or a commented-out grant was "
+                    "reported as a live write grant.",
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Two things, both from the tail of the #393 sweep.

## 1. Sweep remainder (MEDIUM/LOW) — the sweep backlog is now empty

- **`codeql_single_model`** — enumerate both extensions AND composite actions (a `codeql.yaml`, or a composite `action.yml` invoking `codeql-action/init`, is just as much a second model, and neither was globbed); read the `uses:` key and value bare OR quoted; `? uses` fails closed.
- **`cross_os_non_required`** — `runs-on:`/matrix `os:` read bare OR quoted; the job-name collision check accepts a quoted key **and** a quoted value; `? name`/`? runs-on` fail closed.

| Mutation | Before | After |
|---|---|---|
| `codeql-action/init` in a `codeql.yaml` | `2 passed` | `1 failed` |
| quoted `"uses": codeql-action/init` | `2 passed` | `1 failed` |
| quoted `"runs-on": macos-14` in `lint.yml` | `13 passed` | `1 failed` |
| quoted `"name": Lint` masquerade | `13 passed` | `1 failed` |

### `npm_publish` needed two fixes, and the second only surfaced by checking *which* assertion reported

Teaching the write-grant scan to read a quoted value (`packages: "write"` had produced an **empty** grant list) left the test failing on the unrelated whole-block anchor instead — the precise message never appeared:

```console
$ pytest scanner/tests/test_ci_npm_publish.py  # with packages: "write" injected
1 failed, 11 passed
$ ... | grep -c "broadened with a write grant"
0        # ← the fixed scan was NOT the reporter
```

Behind that anchor the scan could never report, so its correctness was unobservable. Inverting the order fixed it:

```console
    reported BY the write-grant scan? YES — precise diagnosis
    and the grant line is named?      packages: "write"
```

The anchor stays as a structural catch-all for additions the scan does not classify. **Lesson: "the test goes red" is not the same as "the fix is load-bearing" — check which assertion fires.**

## 2. Dead schedule arm — a different class, and worse, because nothing ever went red

Path-gated jobs carry `|| github.event_name == 'schedule'` as their periodic escape hatch. But `lint.yml` had **no `schedule:` trigger at all** — verified both by parsing the file and over 1118 historical runs (654 `pull_request` + 464 `push`, **zero** `schedule`) — so that arm could never be true for **seven** jobs.

Measured consequences:

- **`npm-audit`: zero real executions for ~7 weeks / 117 `main` commits.** Its bucket (`package*.json` / `.nvmrc`) was last touched in `e5b9bbb`. A newly disclosed advisory against the locked tree would have gone unnoticed indefinitely.
- **`pip-audit`** sat dark until a requirements edit finally fired it and it failed on the spot with accumulated runner drift (`setuptools` PYSEC-2026-3447) — a failure that looked like it belonged to the unrelated PR that surfaced it.

A `skipped` job reads as green, so there was no signal to notice.

**Fix:** a weekly `schedule:` on `lint.yml` (Wednesday 05:00 UTC, off the existing cron slots — 06:00 Mon cross-os, 09:00 Mon security-scan, 06:00/06:30 daily). This **cannot block a merge**: required contexts are evaluated per-commit on pull requests and are unaffected; it only adds scheduled runs.

**New guard `test_ci_dead_schedule_arm.py`** keeps the promise repo-wide, because the trap is generic and the next workflow to grow a schedule arm should not have to rediscover it. Direction is **consistency**: for every workflow, IF a job gates on the schedule event THEN the workflow must declare `schedule:` — so removing the trigger while leaving the arms trips it too. Cadence is deliberately not checked (no policy set).

Mutation-proven against the **real pre-fix `lint.yml`**:

```console
lint.yml WITHOUT schedule: (the real pre-fix defect) -> 2 failed, 9 passed
AssertionError: ["lint.yml: a job `if:` gates on `github.event_name == 'schedule'`
 but the workflow has NO `schedule:` trigger, so that arm can never be true and the
 job runs only when its path bucket is touched"]
```

### Its detector is a small ADR-001 §4 rehearsal

The first version enumerated comparison shapes (`==`, the reversed form, `contains(...)`) and the `contains` pattern **failed immediately** on `contains(fromJSON('["schedule","push"]'), github.event_name)` — `[^)]*` cannot span the `)` inside `fromJSON(...)`. Replaced by the invariant that holds for every spelling: **co-occurrence** of `github.event_name` and a quoted `schedule` token on one line. Over-reporting direction only (a stray `echo` mentioning both demands a trigger — a false alarm, never a bypass).

## Verification

```
pytest scanner/tests/                     1742 passed, 5 skipped
python3 -m unittest (all 4 guards)        6 / 13 / 12 / 11 tests, OK
catalog completeness meta-guard           satisfied (new row added; it correctly
                                          failed first, demanding one)
markdownlint                              clean
lint.yml parses, on: = push/pull_request/schedule
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)