### PR TITLE
fix(guards): 58% of what the ADR guards scanned belonged to another branch

### DIFF
--- a/scanner/tests/test_ci_adr_citation_spelling.py
+++ b/scanner/tests/test_ci_adr_citation_spelling.py
@@ -191,9 +191,9 @@ the guards is part of the configuration; NIST SP 800-218 (SSDF) PO.3, PW.4.
 
 import re
 import sys
+import tempfile
 import unittest
 from fnmatch import fnmatch
-from glob import glob
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -202,7 +202,12 @@ from _ci_guard_util import (  # noqa: E402
     apply_mutation,
     assert_disables,
 )
-from test_ci_adr_decision_numbering import ADR_REL, _CITED_GLOBS  # noqa: E402
+from test_ci_adr_decision_numbering import (  # noqa: E402
+    ADR_REL,
+    _CITED_GLOBS,
+    cited_paths,
+    in_nested_checkout,
+)
 
 THIS_REL = "scanner/tests/test_ci_adr_citation_spelling.py"
 
@@ -428,13 +433,14 @@ def spelling_findings(text: str, relpath: str) -> list:
 
 
 def scanned_files() -> list:
-    """`(relpath, text)` for every file the numbering guard's citation scan reads,
-    sorted and de-duplicated (the globs overlap: `*.md` and `docs/**/*.md`)."""
-    paths = set()
-    for pattern in _CITED_GLOBS:
-        paths.update(glob(str(REPO_ROOT / pattern), recursive=True))
+    """`(relpath, text)` for every file the numbering guard's citation scan reads.
+
+    Enumeration lives in `cited_paths()` (sorted, de-duplicated — the globs
+    overlap: `*.md` and `docs/**/*.md` — and with nested checkouts excluded).
+    This guard must police exactly that population, so it must not re-derive it.
+    """
     out = []
-    for path in sorted(paths):
+    for path in cited_paths():
         p = Path(path)
         try:
             out.append((str(p.relative_to(REPO_ROOT)), p.read_text(encoding="utf-8")))
@@ -1041,6 +1047,73 @@ class TestScopeIsSharedWithTheNumberingGuard(unittest.TestCase):
 
         self.assertIs(_CITED_GLOBS, numbering._CITED_GLOBS)
         self.assertTrue(_CITED_GLOBS, "the shared glob tuple is empty")
+
+    def test_path_enumeration_comes_from_the_numbering_guard(self):
+        # Sharing the glob tuple alone was NOT enough: each guard ran its own
+        # `glob()` loop, so the nested-checkout exclusion could be added to one
+        # and silently miss the other. Both now enumerate through one function.
+        import test_ci_adr_decision_numbering as numbering
+
+        self.assertIs(cited_paths, numbering.cited_paths)
+        self.assertEqual([rel for rel, _ in scanned_files()],
+                         [str(Path(p).relative_to(REPO_ROOT)) for p in cited_paths()])
+
+
+class TestNestedCheckoutExclusion(unittest.TestCase):
+    """`.claude/worktrees/<id>/` holds gitignored checkouts of OTHER branches.
+
+    Scanning them made both ADR guards report citation errors for files the
+    current commit does not contain — a failure reproducible only on a developer
+    machine, since a CI checkout has no worktrees. These tests build the shape in
+    a tmpdir rather than in the repo, so they assert the same thing whether or
+    not the developer running them happens to have worktrees checked out.
+    """
+
+    def _tree(self, tmp):
+        root = Path(tmp)
+        (root / "docs").mkdir()
+        (root / "docs" / "own.md").write_text("x", encoding="utf-8")
+        nested = root / ".claude" / "worktrees" / "agent-deadbeef"
+        (nested / "docs").mkdir(parents=True)
+        (nested / "docs" / "other.md").write_text("x", encoding="utf-8")
+        return root, nested
+
+    def test_worktree_gitdir_file_is_detected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, nested = self._tree(tmp)
+            # A LINKED worktree marks its root with a `.git` FILE, not a dir.
+            (nested / ".git").write_text("gitdir: /elsewhere\n", encoding="utf-8")
+            self.assertTrue(in_nested_checkout(nested / "docs" / "other.md", root))
+            self.assertFalse(in_nested_checkout(root / "docs" / "own.md", root))
+
+    def test_vendored_clone_gitdir_directory_is_detected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root, nested = self._tree(tmp)
+            (nested / ".git").mkdir()
+            self.assertTrue(in_nested_checkout(nested / "docs" / "other.md", root))
+
+    def test_repo_own_dot_git_does_not_exclude_everything(self):
+        # The walk must STOP at root: if it inspected root/.git the predicate
+        # would be true for every file and the scan would silently go empty —
+        # a vacuous guard that reads green.
+        with tempfile.TemporaryDirectory() as tmp:
+            root, _ = self._tree(tmp)
+            (root / ".git").mkdir()
+            self.assertFalse(in_nested_checkout(root / "docs" / "own.md", root))
+
+    def test_unmarked_nested_directory_is_still_scanned(self):
+        # Only a real checkout is excluded. A plain subdirectory that merely
+        # lives under .claude/ must stay in the population, or the exclusion
+        # would be a hole a doc could hide in.
+        with tempfile.TemporaryDirectory() as tmp:
+            root, nested = self._tree(tmp)
+            self.assertFalse(in_nested_checkout(nested / "docs" / "other.md", root))
+
+    def test_live_population_contains_no_nested_checkout_paths(self):
+        # Whatever this machine has checked out, the scanned population is
+        # this repo's own files.
+        offenders = [p for p in cited_paths() if in_nested_checkout(p, REPO_ROOT)]
+        self.assertEqual(offenders, [], f"nested-checkout paths leaked in: {offenders[:5]}")
 
     def test_adr_rel_comes_from_the_numbering_guard(self):
         import test_ci_adr_decision_numbering as numbering

--- a/scanner/tests/test_ci_adr_decision_numbering.py
+++ b/scanner/tests/test_ci_adr_decision_numbering.py
@@ -103,6 +103,48 @@ _CITED_GLOBS = (
 )
 
 
+def in_nested_checkout(path, root) -> bool:
+    """True when `path` lives inside a git checkout nested under `root`.
+
+    A linked worktree marks its root with a `.git` FILE (`gitdir: ...`), a
+    vendored clone with a `.git` DIRECTORY — `Path.exists()` covers both. The
+    walk stops at `root` itself, so the repo's own `.git` never matches.
+    """
+    root = Path(root)
+    node = Path(path).parent
+    while node != root and root in node.parents:
+        if (node / ".git").exists():
+            return True
+        node = node.parent
+    return False
+
+
+def cited_paths() -> list:
+    """Absolute paths of every file the citation scan reads — this repo's files only.
+
+    `.claude/**/*.md` reaches into `.claude/worktrees/<id>/`, where the agent
+    worktrees live. Those are gitignored checkouts of OTHER branches: scanning
+    them made both ADR guards report citation errors for files the current
+    commit does not contain, and the failure appeared ONLY on a developer's
+    machine because a CI checkout has no worktrees. A guard that fails for a
+    reason the tree cannot cause is a guard people learn to ignore.
+
+    The rule is structural rather than a `.claude/worktrees/` path literal, so a
+    checkout nested anywhere — a vendored clone, a worktree relocated by
+    `OMC_STATE_DIR` — is excluded by construction (ADR-001 §5).
+
+    Both guards enumerate through here. Sharing only the glob TUPLE was not
+    enough: the two `glob()` loops were separate code, which is exactly where an
+    exclusion added to one would fail to reach the other.
+    """
+    out = set()
+    for pattern in _CITED_GLOBS:
+        for path in glob(str(REPO_ROOT / pattern), recursive=True):
+            if not in_nested_checkout(path, REPO_ROOT):
+                out.add(path)
+    return sorted(out)
+
+
 def decision_section(text: str) -> str:
     """The text between the `## Decision` heading and the next `##` heading."""
     m = re.search(r"^## Decision\s*$(.*?)^## ", text, re.M | re.S)
@@ -125,17 +167,16 @@ def parsed_decisions(text: str) -> dict:
 def citation_numbers() -> dict:
     """`{number: [file:line, ...]}` for every `ADR-001 §N` in the repo."""
     out = {}
-    for pattern in _CITED_GLOBS:
-        for path in glob(str(REPO_ROOT / pattern), recursive=True):
-            p = Path(path)
-            try:
-                text = p.read_text(encoding="utf-8")
-            except (UnicodeDecodeError, OSError):
-                continue
-            for lineno, line in enumerate(text.splitlines(), start=1):
-                for m in _CITE_RE.finditer(line):
-                    rel = p.relative_to(REPO_ROOT)
-                    out.setdefault(int(m.group(1)), []).append(f"{rel}:{lineno}")
+    for path in cited_paths():
+        p = Path(path)
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            for m in _CITE_RE.finditer(line):
+                rel = p.relative_to(REPO_ROOT)
+                out.setdefault(int(m.group(1)), []).append(f"{rel}:{lineno}")
     return out
 
 


### PR DESCRIPTION
## The gap

`_CITED_GLOBS` includes `.claude/**/*.md`, which reaches into `.claude/worktrees/<id>/` — the agent worktrees. Those are gitignored checkouts of **other branches**, so both ADR guards were reading files the current commit does not contain.

Measured on a machine with four worktrees checked out:

```
globbed : 564
kept    : 232
excluded: 332      <- 58%, all under .claude/worktrees/
```

`test_no_new_non_canonical_citation` failed on citations living in someone else's tree — and it failed **only on a developer machine**, since a CI checkout has no worktrees. A guard that fails for a reason the tree cannot cause is a guard people learn to ignore.

It also inflated `test_population_is_scanned`'s canonical-count canary, so the one check meant to notice the scan going quiet was reading four extra copies of everything.

## The rule

Structural, not a `.claude/worktrees/` path literal: **a file whose nearest enclosing `.git` is not the repo's own is not the repo's file.** That covers a vendored clone, or a worktree relocated by `OMC_STATE_DIR`, by construction (ADR-001 §5). A linked worktree marks its root with a `.git` FILE, a clone with a `.git` DIRECTORY — `Path.exists()` covers both.

Sharing the glob TUPLE was not enough. Each guard ran its own `glob()` loop, which is exactly where an exclusion added to one silently misses the other. Both now enumerate through `cited_paths()`, and a meta-guard pins that they do.

## Tests

Built in a tmpdir rather than in the repo, so they assert the same thing whether or not the developer running them has worktrees checked out:

- linked-worktree `.git` **file** detected; vendored-clone `.git` **directory** detected
- the walk **stops at root** — otherwise the repo's own `.git` would exclude every file and the scan would go silently empty, which is a vacuous guard that reads green
- an unmarked nested directory is **still scanned**, so the exclusion is not a hole a doc could hide in
- the live population contains no nested-checkout path

## Verification

```
pytest test_ci_adr_citation_spelling.py test_ci_adr_decision_numbering.py
72 passed
```

`test_no_new_non_canonical_citation` fails on `main` with worktrees present and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)