### PR TITLE
fix(ci): templates/ ships workflows to other repos and no guard read them

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -781,6 +781,71 @@ being on its list:
   for". Rationale lives in
   [the retrospective](../reports/runner-key-audit-retrospective.md).
 
+### Redirect-surface survey 2026-08-10 (post-#412)
+
+PR #412 closed the REDIRECT class inside the required graph. This survey asked
+where else those keys can reach, and found the exposure is nil — but found a
+different, larger gap on the way.
+
+**Redirect keys outside the required graph: none.** The only `working-directory`/
+`shell`/`defaults` sites repo-wide are `shell: bash` in the two composite
+actions, which GitHub *requires* on a composite `run:` step. `lint.yml` has a
+line that greps as `shell:` — it is an **output name** under `outputs:`, not a
+step key, and the column-derived matcher correctly ignores it (a naive
+`grep shell:` would have raised it as a finding).
+
+**The composite actions are not called by this repo at all.** No `uses: ./`
+appears anywhere under `.github/workflows/`. They are called from
+`templates/prowler.yml` and `templates/security-scan-suite.yml`, which ship to
+OTHER repositories. A docstring in `_ci_guard_util.workflow_and_action_files`
+asserted the opposite ("required workflows call them") and is corrected.
+
+**The real finding: `templates/` was scanned by nobody.** `scripts/setup.sh`
+copies `templates/codeql.yml` and `templates/dependency-review.yml` straight
+into a target repo's `.github/workflows/`, and both composite actions alongside
+them. So an injection there executes in someone else's repo with their token —
+strictly higher blast radius than this repo's own CI — and
+`workflow_and_action_files()` returned 18 files, none under `templates/`.
+
+`test_ci_injection_surface.py` now scans all 13 templates. Baseline is clean
+(zero untrusted-context interpolations, zero unscannable shapes), so it is a
+pure ratchet, with a canary and a mutation test that plants a live
+`${{ github.event.issue.title }}` in the real `templates/codeql.yml`.
+
+**Deliberately NOT changed — a product decision, not a guard's to make.** The
+templates carry ~30 tag-pinned `uses:` refs (`@v3`, `@v4`) while this repo
+enforces 40-hex SHA pins on its own workflows. That is why the template glob was
+added to *this guard* rather than to the shared `workflow_and_action_files()`:
+widening the shared enumerator would have enrolled the templates in
+`test_ci_gate_topology.test_every_uses_is_sha_pinned` and failed the build on a
+question nobody has decided. Injection is not a policy question and is closed
+now; whether a shipped *example* should carry SHA pins (and who then keeps them
+fresh in the user's repo) is left open and visible.
+
+### Mutation-fixture helpers (2026-08-10)
+
+`apply_mutation` and `assert_disables` in `_ci_guard_util`. Added because FIVE
+probes in one audit failed the same way — the fixture did not change the thing
+it claimed to — and each nearly produced a "fix" to a guard that was correct:
+
+1. a `case` arm moved just BEFORE the `*)` catch-all — still reachable;
+2. a section HEADER edited instead of the entry beneath it;
+3. a `job_block` case written only for end-of-file, where the discriminating
+   shape is a following top-level key;
+4. `if: always()` deleted from a gate whose explanatory COMMENTS quote it
+   verbatim — this repo's own comment-evasion class, biting the fixture rather
+   than the guard;
+5. text injected onto a TestCase class that `setUpClass` then overwrote from
+   disk, so the assertion ran against the unmutated real file.
+
+`apply_mutation` closes 2 and 5 mechanically: the substring must be present, and
+the result must differ, or it raises at the point of the mistake. **1, 3 and 4
+are semantic** — whether the edit disables the CONTROL, not whether it changed
+bytes — and no helper decides that; the docstring says so rather than implying
+coverage it does not have. Migrated the six literal-`replace` fixtures;
+`re.sub`-based ones in `test_ci_security_gate_behaviour.py` are left alone
+rather than forced into a substring API.
+
 ### Verified already-guarded during this review (not backlog)
 
 > **Re-checked 2026-08-10. One entry had gone false, and the section's shape is

--- a/scanner/tests/_ci_guard_util.py
+++ b/scanner/tests/_ci_guard_util.py
@@ -107,8 +107,11 @@ def workflow_and_action_files() -> list:
     - Actions honours `.yaml` as well as `.yml`, so an `evil.yaml` workflow was
       invisible to every guard globbing `*.yml`.
     - `.github/actions/<name>/action.yml` (`runs.using: composite`) carries
-      `steps[].uses` and `steps[].run` exactly like a workflow, and required
-      workflows call them — yet no guard globbed that directory at all. A
+      `steps[].uses` and `steps[].run` exactly like a workflow — yet no guard
+      globbed that directory at all. (They are called from `templates/`, which
+      ships to user repos, NOT from this repo's own workflows; an earlier version
+      of this docstring claimed the latter and was wrong — verified 2026-08-10:
+      no `uses: ./` appears anywhere under `.github/workflows/`.) A
       tag-pinned `uses:` planted there defeated the SHA-pin check with the suite
       green.
 
@@ -529,3 +532,65 @@ def job_needs(block: str) -> list:
             elif line.strip():
                 in_needs = False
     return needs
+
+
+def apply_mutation(text: str, old: str, new: str, *, count: int = 1) -> str:
+    """`text` with `old` replaced by `new`, REFUSING to return an unchanged copy.
+
+    Every mutation self-test rests on a fixture that must genuinely disable the
+    control, and a fixture that quietly fails to apply turns the test into a
+    tautology: the guard passes, the author reads "not caught", and either a real
+    gap is missed or a correct guard gets "fixed".
+
+    That is not hypothetical. The 2026-08-10 audit produced FIVE wrong probes,
+    all of this one shape:
+
+    1. a bash `case` arm moved to just BEFORE the `*)` catch-all — still
+       perfectly reachable, so the guard was right to stay green;
+    2. a section HEADER edited instead of the entry beneath it;
+    3. a `job_block` case written only for end-of-file, where the discriminating
+       shape is a following TOP-LEVEL key;
+    4. `if: always()` deleted from a gate whose explanatory COMMENTS quote it
+       verbatim — the repo's own comment-evasion class, biting the fixture
+       instead of the guard;
+    5. text injected onto a TestCase class that `setUpClass` then overwrote from
+       disk, so the assertion ran against the unmutated real file.
+
+    This helper closes shapes 2 and 5 mechanically (the substring must be present
+    and the result must differ). Shapes 1, 3 and 4 are semantic — whether the
+    edit disables the CONTROL, not merely whether it changed bytes — and no
+    helper can decide them; use `assert_disables` for those, and state in the
+    test why the mutant is really broken.
+
+    Raises AssertionError rather than returning, so a stale fixture fails at the
+    point of the mistake instead of surfacing as a confusing downstream pass."""
+    if old not in text:
+        raise AssertionError(
+            f"mutation fixture is stale: {old!r} not found in the target text — "
+            "the file changed under the test, so this case proves nothing"
+        )
+    out = text.replace(old, new, count)
+    if out == text:
+        raise AssertionError(f"mutation {old!r} -> {new!r} left the text unchanged")
+    return out
+
+
+def assert_disables(detector, clean_text: str, mutant_text: str, label: str = ""):
+    """Assert `detector` is quiet on `clean_text` and fires on `mutant_text`.
+
+    Pins BOTH directions in one place, because either alone is satisfiable by a
+    broken detector: one that always fires passes the mutant half, and one that
+    never fires passes the clean half. Returns the mutant findings so a caller
+    can assert on their content."""
+    where = f" [{label}]" if label else ""
+    clean = detector(clean_text)
+    if clean:
+        raise AssertionError(f"detector fired on the CLEAN text{where}: {clean!r}")
+    found = detector(mutant_text)
+    if not found:
+        raise AssertionError(
+            f"detector did NOT fire on the mutant{where} — either the guard has a "
+            "gap, or the mutation does not actually disable the control. Check the "
+            "SECOND possibility first (see apply_mutation)."
+        )
+    return found

--- a/scanner/tests/test__ci_guard_util.py
+++ b/scanner/tests/test__ci_guard_util.py
@@ -45,6 +45,8 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import _ci_guard_util  # noqa: E402  (module handle: the enumeration test patches its dirs)
 from _ci_guard_util import (  # noqa: E402
+    apply_mutation,
+    assert_disables,
     desired_contexts,
     explicit_key_lines,
     extract_on_block,
@@ -650,6 +652,49 @@ class TestWorkflowAndActionFiles(unittest.TestCase):
         found = workflow_and_action_files()
         self.assertTrue([p for p in found if "/workflows/" in p])
         self.assertTrue([p for p in found if "/actions/" in p])
+
+
+class TestApplyMutation(unittest.TestCase):
+    """The helper exists because five probes in one audit failed the same way —
+    the fixture did not actually change the thing it claimed to."""
+
+    def test_applies_and_returns_the_mutant(self):
+        self.assertEqual(apply_mutation("a b c", "b", "X"), "a X c")
+
+    def test_missing_substring_raises_rather_than_no_ops(self):
+        with self.assertRaises(AssertionError) as cm:
+            apply_mutation("a b c", "zzz", "X")
+        self.assertIn("stale", str(cm.exception))
+
+    def test_replacement_equal_to_the_original_raises(self):
+        # The shape that produced wrong probe #2: an edit that changes nothing.
+        with self.assertRaises(AssertionError) as cm:
+            apply_mutation("a b c", "b", "b")
+        self.assertIn("unchanged", str(cm.exception))
+
+    def test_count_limits_the_replacement(self):
+        self.assertEqual(apply_mutation("x x x", "x", "y", count=2), "y y x")
+
+
+class TestAssertDisables(unittest.TestCase):
+    @staticmethod
+    def _detector(text):
+        return ["hit"] if "BROKEN" in text else []
+
+    def test_passes_when_clean_is_quiet_and_mutant_fires(self):
+        self.assertEqual(assert_disables(self._detector, "fine", "BROKEN"), ["hit"])
+
+    def test_fails_when_the_detector_fires_on_clean_text(self):
+        with self.assertRaises(AssertionError) as cm:
+            assert_disables(lambda t: ["always"], "fine", "BROKEN")
+        self.assertIn("CLEAN", str(cm.exception))
+
+    def test_fails_when_the_mutant_is_not_detected(self):
+        # And the message points at the likelier cause first: a mutation that
+        # does not really disable the control.
+        with self.assertRaises(AssertionError) as cm:
+            assert_disables(self._detector, "fine", "also fine")
+        self.assertIn("does not actually disable", str(cm.exception))
 
 
 if __name__ == "__main__":

--- a/scanner/tests/test_ci_gate_topology.py
+++ b/scanner/tests/test_ci_gate_topology.py
@@ -28,6 +28,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _ci_guard_util import (  # noqa: E402
+    apply_mutation,
     explicit_key_lines,
     job_block,
     job_needs,
@@ -371,9 +372,8 @@ class TestKeyQuotingAndEnumerationMutation(unittest.TestCase):
         for fname in ("lint.yml", "security-scan.yml"):
             with self.subTest(workflow=fname):
                 mutated = dict(texts)
-                mutated[fname] = texts[fname].replace("jobs:\n", "jobs:\n" + rogue, 1)
-                self.assertNotEqual(
-                    mutated[fname], texts[fname], "mutation did not apply"
+                mutated[fname] = apply_mutation(
+                    texts[fname], "jobs:\n", "jobs:\n" + rogue
                 )
                 aggregators, _ = required_aggregators(mutated)
                 gate = aggregators[fname]

--- a/scanner/tests/test_ci_injection_surface.py
+++ b/scanner/tests/test_ci_injection_surface.py
@@ -58,6 +58,7 @@ import re
 import sys
 import tempfile
 import unittest
+from glob import glob
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -378,17 +379,41 @@ def unscannable_run_keys(text: str) -> list:
     return explicit_key_lines(text, "run")
 
 
-def _scanned_files():
-    """Every file in this repo whose `run:` bodies GitHub Actions executes.
+# Shipped workflow templates. `scripts/setup.sh` copies `templates/codeql.yml`
+# and `templates/dependency-review.yml` straight into a target repo's
+# `.github/workflows/`, and the rest are documented copy-me examples — so an
+# injection here executes in SOMEONE ELSE'S repo, with their token. Higher blast
+# radius than this repo's own CI, and until 2026-08-10 no guard looked at the
+# directory at all (verified: `workflow_and_action_files()` returned 18 files,
+# none under `templates/`).
+TEMPLATE_DIR = REPO_ROOT / "templates"
 
-    Delegates to the shared `workflow_and_action_files()`, which carries the two
-    enumeration gaps this guard originally found — `*.yaml` workflows, and
+
+def _scanned_files():
+    """Every file whose `run:` bodies GitHub Actions executes — this repo's own,
+    plus the templates it ships to other people's repos.
+
+    The shared `workflow_and_action_files()` carries the two enumeration gaps
+    this guard originally found — `*.yaml` workflows, and
     `.github/actions/**/action.yml` composite steps (a live
     `${{ github.event.pull_request.title }}` planted in one left this guard
-    green, the exact CICD-SEC-4 RCE it exists to prevent). Kept as a named
-    indirection because the canary and mutation tests below assert on THIS
-    guard's file set."""
-    return workflow_and_action_files()
+    green, the exact CICD-SEC-4 RCE it exists to prevent).
+
+    `templates/*.yml` is added HERE rather than to the shared enumerator on
+    purpose. Widening the shared list would silently enrol the templates in every
+    other consumer — including `test_ci_gate_topology.test_every_uses_is_sha_pinned`,
+    which they would fail on ~30 tag-pinned `uses:` refs. Whether a shipped
+    example should carry 40-hex SHA pins is a PRODUCT decision with a real
+    maintenance cost, not something a scanning guard gets to settle as a side
+    effect. Injection is not a policy question, so it is closed now and the pin
+    question is left open and visible.
+
+    Baseline when added: zero injection hits, zero unscannable shapes across all
+    13 templates — a pure ratchet."""
+    out = list(workflow_and_action_files())
+    for name in ("*.yml", "*.yaml"):
+        out += glob(str(TEMPLATE_DIR / name))
+    return sorted(out)
 
 
 class TestNoInjectionSurface(unittest.TestCase):
@@ -1004,8 +1029,13 @@ class TestInjectionDetectorMutation(unittest.TestCase):
         # enumeration actually reads them. Patching a local copy would have gone
         # green against a helper that never saw the fixture — so this now covers
         # the enumeration EVERY guard uses, not one guard's private glob.
+        # TEMPLATE_DIR is redirected too: this module adds it on top of the
+        # shared enumerator, so leaving it pointed at the real `templates/` let
+        # 13 live files leak into the fixture's expected set.
+        global TEMPLATE_DIR
         original_wf = _ci_guard_util.WORKFLOW_DIR
         original_act = _ci_guard_util.ACTION_DIR
+        original_tpl = TEMPLATE_DIR
         with tempfile.TemporaryDirectory() as tmp:
             wf = Path(tmp, "workflows")
             wf.mkdir()
@@ -1024,10 +1054,12 @@ class TestInjectionDetectorMutation(unittest.TestCase):
             try:
                 _ci_guard_util.WORKFLOW_DIR = wf
                 _ci_guard_util.ACTION_DIR = act
+                TEMPLATE_DIR = Path(tmp, "no-templates")
                 found = sorted(Path(p).name for p in _scanned_files())
             finally:
                 _ci_guard_util.WORKFLOW_DIR = original_wf
                 _ci_guard_util.ACTION_DIR = original_act
+                TEMPLATE_DIR = original_tpl
         self.assertEqual(
             found,
             ["a.yml", "action.yaml", "action.yml", "b.yaml"],
@@ -1046,6 +1078,39 @@ class TestInjectionDetectorMutation(unittest.TestCase):
         self.assertTrue(
             any("github.event.comment.body" in c for _, c in injection_violations(wf)),
             "Mutation FAILED: tab-indented block body bypassed the indent check.",
+        )
+
+    def test_shipped_templates_are_scanned(self):
+        # Canary. `templates/` ships to other repos via scripts/setup.sh; if the
+        # glob breaks, the higher-blast-radius half of this scan goes silently
+        # vacuous while the internal half keeps it green.
+        found = [p for p in _scanned_files() if "/templates/" in p]
+        self.assertTrue(
+            found,
+            "No shipped template scanned — `scripts/setup.sh` copies "
+            "templates/codeql.yml and templates/dependency-review.yml into a "
+            "target repo's .github/workflows/, so an injection there runs with "
+            "SOMEONE ELSE'S token.",
+        )
+
+    def test_injection_planted_in_a_template_is_caught(self):
+        # Mutation self-test for the new surface, on a real template file.
+        tpl = TEMPLATE_DIR / "codeql.yml"
+        self.assertTrue(tpl.is_file(), f"{tpl} not found")
+        mutant = tpl.read_text(encoding="utf-8").replace(
+            "jobs:\n",
+            'jobs:\n  evil:\n    steps:\n      - run: echo "${{ github.event.issue.title }}"\n',
+            1,
+        )
+        hits = [
+            ln
+            for ln in run_block_lines(mutant)
+            for e in _EXPR_RE.findall(ln)
+            if _UNTRUSTED_RE.search(e)
+        ]
+        self.assertTrue(
+            hits, "an untrusted-context interpolation planted in a shipped template "
+            "was not detected"
         )
 
     def test_real_workflows_clean(self):

--- a/scanner/tests/test_ci_no_raw_output_interpolation.py
+++ b/scanner/tests/test_ci_no_raw_output_interpolation.py
@@ -50,7 +50,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import join_continuations, strip_comment_lines  # noqa: E402
+from _ci_guard_util import apply_mutation, join_continuations, strip_comment_lines  # noqa: E402
 
 
 # (relpath, [required escaper-usage substrings], [forbidden raw-interp substrings])
@@ -139,8 +139,7 @@ class TestNoRawOutputInterpolation(unittest.TestCase):
         """Removing a required escaper usage must be reported as a violation."""
         relpath, required, forbidden = SINKS[0]
         source = _normalized_source(relpath)
-        mutated = source.replace(required[0], "", 1)
-        self.assertNotEqual(mutated, source, "mutation pattern not present in source")
+        mutated = apply_mutation(source, required[0], "")
         self.assertTrue(
             _violations(mutated, required, forbidden),
             "guard failed to detect a removed escaper usage",

--- a/scanner/tests/test_ci_required_graph_not_disabled.py
+++ b/scanner/tests/test_ci_required_graph_not_disabled.py
@@ -518,7 +518,11 @@ class TestGraphViolationDetector(unittest.TestCase):
         Calls the REAL function with substituted text — not a parallel copy — so
         every mutation below exercises the code that actually guards the repo."""
         texts = workflow_texts()
-        self.assertNotEqual(mutant, texts[fname], "mutation did not apply — the test is vacuous")
+        if mutant == texts[fname]:
+            raise AssertionError(
+                "mutation did not apply — the test is vacuous (see "
+                "_ci_guard_util.apply_mutation for why this check exists)"
+            )
         texts[fname] = mutant
         return graph_violations(texts)
 

--- a/scanner/tests/test_ci_required_jobs_exist.py
+++ b/scanner/tests/test_ci_required_jobs_exist.py
@@ -50,7 +50,7 @@ import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import job_block, top_level_jobs  # noqa: E402
+from _ci_guard_util import apply_mutation, job_block, top_level_jobs  # noqa: E402
 
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -120,9 +120,7 @@ class TestRequiredJobsDetectorMutation(unittest.TestCase):
         self.assertIsNotNone(
             block, f"could not isolate the `{job}` job block in the real lint.yml"
         )
-        mutated = self.text.replace(block, "", 1)
-        self.assertNotEqual(mutated, self.text, f"deleting `{job}` changed nothing")
-        return mutated
+        return apply_mutation(self.text, block, "")
 
     def test_each_required_job_is_individually_detected(self):
         # One job at a time: deleting `gitleaks` must report `gitleaks` and
@@ -148,16 +146,14 @@ class TestRequiredJobsDetectorMutation(unittest.TestCase):
         # matcher would report the job missing and send someone chasing a
         # control that is actually there — the false-alarm twin of the quoted-key
         # blindness that hit eight guards in #391/#393/#394.
-        mutated = self.text.replace("\n  gitleaks:\n", '\n  "gitleaks":\n', 1)
-        self.assertNotEqual(mutated, self.text, "quoted-key fixture did not apply")
+        mutated = apply_mutation(self.text, "\n  gitleaks:\n", '\n  "gitleaks":\n')
         self.assertEqual(missing_required_jobs(mutated), set())
 
     def test_fires_on_a_job_demoted_to_a_comment(self):
         # Commenting a job out disables it exactly as deleting it does, and the
         # substring `gitleaks:` still appears in the file — so a raw-text
         # presence check would read green here.
-        mutated = self.text.replace("\n  gitleaks:\n", "\n  # gitleaks:\n", 1)
-        self.assertNotEqual(mutated, self.text, "comment fixture did not apply")
+        mutated = apply_mutation(self.text, "\n  gitleaks:\n", "\n  # gitleaks:\n")
         self.assertEqual(missing_required_jobs(mutated), {"gitleaks"})
 
 

--- a/scanner/tests/test_ci_security_gate.py
+++ b/scanner/tests/test_ci_security_gate.py
@@ -45,6 +45,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _ci_guard_util import (  # noqa: E402
+    apply_mutation,
     extract_on_block,
     job_block,
     job_needs,
@@ -212,10 +213,9 @@ class TestGateBlockBoundaryMutation(unittest.TestCase):
         # used to yield an EMPTY block, which fails every positive assertion at
         # once — a false alarm rather than a bypass, but still a guard broken by
         # an ordinary authoring style.
-        mutant = self.real.replace(
-            "  security-scan-gate:\n", '  "security-scan-gate":\n', 1
+        mutant = apply_mutation(
+            self.real, "  security-scan-gate:\n", '  "security-scan-gate":\n'
         )
-        self.assertNotEqual(mutant, self.real, "fixture did not apply")
         self.assertEqual(
             gate_needs_from(mutant),
             GATE_REQUIRED_NEEDS,


### PR DESCRIPTION
Survey of where the REDIRECT class (#412) reaches **outside** the required graph. The answer is nowhere — and the survey found a larger gap on the way.

## What the survey actually found

**Redirect keys outside the graph: none.** The only `working-directory` / `shell` / `defaults` sites repo-wide are `shell: bash` in the two composite actions, which GitHub *requires* on a composite `run:` step.

Worth noting because it validates #412's design: `lint.yml` has a line that greps as `shell:` — it is an **output name** under `outputs:` (the shell-files-changed bucket), not a step key. The column-derived matcher ignores it correctly. A naive `grep shell:` would have filed it as a finding.

**The composite actions are not called by this repo at all.** No `uses: ./` appears anywhere under `.github/workflows/`. They are called from `templates/prowler.yml` and `templates/security-scan-suite.yml`, which ship to *other* repositories. A docstring in `workflow_and_action_files` asserted the opposite — *"and required workflows call them"* — and is corrected.

## The finding

```console
$ scripts/setup.sh
  cp templates/codeql.yml            -> $TARGET/.github/workflows/
  cp templates/dependency-review.yml -> $TARGET/.github/workflows/
  cp .github/actions/{token-expiry-gate,datadog-ci-collect}/action.yml -> $TARGET/.github/actions/

$ workflow_and_action_files()
  18 files; any under templates/?  False
```

An injection in a template executes **in someone else's repo, with their token** — strictly higher blast radius than this repo's own CI. Nobody was looking at that directory.

`test_ci_injection_surface.py` now scans all 13 templates. Baseline is clean — zero untrusted-context interpolations, zero unscannable shapes — so it is a pure ratchet, with a canary and a mutation test that plants a live `${{ github.event.issue.title }}` in the real `templates/codeql.yml`. Verified end-to-end: with that mutation on disk the suite fails; restored, it passes.

## Deliberately NOT changed — this is your call, not a guard's

The templates carry **~30 tag-pinned `uses:` refs** (`@v3`, `@v4`) while this repo enforces 40-hex SHA pins on its own workflows.

That is precisely why the template glob went into *this guard* and not into the shared `workflow_and_action_files()`: widening the shared enumerator would have enrolled the templates in `test_ci_gate_topology.test_every_uses_is_sha_pinned` and failed the build on a question nobody has decided.

Injection is not a policy question, so it is closed now. Whether a shipped **example** should carry SHA pins — and who keeps them fresh in the *user's* repo afterwards — is left open and visible.

## Also: mutation-fixture helpers

`apply_mutation` / `assert_disables` in `_ci_guard_util`, because five probes in this audit failed the same way — the fixture did not change what it claimed to — and each nearly produced a "fix" to a guard that was correct:

| # | wrong probe | closed by the helper? |
|---|---|---|
| 1 | a `case` arm moved just *before* the `*)` catch-all — still reachable | no (semantic) |
| 2 | a section **header** edited instead of the entry beneath it | **yes** |
| 3 | a `job_block` case written only for end-of-file | no (semantic) |
| 4 | `if: always()` deleted from a gate whose **comments** quote it verbatim | no (semantic) |
| 5 | text injected onto a TestCase that `setUpClass` then overwrote from disk | **yes** |

`apply_mutation` requires the substring to be present *and* the result to differ, raising at the point of the mistake. **1, 3 and 4 are semantic** — whether the edit disables the *control*, not whether it changed bytes — and no helper decides that. The docstring says so rather than implying coverage it does not have.

Six literal-`replace` fixtures migrated. The `re.sub`-based ones in `test_ci_security_gate_behaviour.py` are left alone rather than forced into a substring API.

## Test plan

- [x] `CLAUDESEC_DASHBOARD_OFFLINE=1 pytest scanner/ -q` → **1981 passed, 5 skipped**
- [x] Six touched guards green under `python3 -m unittest` (dual-runner)
- [x] Template injection mutation applied to the real `templates/codeql.yml`, measured (2 failures), restored — `git status` clean
- [x] A no-op fixture forced into a migrated test to confirm `apply_mutation` rejects it → fails as designed
- [x] Enumeration self-test isolated from the real `templates/` (it leaked 13 live files into the fixture on first attempt)
- [x] `markdownlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)