### PR TITLE
chore(deps): bump codeql-action and markdownlint-cli2-action SHAs (supersedes #388)

### DIFF
--- a/.github/workflows/dast-full-scan.yml
+++ b/.github/workflows/dast-full-scan.yml
@@ -177,7 +177,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always() && hashFiles('zap_scan.sarif') != ''
-        uses: github/codeql-action/upload-sarif@e0647621c2984b5ed2f768cb892365bf2a616ad1  # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3  # v4.37.6
         with:
           sarif_file: zap_scan.sarif
           category: "DAST"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -773,7 +773,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Lint Markdown
-        uses: DavidAnson/markdownlint-cli2-action@6bf21b07787794f89a243495939cd651942aeabe  # v24.1.0
+        uses: DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff  # v24.2.0
         with:
           globs: |
             **/*.md


### PR DESCRIPTION
Supersedes #388. Applies the same two action bumps directly, per this repo's documented rule for Dependabot action PRs (`.claude/rules/git-workflow.md`: *"apply the required update directly to `main` (via PR), then close the duplicate/conflicting Dependabot PR with rationale"*).

## Why #388 could not merge

Diagnosed rather than assumed — I ran `gh pr update-branch 388` first to rule out staleness:

```console
$ gh pr checks 388
SUCCESS: 22   (incl. both required: Lint, Security Scan Gate)
SKIPPED: 8
$ gh pr view 388 --json mergeable,mergeStateStatus
{"mergeable":"MERGEABLE","mergeStateStatus":"BLOCKED"}
```

Up to date, zero conflicts, nothing failing — still `BLOCKED`. The remaining gate is `require_code_owner_reviews: true` with CODEOWNERS `* @Twodragon0`: #388 is authored by `app/dependabot`, so no automated identity can satisfy the code-owner requirement, and `enforce_admins: true` leaves no bypass.

Note `reviewDecision` reads `""` on both #388 and the recently-merged #398, because `required_approving_review_count` is `0` — that field does **not** distinguish them. The difference is authorship: #398 was authored by the sole code owner, which satisfies ownership; #388 is not.

## What changed, and one deliberate deviation from #388

| Action | #388 proposed | This PR | Why |
|---|---|---|---|
| `github/codeql-action/upload-sarif` | `f205ea1c` (v4.37.4) | **`5595ccaf` (v4.37.6)** | the `v4` tag moved two patches on since #388 opened 2026-08-05; landing a knowingly stale pin only triggers another Dependabot PR into the same blocked state |
| `DavidAnson/markdownlint-cli2-action` | `21c1be1b` (v24.2.0) | `21c1be1b` (v24.2.0) | unchanged — still the latest release |

Both are patch-level within the pinned major.

## SHA provenance verified upstream, not trusted from the diff

Annotated tags dereferenced to their commits:

```console
v24.2.0 -> 21c1be1b93ad9ed58fa840aacc3f279cde2a72ff   # exactly what #388 proposed
v4.37.4 -> f205ea1c3313d32999d8d6a48b4f6530d4437b38
v4.37.5 -> d1ba80a13dd99fba24a470575428917156a28b43
v4.37.6 -> 5595ccaf912efad79be6eef63a5619ff05969be3   # current `v4` head
```

Drift check: each old SHA occurred **exactly once** under `.github/`, so nothing is left behind on the previous pin.

## Small quality change on the same lines

The codeql-action pin comment goes from `# v4` to `# v4.37.6`. Every other pin in these two files is annotated with its exact version (`# v24.2.0`, `# v7.0.1`, `# v0.13.0`); a bare `# v4` on a moving major hides exactly the drift this PR is correcting.

## Verification

```console
$ python3 -m pytest scanner/ -q
1795 passed, 5 skipped in 9.00s
```

The SHA-pin guard (`test_ci_config_guards` family) validates the 40-hex pin, which both replacements satisfy. CI on this PR exercises both changed actions directly — `markdown-lint` runs the bumped markdownlint action, and `Analyze (*)` / `dast-baseline` exercise the codeql-action upload path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)