### PR TITLE
fix(scanner): "1 reference(s)" over twenty listed paths, and the \n you could see

### DIFF
--- a/scanner/checks/access-control/secrets-scan.sh
+++ b/scanner/checks/access-control/secrets-scan.sh
@@ -182,13 +182,15 @@ for entry in "${SECRET_PATTERNS[@]}"; do
     -not -path "*/dist/*" -not -path "*/.env.example" -not -path "*/scanner/*" \
     -not -path "*/hooks/*" -not -path "*/.venv*/*" -not -path "*/venv/*" \
     -not -path "*/.claudesec-prowler/*" -not -path "*/.claudesec-history/*" \
-    -not -path "*/.claudesec-assets/*" \
+    -not -path "*/.claudesec-assets/*" -not -path "*/.claude/worktrees/*" \
     -exec grep -lE "$secret_pattern" {} \; 2>/dev/null | head -3 || true)
 
   if [[ -n "$hit" ]]; then
     _found_secrets=$((_found_secrets + 1))
     _hit_files=$(echo "$hit" | tr '\n' ', ' | sed 's/,$//')
-    _secret_details="${_secret_details}\n    ${secret_name}: ${_hit_files}"
+    # Real newline — see the SECRETS-004 accumulator below for why `"\n"` here
+    # ends up as visible `\n` text in scan-report.json and the dashboard.
+    _secret_details="${_secret_details}"$'\n'"    ${secret_name}: ${_hit_files}"
   fi
 done
 
@@ -346,31 +348,44 @@ for cp in "${_cred_patterns[@]}"; do
     \( -name "*.py" -o -name "*.js" -o -name "*.ts" -o -name "*.yaml" -o -name "*.yml" \
        -o -name "*.sh" -o -name "*.tf" -o -name "Dockerfile*" \) \
     -not -path "*/node_modules/*" -not -path "*/.git/*" -not -path "*/scanner/*" \
+    -not -path "*/.claude/worktrees/*" \
     -exec grep -lE "$cred_pattern" {} \; 2>/dev/null || true)
 
   if [[ -n "$cred_hits" ]]; then
     while IFS= read -r cred_hit; do
       [[ -z "$cred_hit" ]] && continue
       _cred_rel_path="$(_relative_path "$cred_hit")"
+      # A REAL newline, not the two-character "\n": inside double quotes bash
+      # leaves `\n` literal, which collapsed the whole blob into ONE line. The
+      # awk dedup/count below then always returned 1 (so the title said "1
+      # reference" above twenty listed paths), and `_json_escape_str` escaped
+      # the backslash, emitting `\\n` — rendered as visible `\n` garbage in the
+      # dashboard. Findings are stored NUL-separated (_write_findings_file) and
+      # printed with `echo -e`, so an embedded newline is safe in both paths.
       if _is_allowlisted_path "$_cred_rel_path"; then
         _cred_warn_count=$((_cred_warn_count + 1))
-        _cred_warn_details="${_cred_warn_details}\n    $cred_desc: $_cred_rel_path"
+        _cred_warn_details="${_cred_warn_details}"$'\n'"    $cred_desc: $_cred_rel_path"
       else
         _cred_fail_count=$((_cred_fail_count + 1))
-        _cred_fail_details="${_cred_fail_details}\n    $cred_desc: $_cred_rel_path"
+        _cred_fail_details="${_cred_fail_details}"$'\n'"    $cred_desc: $_cred_rel_path"
       fi
     done <<< "$cred_hits"
   fi
 done
 
 # Deduplicate repeated detail lines (same file can match multiple patterns)
+# `awk NF` drops the leading blank line and `$( )` strips the trailing one, so
+# the blob comes back with no leading newline — which would glue the first
+# detail onto the summary line in the title. Re-add it.
 if [[ -n "$_cred_warn_details" ]]; then
   _cred_warn_details="$(echo "$_cred_warn_details" | awk 'NF{if(!seen[$0]++) print}')"
   _cred_warn_count="$(echo "$_cred_warn_details" | awk 'NF{c++} END{print c+0}')"
+  _cred_warn_details=$'\n'"$_cred_warn_details"
 fi
 if [[ -n "$_cred_fail_details" ]]; then
   _cred_fail_details="$(echo "$_cred_fail_details" | awk 'NF{if(!seen[$0]++) print}')"
   _cred_fail_count="$(echo "$_cred_fail_details" | awk 'NF{c++} END{print c+0}')"
+  _cred_fail_details=$'\n'"$_cred_fail_details"
 fi
 
 if [[ $_cred_fail_count -gt 0 ]]; then

--- a/scanner/tests/test_check_secrets_scan.sh
+++ b/scanner/tests/test_check_secrets_scan.sh
@@ -315,6 +315,105 @@ PY
 SCAN_DIR="$tmpdir/cred_clean" run_check
 assert_has_result "No credential path refs -> PASS SECRETS-004" "PASS" "SECRETS-004"
 
+echo "=== SECRETS-004: multi-hit detail blob (count + newline regression) ==="
+
+# The accumulators used to append the two-character sequence `\n` (bash leaves
+# `\n` literal inside double quotes), which collapsed the whole blob onto ONE
+# line. Two defects followed: the awk dedup/count saw a single line and always
+# reported "1 reference(s)" no matter how many files matched, and
+# _json_escape_str escaped the backslash so scan-report.json carried `\\n` —
+# rendered as visible `\n` text in the dashboard. Both are asserted here.
+#
+# The default `warn()` stub above records only the check id, so this block
+# installs a title-capturing stub for the duration and restores it after.
+_captured_warn_title=""
+warn() { RESULTS+=("WARN:$1"); _captured_warn_title="$2"; }
+
+mkdir -p "$tmpdir/cred_multi/templates"
+for _n in one two three; do
+  cat > "$tmpdir/cred_multi/templates/setup-$_n.sh" <<SH
+#!/usr/bin/env bash
+KUBECONFIG=~/.kube/config
+SH
+done
+SCAN_DIR="$tmpdir/cred_multi" run_check
+
+# 1. The count must equal the number of distinct matching files, not 1.
+if [[ "$_captured_warn_title" == 3\ * ]]; then
+  echo "  PASS: 3 matching files -> title reports 3, not 1"
+  ((TEST_PASSED++))
+else
+  echo "  FAIL: expected title to start with '3 ', got: ${_captured_warn_title%%$'\n'*}"
+  ((TEST_FAILED++))
+fi
+
+# 1b. The summary line must stand alone: `awk NF` drops the leading blank line,
+#     which glued the first detail onto it.
+if [[ "${_captured_warn_title%%$'\n'*}" != *"Kubernetes config file:"* ]]; then
+  echo "  PASS: summary line is not glued to the first detail line"
+  ((TEST_PASSED++))
+else
+  echo "  FAIL: first detail is on the summary line: ${_captured_warn_title%%$'\n'*}"
+  ((TEST_FAILED++))
+fi
+
+# 2. Details must be separated by REAL newlines...
+if [[ "$_captured_warn_title" == *$'\n'* ]]; then
+  echo "  PASS: detail lines are separated by real newlines"
+  ((TEST_PASSED++))
+else
+  echo "  FAIL: no real newline in title — the blob collapsed onto one line"
+  ((TEST_FAILED++))
+fi
+
+# 3. ...and must NOT contain a literal backslash-n, which is what leaks into
+#    scan-report.json as `\\n` and reaches the dashboard as visible garbage.
+if [[ "$_captured_warn_title" != *'\n'* ]]; then
+  echo "  PASS: no literal backslash-n in the detail blob"
+  ((TEST_PASSED++))
+else
+  echo "  FAIL: literal backslash-n present — it will render as \\n in the dashboard"
+  ((TEST_FAILED++))
+fi
+
+# Mutation self-test: the assertions above must actually be able to fail.
+# Rebuild the pre-fix blob and confirm each one rejects it.
+_broken=""
+for _p in a b c; do _broken="${_broken}\n    Kubernetes config file: $_p"; done
+_broken="3 references${_broken}"
+if [[ "$_broken" == *$'\n'* ]] || [[ "$_broken" != *'\n'* ]]; then
+  echo "  FAIL: mutation self-test — assertions 2/3 accept the pre-fix blob (vacuous)"
+  ((TEST_FAILED++))
+else
+  echo "  PASS: mutation self-test — assertions 2/3 reject the pre-fix blob"
+  ((TEST_PASSED++))
+fi
+
+# Restore the id-only stub for any later block.
+warn() { RESULTS+=("WARN:$1"); }
+
+echo "=== SECRETS-004: nested worktree checkouts are not scanned ==="
+
+# .claude/worktrees/<id>/ holds gitignored checkouts of OTHER branches. Scanning
+# them reported the same template file once per worktree — four duplicate
+# findings for one real one, on a developer machine only.
+mkdir -p "$tmpdir/cred_wt/templates" "$tmpdir/cred_wt/.claude/worktrees/agent-dead/templates"
+cat > "$tmpdir/cred_wt/.claude/worktrees/agent-dead/templates/setup.sh" <<'SH'
+#!/usr/bin/env bash
+KUBECONFIG=~/.kube/config
+SH
+cat > "$tmpdir/cred_wt/main.py" <<'PY'
+print("hello world")
+PY
+SCAN_DIR="$tmpdir/cred_wt" run_check
+assert_has_result "credential ref only inside .claude/worktrees -> PASS SECRETS-004" "PASS" "SECRETS-004"
+
+# Positive control: the identical file OUTSIDE the worktree must still be found,
+# so the exclusion cannot pass by disabling the check entirely.
+cp "$tmpdir/cred_wt/.claude/worktrees/agent-dead/templates/setup.sh" "$tmpdir/cred_wt/templates/setup.sh"
+SCAN_DIR="$tmpdir/cred_wt" run_check
+assert_has_result "same file outside the worktree -> WARN SECRETS-004" "WARN" "SECRETS-004"
+
 # ── Summary ──────────────────────────────────────────────────────────────────
 
 echo ""


### PR DESCRIPTION
## How it was found

Brought the dashboard up through Docker and read what it actually served. One root cause in `secrets-scan.sh`, three visible defects.

The accumulators appended the two-character sequence `\n`:

```bash
_cred_warn_details="${_cred_warn_details}\n    $desc: $path"
```

Inside double quotes bash leaves `\n` **literal**, so the whole blob was ONE line.

### 1. Wrong count

The dedup/count step is `echo "$blob" | awk 'NF{c++}'`, and bash's `echo` builtin does not interpret `\n`. awk saw a single line, so the count was **1 no matter how many files matched** — the scan printed *"1 operational-allowlisted credential reference(s)"* directly above twenty listed paths. The dedup on the line before never deduplicated anything either.

### 2. Visible `\n` in the product

`_json_escape_str` escaped the backslash, so `scan-report.json` carried `\\n`, which decodes to a literal backslash-n. The served dashboard rendered:

```
...in code\n    AWS credentials file path: templates/...
```

Confirmed by `curl` against the running container, not by reading code.

### 3. Glued summary line

`awk NF` drops the leading blank line and `$( )` strips the trailing one, so the first detail was concatenated onto the summary.

## Why real newlines are safe here

Findings are serialized NUL-separated (`_write_findings_file` / `read -r -d ''`) and printed with `echo -e`, so an embedded newline passes through both the parallel-mode and the text-output path untouched.

## Also: the scan walked other branches' checkouts

16 of the 20 detail lines were four duplicate copies of the four real ones, from `.claude/worktrees/`. The exclusion is scoped to `*/.claude/worktrees/*`, **not** `*/.claude/*` as four other checks use: `.claude/` can hold user hook scripts, and excluding it wholesale would be a false negative on real secrets.

## Verification — end to end through the container

| | before | after |
|---|---|---|
| reported count | 1 (actual 4) | **4** |
| literal `\n` | 20 | **0** |
| worktree refs | 16 | **0** |
| summary line | glued to first detail | **alone** |

```console
$ curl -s localhost:11777/scan.html | grep -c 'in code\n'   # 0
$ curl -s localhost:11777/scan.html | grep -c worktrees     # 0
```

Tests: **22 passed** (up from 15). `shellcheck` clean.

The newline assertions carry a mutation self-test that reconstructs the pre-fix blob and confirms they reject it. The worktree exclusion has a positive control — the identical file **outside** the worktree must still WARN — so the exclusion cannot pass by disabling the check.

`SECRETS-001`'s `_secret_details` had the same literal-`\n` bug on a CRITICAL path and is fixed with it.

## Not addressed here

`find` exclusion lists are hand-duplicated across 48 call sites in 8 files with inconsistent contents (`*/node_modules/*` in 9, `*/.claude/*` in 4). That is an ADR-001 §5 enumeration-vs-rule refactor, deliberately out of scope for a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)