### PR TITLE
docs(skills): promote the nine probe errors into a pre-flight checklist

### DIFF
--- a/.claude/skills/ci-config-guard-claudesec/SKILL.md
+++ b/.claude/skills/ci-config-guard-claudesec/SKILL.md
@@ -99,22 +99,170 @@ if __name__ == "__main__":
 
 ## Non-vacuous verification harness (no real files touched)
 
+Note `apply_mutation` rather than `orig.replace(...)`: a bare `str.replace` whose
+anchor has gone stale returns the input unchanged and the harness then reports
+"NOT non-vacuous" about a guard that is fine. See the probe checklist below.
+
 ```python
-import importlib.util, tempfile
+import importlib.util, sys, tempfile
 from pathlib import Path
-def load(p): 
-    s = importlib.util.spec_from_file_location("m", p); m = importlib.util.module_from_spec(s); s.loader.exec_module(m); return m
+sys.path.insert(0, "scanner/tests")
+from _ci_guard_util import apply_mutation
+
+def load(p):
+    s = importlib.util.spec_from_file_location("m", p)
+    m = importlib.util.module_from_spec(s); s.loader.exec_module(m); return m
+
 m = load("scanner/tests/test_ci_coverage_thresholds.py")
 orig = m.LINT_YML.read_text()
 tmp = tempfile.NamedTemporaryFile("w", suffix=".yml", delete=False)
-tmp.write(orig.replace("--cov-fail-under=99", "--cov-fail-under=80")); tmp.close()
+tmp.write(apply_mutation(orig, "--cov-fail-under=99", "--cov-fail-under=80")); tmp.close()
 m.LINT_YML = Path(tmp.name); m.TestCiCoverageThresholds.setUpClass()
 try:
     m.TestCiCoverageThresholds().test_python_cov_fail_under_present_and_not_lowered()
     print("NOT non-vacuous (bad)")
-except AssertionError:
-    print("OK: guard fails on mutation")
+except AssertionError as e:
+    print("OK: guard fails on mutation ->", str(e).splitlines()[0])
 ```
+
+```console
+$ python3 /tmp/harness.py
+OK: guard fails on mutation -> 80 not greater than or equal to 99 : Python
+coverage gate lowered to 80% (min allowed 99%). If intentional, update
+MIN_PYTHON_COV_FAIL_UNDER in this test and justify in the PR.
+```
+
+## Probe checklist — run this before you believe a "GAP"
+
+A **probe** is the throwaway mutation you apply to argue a guard is bypassable.
+Across #411 / #415 / #419 / #420 / #424 the probe was wrong **nine** times and
+the guard was right every one of them; each near-miss was about to file a false
+finding in the catalog or "fix" a correct guard. Probes are not scratch work —
+they are the evidence, and they get audited like the guard does.
+
+Work the items in order. Every one names the incident that earned it and how you
+would learn the **probe**, not the guard, is what is broken.
+
+1. **Reconcile the contradiction first — it is the signal in every one of these.**
+   A probe verdict of "bypass" that coexists with the guard suite reporting
+   `16 passed` is not a finding; it is two measurements that cannot both be true,
+   and one of them is yours. Stop and resolve which before writing anything down.
+   In #420 a probe handed **raw** text straight to the collector, got `None`, and
+   called it a bypass — while the same probe's own suite said `16 passed`. The
+   suite was right (the immunity was in `setUpClass`; item 5).
+   *Probe is wrong if:* you ran the collector but not the guard. Re-run the
+   guard's own tests against the same mutant; a green suite outranks a
+   hand-called helper, because the guard is what CI executes.
+
+2. **Attack the harness before the code.** Before concluding "gap", state the
+   runtime consequence of your mutant: which command now exits 0, which key the
+   runner now ignores, which arm is now unreachable. #411's provider-labels probe
+   moved a `case` arm to just **before** the `*)` catch-all, where it is still
+   perfectly reachable — nothing was disabled, so the guard's green was correct.
+   #415 produced five in one audit (arm-before-`*)`; a section **header** edited
+   instead of the entry beneath it; a `job_block` case written only for
+   end-of-file when the discriminating shape is a following top-level key;
+   `if: always()` deleted from a gate whose **comments** quote it verbatim, so
+   the repo's own comment-evasion class bit the fixture; text injected onto a
+   TestCase attribute that `setUpClass` overwrote from disk).
+   *Probe is wrong if:* you cannot name that consequence in one sentence, or the
+   sentence is "the guard stopped matching" — that describes the guard, not the
+   control.
+
+3. **A mutation the grammar rejects proves nothing.** An invalid document is not
+   a bypass: it never runs, so no control was removed. #424 planted a comment at
+   the key column inside a folded scalar and filed "3 false positives"; that
+   shape is a `ParserError`, and the verdict was void. Measure with PyYAML —
+   local ground truth only, never an `import yaml` in a guard (not in
+   `requirements-ci.txt`):
+
+   ```python
+   import yaml                                        # pyyaml 6.0.3, local only
+   yaml.safe_load("a:\n  x: 1\n# c\n  y: 2\n")        # {'a': {'x': 1, 'y': 2}}
+   yaml.safe_load("args: >-\n  --one\n  # c\n  --two\n")  # {'args': '--one # c --two'}
+   yaml.safe_load("steps:\n  - run: |\n      echo one\n# c\n      echo two\n")  # ParserError
+   ```
+
+   A comment ends **nothing** in a mapping (so it can hide keys from a collector
+   — a real class), it is **content** in a folded scalar (so pre-stripping
+   deletes a live CLI token), and a less-indented one in a block scalar is a
+   parse error (so it proves nothing).
+   *Probe is wrong if:* `yaml.safe_load(mutant)` raises. Discard the mutant and
+   find a valid one; do not file the finding.
+
+4. **Placement inside the block decides the verdict.** Put the mutation where an
+   author regrouping keys would — at the **END** of the block it terminates. The
+   same comment at the **start** of a job block truncates `steps:` away too,
+   trips assertions that have nothing to do with your invariant, and reads as
+   "caught" (#419).
+   *Probe is wrong if:* the failing assertion names something other than the
+   invariant you targeted. That is collateral damage read as detection — the
+   guard "caught" a broken document, not your bypass.
+
+5. **"No observable effect" is a measurement, not a conclusion — and the
+   immunity is often in the CALLER.** Never file it as a verdict: it explains
+   nothing, so the next audit re-investigates from zero and it is how a stale
+   "known fine" gets written. #420's collector *was* comment-blind; the guard was
+   immune because `setUpClass` builds `cls.text` with
+   `strip_comment_lines(cls.raw)` — one line, in the caller, that nothing
+   asserted. Check `setUpClass` and every wrapper between your entry point and
+   the assertion, then pin the reason where it lives.
+   *Probe is wrong if:* you cannot point at the line that provides the immunity.
+   Until you can, the verdict is unfinished, not clean.
+
+6. **Prove the harness can produce a RED before trusting a green**
+   (ADR-001 Decision 4). Run it against a case you *know* is broken first. The
+   #297 audit's first inertness measurement came back green across the board
+   because `unittest` re-ran `setUpClass`, which reloaded the real file over the
+   injected mutant — the measurement was wrong, not the finding (#415's shape 5
+   is the same bug in a fixture).
+   *Probe is wrong if:* your known-broken control also reports green. Then the
+   harness never reached the code, and every "clean" result it produced is void.
+
+7. **Never hand-roll the substitution — use the helpers, which raise at the
+   mistake site.** `str.replace` and `re.sub` both no-op silently on a stale
+   anchor (#415 for the literal form, #416 for the regex form). Verified
+   signatures in `scanner/tests/_ci_guard_util.py`:
+
+   ```python
+   apply_mutation(text, old, new, *, count=1) -> str
+   apply_regex_mutation(text, pattern, repl, *, count=1, flags=0) -> str
+   assert_disables(detector, clean_text, mutant_text, label="")  # -> mutant findings
+   ```
+
+   ```text
+   apply_mutation("a b c", "zzz", "q")
+     AssertionError: mutation fixture is stale: 'zzz' not found in the target
+     text — the file changed under the test, so this case proves nothing
+   apply_mutation("exit 1", "exit 1", "exit 1")
+     AssertionError: mutation 'exit 1' -> 'exit 1' left the text unchanged
+   apply_regex_mutation(two_occurrences, r"-gt 0 \]; then", "-gt 99 ]; then")
+     AssertionError: pattern '-gt 0 \\]; then' matched 2 times but count=1 —
+     refusing to guess which occurrence the fixture meant. Narrow the pattern,
+     or pass the count you intend (0 for all).
+   ```
+
+   `apply_regex_mutation` adds the check a literal cannot need — **more matches
+   than `count` is an error**, because you can eyeball where a substring occurs
+   and cannot eyeball a pattern (`-gt 0 ]; then` occurs twice in the gate;
+   a countless `str.replace` changed both while the test name claimed one).
+   `assert_disables` pins both directions at once, and its failure message states
+   the priority this checklist is built on:
+
+   ```console
+   AssertionError: detector did NOT fire on the mutant [probe] — either the guard
+   has a gap, or the mutation does not actually disable the control. Check the
+   SECOND possibility first (see apply_mutation).
+   ```
+
+   Two limits to state in the test rather than assume away: the helpers close
+   only the **mechanical** shapes (anchor missing, bytes unchanged) — item 2's
+   arm-before-`*)`, end-of-file-only and comment-quoting shapes are **semantic**
+   and no helper decides them. And a fixture that **appends** text after
+   substituting (`\nfi\n`) differs from the original even when the substitution
+   missed, so the differ check is structurally blind to it; #416's stale anchor
+   surfaced three steps later as `bash: syntax error near unexpected token 'fi'`.
+   Assert the anchor separately in that case.
 
 ## Parse/substring guards — the false-negative class
 
@@ -234,7 +382,7 @@ they follow the parser.
 **Placement decides a probe's verdict.** The same comment at the START of a job
 truncates `steps:` away too, trips unrelated assertions and reads as "caught" — a
 false negative in the probe, not the guard. Put it where an author regrouping keys
-would: at the END of the block it terminates.
+would: at the END of the block it terminates. (Probe checklist item 4.)
 
 **Re-run the existing mutation tests after fixing a shared primitive, before
 reviewing the diff.** Once comments live inside a block, every column derivation
@@ -248,7 +396,7 @@ smoke` was recorded that way and turned out IMMUNE — because `setUpClass` buil
 `cls.text` with `strip_comment_lines(cls.raw)`. The immunity was in the **caller**,
 one line, unasserted; the collector alone still truncates
 (`harness_step_block(RAW, …) -> None` vs `(STRIPPED, …) -> the step`). Find the
-reason, then pin it where it lives (#420).
+reason, then pin it where it lives (#420). (Probe checklist item 5.)
 
 ### The inert guard — check the HAYSTACK before the matcher
 
@@ -302,6 +450,7 @@ board** — the harness injected mutated text into the class attribute, but
 `unittest` re-ran `setUpClass`, which reloaded the real file. The measurement
 was wrong, not the finding. Before believing a "no problem here" result, prove
 the harness can produce a RED: run it against a case you *know* is broken.
+(Probe checklist item 6.)
 
 ### Adversarial pass — how to run it
 

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -862,9 +862,19 @@ it claimed to — and each nearly produced a "fix" to a guard that was correct:
 the result must differ, or it raises at the point of the mistake. **1, 3 and 4
 are semantic** — whether the edit disables the CONTROL, not whether it changed
 bytes — and no helper decides that; the docstring says so rather than implying
-coverage it does not have. Migrated the six literal-`replace` fixtures;
-`re.sub`-based ones in `test_ci_security_gate_behaviour.py` are left alone
-rather than forced into a substring API.
+coverage it does not have. Migrated the six literal-`replace` fixtures; the
+`re.sub`-based ones in `test_ci_security_gate_behaviour.py` were initially left
+alone rather than forced into a substring API, then migrated in **#416** once
+`apply_regex_mutation` gave them a region API with the extra check a literal
+does not need (more matches than `count` is an error, because a pattern cannot
+be eyeballed).
+
+The nine probe errors this class produced (#411, #415, #419, #420, #424) are
+written up as an ordered pre-flight checklist in the
+`ci-config-guard-claudesec` skill, under **"Probe checklist — run this before
+you believe a GAP"** — including the unifying signal: a probe claiming a bypass
+while the guard suite reports `16 passed` is a contradiction to resolve, not a
+finding to file.
 
 ### Verified already-guarded during this review (not backlog)
 


### PR DESCRIPTION
## Why

The probe-authoring lessons from the 2026-08 guard-audit cycle lived **only as retrospective prose**. Across #411 / #415 / #419 / #420 / #424 the **probe** was wrong nine times and the guard was right every one of them; each near-miss was about to file a false finding in the catalog or "fix" a correct guard. Prose does not run before the next probe. A checklist does.

Counted: #411 x1 (provider-labels `case` arm), #415 x5 (the five shapes that earned `apply_mutation`), #419 x1 (comment at the job-block **start**), #420 x1 (raw text -> `None`), #424 x1 (`ParserError` mutation).

## Where it goes, and why not a new skill

Extends `.claude/skills/ci-config-guard-claudesec/SKILL.md` (project-scoped, committable) with one new section, `## Probe checklist — run this before you believe a "GAP"`.

Evaluated in the order the task prescribes:

| Candidate | Verdict |
|---|---|
| `ci-config-guard-claudesec` | **chosen.** Probe authoring only happens inside guard authoring/auditing, and this skill already carried three of these lessons as scattered prose — "Placement decides a probe's verdict", "Never file 'no observable effect' as a verdict", "Distrust your own verification harness". Those three now back-reference the checklist item that owns them, so the two places cannot drift |
| `kcov-debug` | no — coverage-gate debugging, unrelated to mutation probes |
| global `~/.claude/skills/ci-config-guard/SKILL.md` | repo-agnostic split, and **not committed to this repo** — see "Belongs in the global skill" below. Not touched |
| a new project skill | rejected. An unnecessary skill is the same sprawl this repo rejected in #424 when it declined a mechanical "never pass raw text to an extractor" guard ("예외 목록이 발견보다 긴 가드는 sprawl"). Splitting "how to author a guard" from "how to prove it works" would put the falsifiers in a file the guard author is not reading |

## The checklist

Seven ordered items. Each is an action, cites the incident that earned it, and states how you would learn the **probe** — not the guard — is what is broken.

| # | Item | Earned by | Falsifier (*probe* is wrong if...) |
|---|---|---|---|
| 1 | **Reconcile the contradiction first** — "bypass" alongside `16 passed` is two measurements that cannot both be true | #420 | you ran the collector but not the guard; a green suite outranks a hand-called helper |
| 2 | **Attack the harness before the code** — name the runtime consequence of your mutant | #411, #415 (5 shapes) | you cannot name it in one sentence, or the sentence describes the guard rather than the control |
| 3 | **A mutation the grammar rejects proves nothing** | #424 | `yaml.safe_load(mutant)` raises — discard the mutant, do not file the finding |
| 4 | **Placement inside the block decides the verdict** — mutate at the END of the block it terminates | #419 | the failing assertion names something other than your invariant |
| 5 | **"No observable effect" is a measurement, not a conclusion — check the CALLER** | #420 | you cannot point at the line that provides the immunity |
| 6 | **Prove the harness can produce a RED before trusting a green** | ADR-001 Decision 4 (#297) | your known-broken control also reports green |
| 7 | **Never hand-roll the substitution** — use `apply_mutation` / `apply_regex_mutation` / `assert_disables` | #415 (literal), #416 (regex) | not needed — the helpers raise `AssertionError` at the mistake site |

Item 1 is deliberately first: the **contradiction** was the signal in all nine incidents, and it is the only item that catches the other six when they are skipped.

Item 7 points at the real API, read out of `scanner/tests/_ci_guard_util.py` and executed:

```text
apply_mutation(text, old, new, *, count=1) -> str
apply_regex_mutation(text, pattern, repl, *, count=1, flags=0) -> str
assert_disables(detector, clean_text, mutant_text, label="")  # -> mutant findings
```

It also records the two limits rather than assuming them away: the helpers close only the **mechanical** shapes (anchor missing, bytes unchanged) — item 2's arm-before-`*)`, end-of-file-only and comment-quoting shapes are **semantic** and no helper decides them — and a fixture that **appends** text after substituting (`\nfi\n`) defeats the differ check structurally (#416).

## Two contradictions found while writing it

1. **The skill contradicted its own new item 7.** Its "Non-vacuous verification harness" snippet built the mutant with a bare `orig.replace(...)` — precisely the silent-miss anti-pattern. Now uses `apply_mutation`, and carries the executed output:

   ```console
   OK: guard fails on mutation -> 80 not greater than or equal to 99 : Python
   coverage gate lowered to 80% (min allowed 99%). If intentional, update
   MIN_PYTHON_COV_FAIL_UNDER in this test and justify in the PR.
   ```

2. **The catalog was stale about the same helpers.** `### Mutation-fixture helpers (2026-08-10)` still said the `re.sub`-based fixtures in `test_ci_security_gate_behaviour.py` "are left alone rather than forced into a substring API". #416 migrated them:

   ```console
   $ grep -n "apply_regex_mutation" scanner/tests/test_ci_security_gate_behaviour.py
   75:    apply_regex_mutation,
   711:        # build their mutants with `apply_mutation` / `apply_regex_mutation`,
   726:        m = apply_regex_mutation(
   732:        m = apply_regex_mutation(
   757:        # regions is the ambiguity `apply_regex_mutation` refuses outright.
   825:        m = apply_regex_mutation(
   ```

   Corrected, and pointed at the new checklist — leaving it would have published two sources disagreeing about the same helpers, the section-3 document-rot class this cycle documented three times.

## Grammar measurements (item 3), executed

PyYAML is local ground truth only — never `import yaml` in a guard (not in `requirements-ci.txt`):

```console
$ python3 -c "import yaml; print(yaml.__version__)"
6.0.3
$ # mapping: a comment ends nothing
yaml.safe_load("a:\n  x: 1\n# c\n  y: 2\n")             -> {'a': {'x': 1, 'y': 2}}
$ # folded scalar: a '#' is CONTENT (pre-stripping deletes a live CLI token)
yaml.safe_load("args: >-\n  --one\n  # c\n  --two\n")   -> {'args': '--one # c --two'}
$ # block scalar: a less-indented '#' is a parse error — proves nothing
yaml.safe_load("steps:\n  - run: |\n      echo one\n# c\n      echo two\n") -> ParserError
```

## Helper failure messages (item 7), executed

```text
apply_mutation("a b c", "zzz", "q")
  AssertionError: mutation fixture is stale: 'zzz' not found in the target text
  — the file changed under the test, so this case proves nothing
apply_mutation("exit 1", "exit 1", "exit 1")
  AssertionError: mutation 'exit 1' -> 'exit 1' left the text unchanged
apply_regex_mutation(two_occurrences, r"-gt 0 \]; then", "-gt 99 ]; then")
  AssertionError: pattern '-gt 0 \\]; then' matched 2 times but count=1 —
  refusing to guess which occurrence the fixture meant. Narrow the pattern, or
  pass the count you intend (0 for all).
assert_disables(detector, "exit 1\n", "exit 1  # regrouped\n", label="probe")
  AssertionError: detector did NOT fire on the mutant [probe] — either the guard
  has a gap, or the mutation does not actually disable the control. Check the
  SECOND possibility first (see apply_mutation).
```

That last message is the checklist's thesis, already shipped in the helper: **check the probe first.**

## Belongs in the global skill, not this PR

Anything under `~/.claude/` is not committed here, so it is **out of scope for this PR** and was left untouched. Four of the seven items are repo-agnostic and would improve `~/.claude/skills/ci-config-guard/SKILL.md` (which today has no probe section at all): item 1 (the contradiction heuristic), item 2 (attack the harness), item 3 (a grammar-rejected mutation proves nothing) and item 6 (prove a RED first). Items 4, 5 and 7 are ClaudeSec-specific — they name `_ci_guard_util`, `setUpClass` and this repo's block-collector conventions — and belong here.

## No catalog row / meta-guard row needed

`test_ci_catalog_completeness.py` requires a row per `scanner/tests/test_ci_*.py` **guard file**, and `test_ci_catalog_no_ghost_rows.py` requires every cited path to exist. This PR adds no guard file and cites no new path, so neither needs a row — confirmed by running both. `.claude-plugin/marketplace.json` lists only the five published **CLI** skills (`scan` / `prowler` / `compliance` / `dashboard` / `setup`), which an authoring skill is not.

## Verification

Docs-only diff (`git diff --name-only` -> the two `.md` files, no `.py`).

```console
$ markdownlint "**/*.md"
markdownlint exit=0
```

CI's `markdown-lint` job excludes `.claude/**` (`globs: **/*.md` plus `!.claude/**`), so the skill file would not be linted there — linted on its own as well, clean:

```console
$ markdownlint ".claude/skills/ci-config-guard-claudesec/SKILL.md"
(no output)
```

```console
$ lychee ".claude/skills/ci-config-guard-claudesec/SKILL.md" "docs/devsecops/ci-config-regression-guards.md"
5 Total (in 1s 186ms) 5 Unique 3 OK 0 Errors 2 Excluded
```

Whole-repo `lychee "**/*.md"` reports **4 pre-existing** failures, all in files this PR does not touch — `https://www.sans.org/white-papers/33901` 403 x2 in `docs/guides/incident-response.md`, `https://github.com/Twodragon0/claudesec/stargazers` 404 x2 in `README.md`. CI passes them via `--accept '100..=599'`.

```console
$ CLAUDESEC_DASHBOARD_OFFLINE=1 python3 -m pytest scanner/ -q
2076 passed, 5 skipped in 11.60s
```

**Deviation from the stated 2062/5 baseline, explained:** +14 is #427 (`30f1301`), which was already on `main` when this branch was cut; its own PR body records 2076 passed / 5 skipped. This diff adds no tests (docs-only), so it cannot move the count.

```console
$ python3 -m unittest scanner.tests.test_ci_catalog_completeness scanner.tests.test_ci_catalog_no_ghost_rows
Ran 18 tests in 0.002s

OK
```

## References

- ADR-001 Decision 4 — mutation self-test / prove the harness can produce a RED
- ADR-001 Decision 9 corollaries — "Placement decides a probe's verdict"; "'No observable effect' is not a verdict"
- `docs/reports/guard-audit-cycle-2026-08-retrospective.md` section 2.5 ("프로브가 세 번 더 틀렸다"), section 3 ("하네스를 먼저 공격하라"), section 4
- OWASP Top 10 CI/CD — CICD-SEC-1 (Insufficient Flow Control)
- NIST SP 800-218 (SSDF) — PO.3 / PW.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)
