### PR TITLE
docs(ci): annotate every verdict-suppressing site, and the three that matter

### DIFF
--- a/.github/workflows/dast-baseline.yml
+++ b/.github/workflows/dast-baseline.yml
@@ -44,6 +44,15 @@ jobs:
         run: chmod -R a+w .
 
       - name: ZAP Baseline Scan
+        # VERDICT SUPPRESSED — WHAT IT HIDES: three layers, all non-blocking.
+        # `continue-on-error` swallows the step's status; `fail_action: false` stops
+        # ZAP itself from exiting non-zero on findings; `allow_issue_writing: false`
+        # stops it filing an issue. Net effect: DAST findings are recorded ONLY in
+        # the uploaded `zap-baseline-results` artifact, which nothing reads
+        # automatically — an alert appearing here notifies no one, and a scan that
+        # fails to run at all is indistinguishable from a clean scan.
+        # Deliberate (this is a non-required advisory job on a local container),
+        # but it means the DAST verdict is human-review-only.
         uses: zaproxy/action-baseline@de8ad967d3548d44ef623df22cf95c3b0baf8b25  # v0.15.0
         continue-on-error: true
         with:

--- a/.github/workflows/dast-full-scan.yml
+++ b/.github/workflows/dast-full-scan.yml
@@ -152,6 +152,14 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: ZAP Full Scan
+        # VERDICT SUPPRESSED — WHAT IT HIDES: `continue-on-error` stops a ZAP
+        # non-zero exit from failing the job. Unlike dast-baseline.yml this one is
+        # COMPENSATED: the status is preserved as `steps.zap.outcome` and re-raised
+        # by "Notify on Critical Findings" (`if: steps.zap.outcome == 'failure'`)
+        # below, so findings still reach a human. What remains lost is the
+        # distinction between "ZAP found something" and "ZAP could not run" — both
+        # surface as `outcome == 'failure'` and produce the same notification.
+        # If that notify step is ever removed, this becomes a silent suppression.
         uses: zaproxy/action-full-scan@3c58388149901b9a03b7718852c5ba889646c27c  # v0.13.0
         id: zap
         continue-on-error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -172,6 +172,13 @@ jobs:
       - name: Run pip-audit
         # CVE-2026-4539: pygments <=2.19.2 local ReDoS — no fix available yet
         # CVE-2026-3219: pip 26.0.1 tar+ZIP confusion — no fix version published yet
+        #
+        # VERDICT SUPPRESSED — WHAT EACH `--ignore-vuln` HIDES: exactly those two
+        # CVEs, and it keeps hiding them SILENTLY once a fix ships — pip-audit does
+        # not warn that an ignore has become unnecessary. So each entry is an
+        # un-expiring exemption on the REQUIRED `Lint` check. Re-check both at the
+        # quarterly guard audit and delete the flag once a fix version exists;
+        # the note above records why each was added, not that it is still needed.
         run: pip-audit --strict --desc --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-3219
 
   shell-lint:
@@ -188,6 +195,13 @@ jobs:
           SHELLCHECK_OPTS: -x
         with:
           version: v0.11.0
+          # VERDICT NARROWED — WHAT IT HIDES: `severity: error` means shellcheck
+          # `warning`/`info`/`style` findings do NOT fail this job (e.g. SC2086
+          # unquoted expansion is a *warning*), and `ignore_paths` below means no
+          # `.sh` under those directories is linted at all — `templates/` and
+          # `examples/` ship shell to users unchecked. shell-lint is in
+          # `lint-gate`'s `needs:`, so both narrowings ride the REQUIRED `Lint`.
+          # Widening either is a deliberate decision, not a cleanup.
           severity: error
           scandir: '.'
           ignore_paths: >-
@@ -282,6 +296,14 @@ jobs:
         run: |
           python3 -m py_compile scanner/lib/dashboard-gen.py scanner/lib/compliance-map.py scanner/lib/prowler_compliance_summary.py scanner/tests/test_dashboard_gen_smoke.py scanner/tests/test_markdown_preview.py scanner/tests/test_prowler_ocsf.py scanner/tests/test_prowler_ocsf_e2e.py scanner/tests/test_compliance_map.py scanner/tests/test_prowler_compliance_summary.py
           mkdir -p test-reports
+          # VERDICT DEFERRED (not suppressed) — `set +e` + `exit 0` below make this
+          # step green even when pytest fails, ON PURPOSE: the report/artifact/
+          # Codecov steps that follow need `if: always()` to be reachable, and the
+          # real exit code is exported as `test_exit_code` and re-raised by "Fail
+          # workflow on scanner unittest / coverage failure". The re-raise fails
+          # CLOSED (an unset output is `!= '0'`), so a lost GITHUB_OUTPUT write
+          # still blocks. What would be silently lost: deleting that final step,
+          # which is the ONLY thing turning pytest + the 99% floor into a verdict.
           set +e
           python3 -m pytest scanner/tests/ \
             --junitxml=test-reports/pytest-junit.xml \
@@ -298,6 +320,14 @@ jobs:
         uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16  # v6.4.2
         with:
           report_paths: 'test-reports/*.xml'
+          # VERDICT SUPPRESSED — WHAT IT HIDES: `fail_on_failure: false` means a
+          # red test in the junit XML does not fail this step, and
+          # `require_tests: false` means a run that collected ZERO tests (or wrote
+          # no XML at all) also reads green. Both are intentional: this step is a
+          # REPORTER, and the actual verdict is re-raised from the captured exit
+          # code by "Fail workflow on scanner unittest / coverage failure" below.
+          # That step is the only thing enforcing pytest + the 99% floor here — if
+          # it is ever deleted, this job goes green on every test failure.
           fail_on_failure: false
           require_tests: false
       - name: Upload scanner unittest + coverage artifacts
@@ -310,6 +340,12 @@ jobs:
           if-no-files-found: ignore
       - name: Upload coverage to Codecov
         if: always()
+        # VERDICT SUPPRESSED — WHAT IT HIDES: `continue-on-error` +
+        # `fail_ci_if_error: false` mean an upload failure (Codecov outage, missing
+        # or expired CODECOV_TOKEN, rate-limit) is invisible. What is lost is only
+        # REPORTING: the badge and the Codecov diff go stale silently. No gate is
+        # lost — the 99% floor is enforced locally by `--cov-fail-under=99` above,
+        # not by Codecov. Deliberate: a third-party outage must not block merges.
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         continue-on-error: true
         with:
@@ -415,6 +451,30 @@ jobs:
           # regression in 30s instead of 120s. Exit 124 (cap hit) is treated as
           # a warning so the remaining tests still run and we still get a
           # coverage merge; normal kcov exit codes are preserved.
+          #
+          # VERDICT SUPPRESSED HERE — WHAT IT HIDES (audit 2026-08-12):
+          # every non-zero rc below becomes a log line, so THIS STEP CANNOT FAIL
+          # on a failing shell test. Two distinct losses, both measured:
+          #   1. rc=124 (cap hit): a test pushed onto the 30s cap surfaces only as
+          #      `elapsed=30s rc=124` inside a green job. That is how #431's
+          #      watchdog bug read green.
+          #   2. rc!=0 and !=124 (ASSERTION FAILURE): swallowed by the plain
+          #      `echo WARN:` below — not even a ::warning:: annotation. This
+          #      matters because the `scanner-unit-tests` job's shell-test list is
+          #      EXPLICIT and does not auto-discover: 20 of the 54
+          #      `scanner/tests/test_*.sh` files are named in NO workflow and are
+          #      reached only by this glob. For those 20, this loop is the only
+          #      thing that runs them, and it cannot fail — so they gate nothing.
+          #      Measured by running this step body verbatim with a real SUT
+          #      regression (output.sh `_score_to_grade` C boundary 70->75):
+          #      `test_print_summary_score_to_grade.sh` exits 1, this step exits 0,
+          #      and `lint-gate` ("Lint", a REQUIRED check that lists
+          #      scanner-shell-coverage in `needs:`) reads success.
+          #      The kcov coverage floor does NOT compensate: an assertion that
+          #      fails still executes its lines, so `percent_covered` is unchanged.
+          # Registering a test in the `scanner-unit-tests` list is what makes it
+          # gate. Adding it here only buys coverage. Do not read a green
+          # scanner-shell-coverage as "the shell tests passed".
           chmod +x scanner/tests/test_*.sh
           # GitHub Actions sets `bash -eo pipefail` by default, so any non-zero
           # exit from `timeout 30 kcov ...` (e.g., 124 on cap-hit) would abort
@@ -456,6 +516,10 @@ jobs:
             if [ "$rc" -eq 124 ]; then
               echo "::warning::kcov $name TIMED OUT after ${elapsed}s (>=30s cap)"
             elif [ "$rc" -ne 0 ]; then
+              # HIDES: a genuine assertion failure. Plain text, not ::warning::,
+              # so it does not even raise an annotation on the run. See the
+              # "VERDICT SUPPRESSED HERE" note above for the 20 tests this is the
+              # only runner of.
               echo "WARN: $sh exited non-zero under kcov (rc=$rc, ${elapsed}s)"
             fi
             echo "kcov $name elapsed=${elapsed}s rc=${rc}"
@@ -477,6 +541,11 @@ jobs:
             pct=$(python3 -c "import json,sys; d=json.load(open(sys.argv[1])); print(d.get('percent_covered','?'))" "$cov_json")
             echo "Bash coverage (merged): ${pct}%"
           else
+            # HIDES nothing that matters: this step is a PRINTER. The identical
+            # find-based discovery is repeated in "Enforce bash coverage threshold"
+            # below, where a missing coverage.json is `::error::` + `exit 1`. If
+            # that duplicate discovery is ever refactored away into this step, the
+            # warn here becomes the whole verdict and the floor stops being enforced.
             echo "WARN: no coverage.json found under kcov-out/"
             echo "Contents of kcov-out/merged/ (top two levels):"
             find kcov-out/merged -maxdepth 2 -print 2>/dev/null || true
@@ -797,6 +866,21 @@ jobs:
           # Exclude allowlist lives in lychee.toml (single source of truth,
           # guarded by scanner/tests/test_ci_lychee_config.py) so it cannot
           # drift from a second inline copy. Only operational flags stay here.
+          #
+          # VERDICT SUPPRESSED BY `--accept '100..=599'` — WHAT IT HIDES:
+          # every HTTP status from 100 to 599 counts as OK, so this job fails
+          # only on a link that does not RESOLVE at all (DNS/TLS/timeout). Dead
+          # links pass. Measured against a local 404 (lychee 0.24.2):
+          #   no --accept          -> `[404] ... Rejected status code`, exit 2
+          #   --accept '100..=599' -> `2 Total  2 OK  0 Errors`, exit 0
+          # `fail: true` below therefore never fires for link ROT, and because
+          # `link-check` is in `lint-gate`'s `needs:`, a 404 ships green through
+          # the REQUIRED `Lint` check. This is deliberate: PR-time link checking
+          # must not fail on someone else's transient 5xx. The compensating
+          # control is the MONTHLY sweep in lychee-redirect-sweep.yml, which runs
+          # the same lychee/lychee.toml with the strict `--accept '200..=299'`
+          # and opens a self-healing issue (#298). If that sweep is ever removed
+          # or goes dark, link rot has NO detector anywhere in CI.
           args: >-
             --config lychee.toml
             --no-progress

--- a/.github/workflows/provenance-verify.yml
+++ b/.github/workflows/provenance-verify.yml
@@ -83,6 +83,23 @@ jobs:
           npm init -y >/dev/null 2>&1
 
           # Transient install/network failure -> no-op (don't cry wolf).
+          #
+          # VERDICT SUPPRESSED HERE — WHAT IT HIDES (audit 2026-08-12): this branch
+          # exits 0 having verified NOTHING, and `status=transient` has no consumer
+          # anywhere in this workflow (the only readers are the two
+          # `status == 'failed'` steps below). So a PERSISTENT install failure —
+          # package unpublished or renamed, registry blocking the runner, a bad
+          # `npm@>=11.5.1` upgrade, an npm-side auth change — makes this monitor
+          # report green forever while never once checking a signature. Nothing
+          # opens an issue, nothing writes a summary, nothing degrades.
+          # This is exactly the dark-workflow class of #396/#397, and the sibling
+          # notifier protection-drift-watch.yml was FIXED for it: its no-op branch
+          # opens a self-healing `protection-drift` issue precisely because "a green
+          # check for work that never happened is worse than no check"
+          # (protection-drift-watch.yml:19-31 — the standing example).
+          # Distinguishing transient from persistent needs state this workflow does
+          # not keep. The cheap fix is the sibling's, i.e. make the no-op branch
+          # visible rather than silent. Not changed here, annotation-only PR.
           if ! npm install claudesec@latest --no-audit --no-fund > install.log 2>&1; then
             echo "::warning::Could not install claudesec@latest (transient?). Skipping."
             cat install.log || true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -164,11 +164,35 @@ jobs:
           name: security-dashboard
           path: "${{ github.workspace }}/claudesec-dashboard.html"
           retention-days: 30
+          # VERDICT SUPPRESSED — WHAT IT HIDES: if the dashboard was never written,
+          # this step warns instead of failing. The loss is deferred, not avoided:
+          # the downstream `lighthouse` job then fails on the missing artifact
+          # instead, so the signal survives but points at the wrong job. `warn`
+          # (not `error`) is kept because `lighthouse` is the better place to fail.
           if-no-files-found: warn
 
       # Gate: count critical/high findings from scan output.
       # Any CRITICAL finding FAILS the build (blocks merge via the Security Scan
       # Gate required check); HIGH findings are surfaced as warnings only.
+      #
+      # VERDICT SUPPRESSED HERE — WHAT IT HIDES (audit 2026-08-12). This gate has
+      # NO positive control on its own input: it cannot tell "zero criticals" from
+      # "no parseable scan output", and every indistinguishable case reads GREEN on
+      # the REQUIRED `Security Scan Gate`. Measured by running this step body
+      # verbatim under `bash -eo pipefail`:
+      #   scan-output.txt missing -> `Critical: , High: ` + `[: : integer
+      #     expression expected` TWICE, step exit 0. The `[` errors are non-fatal
+      #     because they sit in an `if` CONDITION, where `set -e` does not apply.
+      #   scan-output.txt empty   -> `Critical: 0, High: 0`, step exit 0.
+      #   glyph/wording drift     -> `[X] Critical severity: ...` scores 0, exit 0.
+      #   one real CRITICAL       -> exit 1 (the gate does work on its happy path).
+      # So a scanner that silently stops emitting findings, or renames `✗`, or
+      # writes to stderr instead of stdout, disarms the only merge-blocking
+      # severity gate in the repo without turning anything red. Same class as
+      # #396/#397 (a no-op job reads green).
+      # `|| true` on both greps is REQUIRED (grep exits 1 on zero matches) and is
+      # not itself the defect — the absent non-empty-input assertion is.
+      # HIGH findings are warn-only by design (see ::warning:: below).
       - name: Check for critical/high failures
         run: |
           CRITS=$(grep -ci '✗.*critical\|CRITICAL.*Fail' scan-output.txt || true)
@@ -176,6 +200,10 @@ jobs:
           echo "Critical: $CRITS, High: $HIGHS"
           echo "::notice::Security scan completed — Critical: $CRITS, High: $HIGHS"
           if [ "$HIGHS" -gt 0 ]; then
+            # HIDES: every HIGH-severity finding. Only CRITICAL blocks a merge, so
+            # an unbounded number of HIGHs ships green on the required check.
+            # Deliberate, because scanner HIGHs include advisory checks. The only
+            # record of them is this annotation plus scan-output.txt in the run log.
             echo "::warning::$HIGHS high finding(s) detected"
           fi
           if [ "$CRITS" -gt 0 ]; then
@@ -226,6 +254,11 @@ jobs:
           echo "Performance: $PERF, Accessibility: $A11Y"
 
           if [ "$PERF" -lt 90 ] || [ "$A11Y" -lt 90 ]; then
+            # HIDES: a Performance/Accessibility regression on the freshly-built
+            # dashboard. Warn-only ON PURPOSE, because a single Lighthouse run is
+            # noisy. The hard >= 0.90 gate lives in lighthouse.yml on deployed Pages.
+            # What is genuinely lost: a regression that only reproduces on the
+            # PR-built artifact and not on the deployed site has no blocking gate.
             echo "::warning::Dashboard quality below threshold (Perf=$PERF, A11y=$A11Y)"
           fi
 


### PR DESCRIPTION
## What this is

First execution of the checklist rule PR #435 registered in
`.github/workflows/guard-audit-reminder.yml`:

> **Enumerate every place CI converts a failure into a warning; state per site what is lost.** Violation = a verdict-suppressing site with no comment saying what it hides.

**Comment-only. No behaviour change, no gate altered, no `.sh` touched.** 151 insertions, 0 deletions. Both probes were re-run against the edited files and produce identical results (`STEP_EXIT=0`; gate cases A–E unchanged).

## Population, re-derived at `b382641`

#435 pinned 42 hits at `21edb45` and said to classify rather than count. Reproduced exactly, and here is why counting fails: at `b382641` the same grep gives **43 lines but 46 matches** — the one added line is #435's own checklist text, which alone contributes 4 matches.

| step | number |
|---|---|
| broad sweep, 24 alternatives, deliberately over-broad | **184 lines** |
| subtracted by stated rule (prose, GHA/JS boolean-or, fatal-tailed fallback chains, aggregator `success`/`skipped` maps, trigger scoping) | 105 |
| hand-certified non-suppressing residual | 7 |
| **enumerator population** | **72 sites** |

## Enumerator recall — measured, not asserted

E1 (first enumerator) found 53 sites = **73.6% recall** against E2's 72. Each miss was a defect class, and three hid a site on #435's *own* known-suppressor list:

| defect | what it hid |
|---|---|
| **D1** `\|\| true` anchored to end-of-line | `x=$(cmd \|\| true)` invisible — 11 lines incl. the CRITICAL-gate greps |
| **D2** warn detection keyed on `::warning::` only | plain `echo "WARN:"` invisible — **that is finding (c1)** |
| **D3** widening flags sought in `run:` bodies only | `--accept '100..=599'` in the lychee action's `with: args:` block scalar |
| **D4** widening-input allowlist incomplete | `ignore_paths`, `severity` |

A **ninth shape is invisible to any text pattern** and was found only by executing the gate: a `[` test that errors inside an `if` **condition**, where `set -e` does not apply. Text recall for shapes is **8/9**.

## Category (c) — live suppressions, each driven through the real gate

**c1 — `lint.yml` kcov loop cannot fail (required `Lint` closure).** `|| rc=$?` plus a warn-only rc branch. **20 of 54** `scanner/tests/test_*.sh` are named in **no** workflow and reached only by this glob, so nothing gates them. No registration-completeness guard exists. Executed with a real SUT regression (`output.sh` `_score_to_grade` C boundary 70→75):

```
0) BASELINE, unmutated sandbox: === Results: 13 passed, 0 failed ===
1) mutated test's own verdict:  FAIL: score 70 → C YELLOW   test exit=1
2) same regression through the VERBATIM kcov step body:
   WARN: ...test_print_summary_score_to_grade.sh exited non-zero under kcov (rc=1, 1s)
   STEP_EXIT=0   <-- GREEN
```

Four-row score table (per-assertion, probe item 8):

| kcov step body | fixture | STEP_EXIT | verdict |
|---|---|---|---|
| real (`\|\| rc=$?` present) | exit 0 | 0 | green, correct |
| real | exit 1 | **0** | **GREEN — the suppression** |
| mutant (`\|\| rc=$?` removed) | exit 1 | 1 | RED — names the immunity |
| registered path `run: bash t.sh` | exit 1 | 1 | RED — how the other 34 run |

The kcov floor does **not** compensate: a failing assertion still executes its lines.

**c2 — `security-scan.yml` CRITICAL gate has no positive control on its input (required `Security Scan Gate`).** Executed under `bash -eo pipefail`:

| case | STEP_EXIT | verdict |
|---|---|---|
| missing `scan-output.txt` | 0 | **PASSES** — prints `Critical: , High: ` and `[: : integer expression expected` **twice** |
| empty `scan-output.txt` | 0 | **PASSES** (`Critical: 0, High: 0`) |
| one real CRITICAL | 1 | BLOCKS *(positive control)* |
| one HIGH | 0 | PASSES (deliberate) |
| glyph/wording drift | 0 | **PASSES** |

Both `[` tests sit in `if` **conditions**, so their error is non-fatal. `|| true` on the greps is *required* (grep exits 1 on zero matches) and is not the defect — the absent non-empty-input assertion is.

**c3 — `provenance-verify.yml` transient branch is terminal-silent.** Exits 0 having verified nothing, and `status=transient` has **no consumer** (only two `== 'failed'` readers). A persistent install failure reports green forever. Same class as #396/#397, which the sibling `protection-drift-watch.yml` was explicitly fixed for.

Also proven by execution (category b): `--accept '100..=599'` turns a 404 from `exit 2` into `exit 0` (lychee 0.24.2, local 404 source), so link rot ships green through the required `Lint`.

## My probes were wrong twice before they were right

Recorded in the probe scripts, per the checklist's own warning:

- Control B removed `|| rc=$?` but left a dangling line continuation → `syntax error near unexpected token 'done'`. A mutant the grammar rejects proves nothing (probe item 3).
- The real-SUT probe used `open(p,'w').write(apply_mutation(...))`. Python evaluates `open(p,'w')` **before** the raising argument, so a stale anchor **truncated the SUT** — 13/13 assertions failed including a line-count one, i.e. the failures named something other than the target (probe item 4). `apply_mutation` raised correctly; the harness ignored it.

Annotating also tripped `test_ci_security_gate_behaviour.py` (**10 failed**): it *executes* the extracted gate body behind a command allowlist, splits statements on `;`, and skips only statements that **begin** with `#` — so a `;` inside my comment read as the command `the`. That extractor is deliberately over-reporting by design, so **the wording was fixed, not the guard**.

## Scope decision: path-gating is NOT folded in

The mechanism differs — a suppression converts an **observed** failure; gating means nothing was observed and the aggregator maps `skipped` to success. The repo already controls it separately (`test_ci_pr_trigger_scope.py`, the `changes` + `always()` convention, the #186 `paths-ignore` rule), and the **fixes** are different: re-raise a status vs. assert the work happened. One shared consequence class (#396/#397) is noted at the boundary site (`dast-full-scan`'s `coverage-notice`).

## Explicitly NOT in this PR

No behavioural fix is bundled. c1/c2/c3 each need their own PR, and I did not want to ship a half-change:

- **c1**: either register the 20 tests in `scanner-unit-tests`, or make the kcov loop accumulate a failure count and exit non-zero (plus a registration-completeness guard).
- **c2**: assert `scan-output.txt` is non-empty and that the gate's patterns matched *something*, before trusting a 0 count.
- **c3**: give the transient branch the sibling's self-healing issue.

Also reported, not fixed: `lint.yml`'s re-raise step prints *"coverage below 90%"* while that gate is `--cov-fail-under=99` — a misleading number in a verdict message.

## Verification

```
CLAUDESEC_DASHBOARD_OFFLINE=1 python3 -m pytest scanner/ -q
  baseline b382641 clean tree : 2090 passed, 5 skipped
  this branch                 : 2090 passed, 5 skipped

pytest scanner/tests/test_ci_*.py test__ci_guard_util.py -q  : 824 passed
python3 -m unittest (10 workflow-sweeping guards, dual-runner): Ran 194 tests OK
markdownlint "**/*.md"  : clean (exit 0)
PyYAML parse, all 5 edited workflows : OK
git diff --stat : 5 files, 151 insertions(+), 0 deletions
```

No `.sh` touched, so `shellcheck` has no new surface (0.11.0 available, tree unchanged).

Reference: OWASP CICD-SEC-1 (Insufficient Flow Control); NIST SSDF (SP 800-218) PO.3/PW.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
