### PR TITLE
test(guard-util): a regex fixture opts out of every check the literal one gets

### DIFF
--- a/scanner/tests/_ci_guard_util.py
+++ b/scanner/tests/_ci_guard_util.py
@@ -563,7 +563,12 @@ def apply_mutation(text: str, old: str, new: str, *, count: int = 1) -> str:
     test why the mutant is really broken.
 
     Raises AssertionError rather than returning, so a stale fixture fails at the
-    point of the mistake instead of surfacing as a confusing downstream pass."""
+    point of the mistake instead of surfacing as a confusing downstream pass.
+
+    For a fixture whose target is a REGION rather than a substring (a whole
+    `if … fi` block, the inside of a quoted argument), use
+    `apply_regex_mutation` — not bare `re.sub`, which no-ops on a miss exactly
+    like `str.replace`."""
     if old not in text:
         raise AssertionError(
             f"mutation fixture is stale: {old!r} not found in the target text — "
@@ -572,6 +577,47 @@ def apply_mutation(text: str, old: str, new: str, *, count: int = 1) -> str:
     out = text.replace(old, new, count)
     if out == text:
         raise AssertionError(f"mutation {old!r} -> {new!r} left the text unchanged")
+    return out
+
+
+def apply_regex_mutation(text: str, pattern: str, repl: str, *, count: int = 1, flags: int = 0) -> str:
+    """`apply_mutation` for fixtures whose target is a REGION, not a substring.
+
+    Some mutations cannot be expressed as a literal: deleting a whole `if … fi`
+    block, or rewriting the contents of a quoted argument, needs a pattern. The
+    fixtures that did so called `re.sub` directly and so opted out of every check
+    `apply_mutation` exists to provide — and `re.sub` fails the same silent way
+    `str.replace` does, returning the input unchanged when nothing matched.
+
+    Same two mechanical checks (the pattern must match; the result must differ),
+    plus one the literal API does not need:
+
+    **The match must not be ambiguous.** With a substring you can eyeball where it
+    occurs; with a pattern you cannot, and this repo has already executed a
+    stranger's `run:` body because a greedy regex matched more than its author
+    believed (`test_ci_security_gate_behaviour`'s prototype started
+    `python3 -m http.server`). So more matches than `count` is an error rather
+    than a silent first-wins: narrow the pattern, or raise `count` deliberately.
+    `count=0` means "every match" (`re.sub`'s own convention) and skips that
+    check.
+
+    It cannot check that the pattern matched the region you MEANT — that is the
+    same semantic limit `apply_mutation` documents. Read the mutant."""
+    matches = list(re.finditer(pattern, text, flags))
+    if not matches:
+        raise AssertionError(
+            f"mutation fixture is stale: pattern {pattern!r} matched nothing in the "
+            "target text — the file changed under the test, so this case proves nothing"
+        )
+    if count > 0 and len(matches) > count:
+        raise AssertionError(
+            f"pattern {pattern!r} matched {len(matches)} times but count={count} — "
+            "refusing to guess which occurrence the fixture meant. Narrow the "
+            "pattern, or pass the count you intend (0 for all)."
+        )
+    out = re.sub(pattern, repl, text, count=count, flags=flags)
+    if out == text:
+        raise AssertionError(f"mutation {pattern!r} -> {repl!r} left the text unchanged")
     return out
 
 

--- a/scanner/tests/test__ci_guard_util.py
+++ b/scanner/tests/test__ci_guard_util.py
@@ -46,6 +46,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import _ci_guard_util  # noqa: E402  (module handle: the enumeration test patches its dirs)
 from _ci_guard_util import (  # noqa: E402
     apply_mutation,
+    apply_regex_mutation,
     assert_disables,
     desired_contexts,
     explicit_key_lines,
@@ -674,6 +675,54 @@ class TestApplyMutation(unittest.TestCase):
 
     def test_count_limits_the_replacement(self):
         self.assertEqual(apply_mutation("x x x", "x", "y", count=2), "y y x")
+
+
+class TestApplyRegexMutation(unittest.TestCase):
+    """The regex sibling. Every check `apply_mutation` makes, plus the
+    ambiguity check a literal target does not need."""
+
+    def test_applies_and_returns_the_mutant(self):
+        self.assertEqual(apply_regex_mutation("a bbb c", r"b+", "X"), "a X c")
+
+    def test_non_matching_pattern_raises_rather_than_no_ops(self):
+        # `re.sub` returns the input unchanged on a miss — the same silent
+        # failure as `str.replace`, which is the whole reason this exists.
+        with self.assertRaises(AssertionError) as cm:
+            apply_regex_mutation("a b c", r"z+", "X")
+        self.assertIn("stale", str(cm.exception))
+
+    def test_replacement_equal_to_the_original_raises(self):
+        with self.assertRaises(AssertionError) as cm:
+            apply_regex_mutation("a b c", r"b", "b")
+        self.assertIn("unchanged", str(cm.exception))
+
+    def test_more_matches_than_count_raises(self):
+        # A pattern hitting two regions while the fixture replaces one is a
+        # coin flip over which control got disabled.
+        with self.assertRaises(AssertionError) as cm:
+            apply_regex_mutation("x1 x2", r"x\d", "y")
+        self.assertIn("matched 2 times", str(cm.exception))
+
+    def test_explicit_count_permits_the_matches_it_names(self):
+        self.assertEqual(apply_regex_mutation("x1 x2", r"x\d", "y", count=2), "y y")
+
+    def test_count_zero_replaces_every_match(self):
+        # `re.sub`'s own convention for "all", and it opts out of the
+        # ambiguity check because nothing is left unreplaced to be ambiguous.
+        self.assertEqual(apply_regex_mutation("x1 x2 x3", r"x\d", "y", count=0), "y y y")
+
+    def test_flags_are_honoured(self):
+        self.assertEqual(
+            apply_regex_mutation("A\nb\n", r"^b$", "X", flags=re.M), "A\nX\n"
+        )
+
+    def test_group_references_in_the_replacement(self):
+        # The reason a caller reaches for this API at all: keep the anchors,
+        # rewrite what sits between them.
+        self.assertEqual(
+            apply_regex_mutation("grep -ci 'real'", r"(grep -ci ')[^']*(')", r"\1decoy\2"),
+            "grep -ci 'decoy'",
+        )
 
 
 class TestAssertDisables(unittest.TestCase):

--- a/scanner/tests/test_ci_security_gate_behaviour.py
+++ b/scanner/tests/test_ci_security_gate_behaviour.py
@@ -70,6 +70,8 @@ from pathlib import Path
 # version of this file repeated it with a hardcoded `^\s{8}(?:if|"if"|'if')\s*:`.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _ci_guard_util import (  # noqa: E402
+    apply_mutation,
+    apply_regex_mutation,
     explicit_key_lines,
     keys_at_column,
     strip_inline_comment_sh,
@@ -698,10 +700,15 @@ class TestGateBehaviourDetector(unittest.TestCase):
     _GATE_RE = r'if \[ "\$CRITS" -gt 0 \]; then\n(?:.*\n)*?fi\n'
 
     def _assert_caught(self, mutant, why):
-        # No-op guard on EVERY mutation, not just the first. Without it a
-        # `str.replace` that silently matches nothing asserts on the UNMUTATED
-        # script, which is vacuously green whenever the gate is already dead
-        # (review of #404, F7).
+        # Backstop for the no-op-fixture class (review of #404, F7): a mutation
+        # that silently matched nothing asserts on the UNMUTATED script, which is
+        # vacuously green whenever the gate is already dead. The fixtures below
+        # build their mutants with `apply_mutation` / `apply_regex_mutation`,
+        # which raise AT THE POINT of the stale fixture with the pattern in the
+        # message; this stays because it also covers mutants assembled by other
+        # means — `test_gate_wrapped_in_an_unreachable_branch` appends text after
+        # replacing, so its result differs from the original even when the
+        # replacement misses, and only the helper can see that.
         self.assertNotEqual(
             mutant, self.script, "mutation did not apply — the test is vacuous: " + why
         )
@@ -711,30 +718,47 @@ class TestGateBehaviourDetector(unittest.TestCase):
         )
 
     def test_gate_deleted(self):
-        m = re.sub(self._GATE_RE, 'echo "::notice::$CRITS recorded"\n', self.script)
-        self.assertNotEqual(m, self.script, "mutation did not apply")
+        m = apply_regex_mutation(
+            self.script, self._GATE_RE, 'echo "::notice::$CRITS recorded"\n'
+        )
         self._assert_caught(m, "gate block removed")
 
     def test_gate_replaced_by_a_quoted_decoy(self):
-        m = re.sub(
+        m = apply_regex_mutation(
+            self.script,
             self._GATE_RE,
             """echo 'legacy: if [ "$CRITS" -gt 0 ]; then exit 1; fi'\n""",
-            self.script,
         )
         self._assert_caught(m, "gate replaced by a quoted mention of itself")
 
     def test_gate_wrapped_in_an_unreachable_branch(self):
-        m = self.script.replace(
-            'if [ "$CRITS" -gt 0 ]; then', 'if false; then\nif [ "$CRITS" -gt 0 ]; then'
+        # The one fixture here whose own result cannot prove it applied: the
+        # trailing `fi` makes the mutant differ from the original even if the
+        # replacement missed, so `_assert_caught`'s no-op guard is blind to it and
+        # a stale anchor would surface as a bash syntax error three asserts later.
+        # `apply_mutation` is what makes the miss legible.
+        m = apply_mutation(
+            self.script,
+            'if [ "$CRITS" -gt 0 ]; then',
+            'if false; then\nif [ "$CRITS" -gt 0 ]; then',
         ).rstrip() + "\nfi\n"
         self._assert_caught(m, "gate wrapped in `if false; then … fi`")
 
     def test_gate_bound_moved_out_of_reach(self):
-        m = self.script.replace('-gt 0 ]; then', '-gt 999999 ]; then')
-        self._assert_caught(m, "threshold raised beyond any real finding count")
+        # Anchored on `$CRITS` rather than the bare `-gt 0 ]; then`, which occurs
+        # TWICE (the `$HIGHS` warning branch too). The old fixture replaced both
+        # and read as if it had targeted the gate; raising the HIGHS threshold is
+        # not what this case is about, and an un-counted literal that matches two
+        # regions is the ambiguity `apply_regex_mutation` refuses outright.
+        m = apply_mutation(
+            self.script, 'if [ "$CRITS" -gt 0 ]; then', 'if [ "$CRITS" -gt 999999 ]; then'
+        )
+        self._assert_caught(m, "gate threshold raised beyond any real finding count")
 
     def test_exit_moved_into_a_dead_case_arm(self):
-        m = self.script.replace("  exit 1\n", '  case "${MODE:-run}" in never) exit 1 ;; esac\n')
+        m = apply_mutation(
+            self.script, "  exit 1\n", '  case "${MODE:-run}" in never) exit 1 ;; esac\n'
+        )
         self._assert_caught(m, "`exit 1` moved into an unreachable case arm")
 
     def test_escalating_high_to_a_merge_block_is_caught(self):
@@ -744,12 +768,10 @@ class TestGateBehaviourDetector(unittest.TestCase):
         MORE aggressive, not less. Without this the HIGH test would pass on a
         gate that had been quietly rewritten to block on HIGH, since it never
         proves the assertion can fail."""
-        m = self.script.replace(
+        m = apply_mutation(
+            self.script,
             'echo "::warning::$HIGHS high finding(s) detected"',
             'echo "::warning::$HIGHS high finding(s) detected"\n  exit 1',
-        )
-        self.assertNotEqual(
-            m, self.script, "mutation did not apply — the test is vacuous"
         )
         self.assertNotEqual(
             run_gate(m, _HIGH_FIXTURE).returncode,
@@ -795,22 +817,28 @@ class TestEmitterLinkageDetector(unittest.TestCase):
     # --- X9: the gate's pattern narrowed to a FIXTURE-only token -----------
     def test_gate_pattern_narrowed_to_a_fixture_only_token_is_caught(self):
         # `SEC-001` exists only in _CRITICAL_FIXTURE; the scanner never prints it.
-        m = re.sub(r"(CRITS=\$\(grep -ci ')[^']*(')", r"\1SEC-001\2", self.script)
+        m = apply_regex_mutation(
+            self.script, r"(CRITS=\$\(grep -ci ')[^']*(')", r"\1SEC-001\2"
+        )
         self._assert_caught(m, self.emitter, "gate narrowed to a token only the fixture contains")
 
     # --- X10: the shape survives only in a trailing COMMENT ----------------
     def test_emitter_shape_surviving_only_in_a_comment_is_caught(self):
-        m = self.emitter.replace(
-            '${color}✗ FAIL${NC}', '${color}NG${NC}', 1
-        ).replace(
+        # Two edits, each checked: `_assert_caught` below only asks whether the
+        # PAIR (script, emitter) changed, so a chained `.replace` where the first
+        # link missed and the second landed passed its vacuity check while
+        # testing something else entirely.
+        m = apply_mutation(self.emitter, '${color}✗ FAIL${NC}', '${color}NG${NC}')
+        m = apply_mutation(
+            m,
             '$title ${DIM}(${severity})${NC}"',
-            '$title ${DIM}(${severity})${NC}"   # was: ✗ FAIL', 1,
+            '$title ${DIM}(${severity})${NC}"   # was: ✗ FAIL',
         )
         self._assert_caught(self.script, m, "the `✗ FAIL` shape lives only in an inline comment")
 
     # --- F6, for real this time: the glyph is dropped ----------------------
     def test_emitter_dropping_the_glyph_is_caught(self):
-        m = self.emitter.replace('✗ FAIL', 'FAILED', 1)
+        m = apply_mutation(self.emitter, '✗ FAIL', 'FAILED')
         self._assert_caught(self.script, m, "the emitter dropped the `✗` the gate's pattern relies on")
 
 
@@ -964,10 +992,10 @@ class TestWorkflowLevelDisableDetector(unittest.TestCase):
 
     # --- X4: JOB-level continue-on-error ----------------------------------
     def test_job_level_continue_on_error_is_caught(self):
-        mutant = self.text.replace(
+        mutant = apply_mutation(
+            self.text,
             "  scan:\n    name: Run Security Scan\n",
             "  scan:\n    continue-on-error: true\n    name: Run Security Scan\n",
-            1,
         )
         self._assert_caught(
             mutant,


### PR DESCRIPTION
## What

`#415` added `apply_mutation` (after five probes in one audit failed the same way — the fixture did not change what it claimed to) and migrated six literal-replace fixtures, deliberately leaving the `re.sub`-based ones in `test_ci_security_gate_behaviour.py` alone rather than forcing a region-shaped mutation through a substring API.

That left the hole open: **`re.sub` no-ops on a miss exactly like `str.replace`**, so those fixtures had none of the protection.

`apply_regex_mutation` closes it with the same two mechanical checks (pattern must match; result must differ) plus one a literal target does not need:

> **More matches than `count` is an error.** With a substring you can eyeball where it occurs; with a pattern you cannot, and this repo has already executed a stranger's `run:` body because a greedy regex matched more than its author believed. `count=0` means "all" (`re.sub`'s own convention) and skips the check.

## Three fixtures were not merely unprotected

| Fixture | Defect |
|---|---|
| `test_gate_wrapped_in_an_unreachable_branch` | **Appends** `\nfi\n` after replacing, so the mutant differs from the original even when the replacement misses — `_assert_caught`'s F7 no-op guard is structurally blind to it. A stale anchor surfaced as `bash: syntax error near unexpected token 'fi'` (exit 2) three asserts downstream, reported as "the mutation was supposed to disable the gate but did not". |
| `test_gate_bound_moved_out_of_reach` | Anchored on the bare `-gt 0 ]; then`, which occurs **twice** (the `$HIGHS` warning branch as well as the gate). An un-counted `str.replace` rewrote both while the name and message claimed it targeted the gate. Re-anchored on `$CRITS` — this is the exact ambiguity the new helper refuses. |
| `test_emitter_shape_surviving_only_in_a_comment_is_caught` | Chained two `.replace(…, 1)` calls; its vacuity check asks only whether the `(script, emitter)` **pair** changed, so a first link that missed while the second landed passed while testing something else. Each edit is now checked separately. |

`_assert_caught`'s no-op guard **stays** — the helpers raise at the point of the mistake, but mutants assembled by other means (append-after-replace, `_insert_step_key`) still need the backstop. Its comment now says which layer covers what instead of implying `str.replace` is the only source.

## Verification

```console
$ CLAUDESEC_DASHBOARD_OFFLINE=1 python3 -m pytest scanner/ -q
1989 passed, 5 skipped in 10.16s

$ python3 -m unittest scanner.tests.test_ci_security_gate_behaviour scanner.tests.test__ci_guard_util
Ran 145 tests in 0.236s
OK
```

Stale-anchor failure induced **on disk** (`$CRITS` → `$CRITICALS`), measured, restored, re-run green:

```console
E  AssertionError: mutation fixture is stale: 'if [ "$CRITICALS" -gt 0 ]; then' not found
   in the target text — the file changed under the test, so this case proves nothing
   scanner/tests/_ci_guard_util.py:573
```

Dangling-`fi` claim also measured, not assumed: `bash` exits 2 on it.

- 8 new unit tests for the helper (miss / no-op / ambiguity / explicit count / `count=0` / flags / group refs).
- No `scanner/lib` change → coverage gates untouched. No new guard file → no catalog row needed (`_ci_guard_util.py` is `_`-prefixed and outside the `test_ci_*.py` glob).

🤖 Generated with [Claude Code](https://claude.com/claude-code)