### PR TITLE
docs(compliance): we hand-wrote a worse copy of a mapping Prowler already ships

### DIFF
--- a/docs/plans/compliance-native-mapping-and-cmmc.md
+++ b/docs/plans/compliance-native-mapping-and-cmmc.md
@@ -1,0 +1,127 @@
+---
+title: Compliance mapping — adopt Prowler's native requirement→check data, and add CMMC 2.0 on top of it
+description: Measurement showing the hand-written keyword map reproduces 41.5% of Prowler's own KISA mapping, and the plan to add CMMC 2.0 Level 2 without repeating it
+tags: [compliance, cmmc, nist-800-171, prowler, planning]
+---
+
+# Compliance mapping: stop guessing, read the mapping we already ship
+
+## The finding that changes the plan
+
+The task was "add CMMC 2.0 Level 2 as an 8th framework, designing keywords against
+the Prowler corpus from the start". Measuring the corpus first produced a different
+conclusion: **Prowler ships a native, authoritative requirement→check mapping for
+every framework `COMPLIANCE_CONTROL_MAP` hand-writes**, and the hand-written
+keyword heuristics reproduce it poorly.
+
+Measured 2026-08-14 against Prowler 5.38 (1550 checks with metadata):
+
+| what Prowler ships | file |
+|---|---|
+| SOC 2 | `compliance/{aws,azure,gcp}/soc2_*.json` |
+| ISO 27001:2013 / :2022 | `iso27001_2013_aws.json`, `iso27001_2022_{aws,azure}.json` |
+| PCI-DSS 3.2.1 / 4.0 | `pci_{3.2.1,4.0}_*.json` |
+| NIST 800-53 rev4 / rev5 | `nist_800_53_revision_{4,5}_aws.json` |
+| CIS (per provider, per version) | `cis_*_{aws,azure,gcp,kubernetes,...}.json` |
+| **KISA ISMS-P 2023** | **`kisa_isms_p_2023_aws.json`** (+ a Korean-language variant) |
+| **NIST 800-171 rev2** | **`nist_800_171_revision_2_aws.json`** |
+
+### How far off the hand-written map is
+
+`kisa_isms_p_2023_aws.json` carries **101 requirements mapped to 562 checks**. The
+repo hand-maps 42 KISA ISMS-P controls, of which only **16 share a control id** with
+Prowler's. On those 16, the repo's keywords reproduce **237 of 571 mappings —
+41.5%**.
+
+| control | repo keywords | reproduced |
+|---|---|---|
+| 2.9.4 백업·복구 | `backup, recovery, snapshot, restore` | **0 / 58** |
+| 2.10.8 악성코드 | `malware, antivirus, sentinelone` | **0 / 14** |
+| 2.6.3 세션·토큰 | `token, session, application, oauth` | **0 / 2** |
+| 2.6.2 인증 | `mfa, authentication, _sso, two_factor` | 4 / 64 (6%) |
+| 2.10.1 네트워크 | `firewall, security_group, antivirus` | 9 / 89 (10%) |
+| 2.9.3 로깅 | `logging, audit, log_maxage, cloudtrail` | 9 / 24 (38%) |
+
+2.9.4 scoring 0/58 is the clearest case: the keywords are the *right words*
+(`backup`, `snapshot`, `restore`) and Prowler's 58 backup checks are the *right
+checks* — they simply do not share literal substrings, because Prowler maps by
+intent and the map matches by text.
+
+### Why keywords structurally cannot close this
+
+One check belongs to many requirements. `apigateway_restapi_logging_enabled` is
+mapped by Prowler to 800-171 §3.1 (Access Control), §3.3 (Audit), §3.6 (Incident
+Response) **and** §3.14 (System Integrity) simultaneously. A substring rule assigns
+a check to whichever controls happen to share vocabulary with it — a different
+function entirely.
+
+This is the same root cause behind every miss rate measured in this cycle:
+SOC 2 CC3 78%, CC4 75%, CC5 72%; KISA vulnerability-management 68.5%, logging 42.6%.
+And behind the false-positive classes: `sso` inside "associated", `sast` inside
+"disaster", `change` at 97.5% wrong, `edr` at 100% wrong. Every one is a symptom of
+approximating a semantic mapping with text matching.
+
+## Plan
+
+### Phase 1 — load Prowler's mapping as a data source (prerequisite for CMMC)
+
+Add a loader that reads `compliance/<provider>/<framework>.json` from the Prowler
+installation already present in the scanner image, and resolves
+`requirement id → [check ids]`. A finding then belongs to a control when its
+`event_code` is in that control's check list — exact, not substring.
+
+Keep the keyword map as the **fallback** for two cases it is genuinely needed for:
+GitHub-provider findings (Prowler ships no `soc2_github.json` — this is why SOC 2
+CC8 measures 100% miss against the SOC 2 corpus while matching 8/10 real GitHub
+checks) and any framework Prowler does not ship.
+
+Success criterion, measured the same way as above: reproduce ≥95% of Prowler's own
+mapping for KISA ISMS-P and SOC 2, versus 41.5% today.
+
+### Phase 2 — CMMC 2.0 Level 2 on that foundation
+
+CMMC 2.0 Level 2's 110 practices are drawn directly from NIST SP 800-171, so
+`nist_800_171_revision_2_aws.json` is the mapping basis. It carries 50 requirements
+over 94 distinct checks, grouped by 800-171 family:
+
+| 800-171 | CMMC domain | checks |
+|---|---|---|
+| 3.1 | AC — Access Control | 43 |
+| 3.13 | SC — System & Communications Protection | 52 |
+| 3.5 | IA — Identification & Authentication | 25 |
+| 3.4 | CM — Configuration Management | 22 |
+| 3.3 | AU — Audit & Accountability | 21 |
+| 3.6 | IR — Incident Response | 14 |
+| 3.14 | SI — System & Information Integrity | 13 |
+| 3.12 | CA — Security Assessment | 9 |
+| 3.11 | RA — Risk Assessment | 3 |
+
+**Do not hand-write keywords for these.** A prototype keyword set built from
+vocabulary actually present in each family was measured at **34.2% coverage**
+(3.4 Configuration Management: 1/22; 3.14 System Integrity: 1/13). That is the
+ceiling this approach reaches even when the vocabulary is drawn from the target
+checks themselves.
+
+Coverage caveat to state in the docs: Prowler ships 800-171 for **AWS only**. Azure
+and GCP estates get no CMMC coverage from this source, and the dashboard must say
+so rather than render an empty domain as passing — the same rule already applied to
+non-assessable controls.
+
+### Phase 3 — retire what measurement made unnecessary
+
+Once Phase 1 lands, most of `COMPLIANCE_CONTROL_MAP`'s keyword lists become dead
+weight, and with them the guard machinery built to police them
+(`test_ci_compliance_keyword_guard.py`'s `BENIGN_WORDS` curation, the
+`NEVER_EMITTED_TOKENS` set, the over-broad-whole-word pins). Retire them
+deliberately and with measurement, not by deletion.
+
+## What this plan does not claim
+
+- The 41.5%, 34.2% and per-family numbers are measured. The ≥95% Phase 1 success
+  criterion is a target, not a measurement.
+- Prowler's own mapping is treated as ground truth here. It is authoritative for
+  "which check evidences which requirement", but it is still one vendor's
+  judgement, and it double-maps freely (one check to four families). Adopting it
+  means adopting that judgement.
+- No estimate of implementation effort is given, because the loader's shape depends
+  on how the scanner image exposes the Prowler package, which has not been checked.

--- a/scanner/lib/compliance-map.py
+++ b/scanner/lib/compliance-map.py
@@ -704,6 +704,31 @@ COMPLIANCE_CONTROL_MAP = {
             "checks": ["vulnerability", "dependency", "dependabot", "scan", "cve"],
             "status": "",
         },
+        # CC4 and CC5 both retain a high miss rate against Prowler's own SOC 2
+        # mapping (75% and 72%), and BOTH are structural rather than a keyword
+        # defect. Measured 2026-08-14 against the real 5.38 catalog:
+        #
+        #   CC5's 21 missed checks are ALL CloudWatch / Azure-Monitor alarm
+        #   checks (`cloudwatch_changes_to_network_acls_alarm_configured`,
+        #   `logging_log_metric_filter_and_alert_for_*_changes_enabled`).
+        #   Prowler maps that same alarm family to CC4, CC5 AND CC7
+        #   simultaneously. A keyword set cannot separate what the ground truth
+        #   itself conflates.
+        #
+        # Two edits were proposed by review and both were REJECTED on measurement:
+        #
+        #   CC5 + `default`  -> recovers 0 of the 21 missed checks, while newly
+        #                       lighting 158 corpus-wide. Pure dilution. (The
+        #                       token's 169 corpus hits are real; none of them
+        #                       are CC5's mapped checks.)
+        #   CC4 + `alert`    -> recovers 3 of 24 (miss 85.7% -> 75.0%) but takes
+        #                       CC4's corpus matches 137 -> 182 and its overlap
+        #                       with CC7 from 38% -> 52% of CC4. Buying 3 checks
+        #                       by making half of CC4 indistinguishable from CC7
+        #                       is a bad trade for a per-criterion breakdown.
+        #
+        # Pinned in test_ci_compliance_keyword_guard.py so a future pass does not
+        # re-propose either without re-measuring.
         {
             "control": "CC4",
             "name": "Monitoring activities",

--- a/scanner/tests/test_ci_compliance_keyword_guard.py
+++ b/scanner/tests/test_ci_compliance_keyword_guard.py
@@ -226,6 +226,39 @@ class TestComplianceKeywordRegressionPins(unittest.TestCase):
                 )
 
 
+class TestMeasuredRejections(unittest.TestCase):
+    """Two edits proposed by review and rejected on measurement, 2026-08-14.
+
+    Both look obviously right on inspection — CC5's own action text says "enforce
+    secure defaults", and CC4 is a monitoring criterion with no `alert` token —
+    which is exactly why they need a pin rather than a comment. Measured against
+    Prowler 5.38's real catalog using Prowler's own soc2_{aws,azure,gcp}.json as
+    ground truth:
+
+      CC5 + `default`  recovers 0 of its 21 missed checks and newly lights 158
+                       corpus-wide. The token's 169 hits are real; none are CC5's.
+      CC4 + `alert`    recovers 3 of 24 (85.7% -> 75.0% miss) while taking CC4's
+                       corpus matches 137 -> 182 and its overlap with CC7 from
+                       38% -> 52% of CC4.
+
+    Re-adding either is allowed — but only with a fresh measurement, which is
+    what this failing test forces someone to do.
+    """
+
+    def test_cc5_does_not_carry_default(self):
+        checks = _checks_of("SOC 2 (TSC)", "CC5")
+        self.assertNotIn("default", checks)
+        self.assertNotIn("_default_", checks)
+
+    def test_cc4_does_not_carry_alert(self):
+        self.assertNotIn("alert", _checks_of("SOC 2 (TSC)", "CC4"))
+
+    def test_cc7_still_owns_alert(self):
+        # The rejection is about CC4, not about the token. CC7 is where alerting
+        # belongs, and dropping it there would be a real detection loss.
+        self.assertIn("alert", _checks_of("SOC 2 (TSC)", "CC7"))
+
+
 class TestComplianceKeywordCollision(unittest.TestCase):
     def test_no_keyword_is_proper_substring_of_benign_word(self):
         hits = _collisions(_all_keywords())


### PR DESCRIPTION
Two review recommendations were measured and **both rejected** — and measuring them turned up why this whole approach keeps missing.

## Rejected on measurement

**CC5 + `default`** — recovers **0** of CC5's 21 missed checks while newly lighting **158** corpus-wide. The token's 169 hits are real; none of them are checks Prowler maps to CC5. The two reviewers disagreed on its hit count (169 vs 206); neither had measured the only thing that decides it.

**CC4 + `alert`** — recovers 3 of 24 (miss 85.7% → 75.0%) but takes CC4's corpus matches 137 → 182 and its overlap with CC7 from **38% → 52% of CC4**. Buying 3 checks by making half of CC4 indistinguishable from CC7 is a bad trade for a per-criterion breakdown.

Both residual misses are **structural**. CC5's 21 missed checks are all CloudWatch / Azure-Monitor alarm checks, and Prowler maps that same family to CC4, CC5 **and** CC7 at once. Keywords cannot separate what the ground truth conflates.

Pinned in `test_ci_compliance_keyword_guard.py`. Re-adding either is allowed — but only after a fresh measurement, which the failing test forces someone to do.

## The larger finding

**Prowler ships a native requirement→check mapping for every framework `COMPLIANCE_CONTROL_MAP` hand-writes**: `soc2_*`, `iso27001_*`, `pci_*`, `nist_800_53_revision_*`, `cis_*` — and `kisa_isms_p_2023_aws.json`, a Korean framework, natively mapped, with a Korean-language variant.

`kisa_isms_p_2023_aws.json` carries **101 requirements over 562 checks**. The repo hand-maps 42 KISA controls, 16 of which share an id with Prowler's. On those 16, the repo's keywords reproduce **237/571 = 41.5%**.

| control | repo keywords | reproduced |
|---|---|---|
| 2.9.4 백업·복구 | `backup, recovery, snapshot, restore` | **0 / 58** |
| 2.10.8 악성코드 | `malware, antivirus, sentinelone` | **0 / 14** |
| 2.6.2 인증 | `mfa, authentication, _sso, two_factor` | 4 / 64 |
| 2.10.1 네트워크 | `firewall, security_group, antivirus` | 9 / 89 |

2.9.4 at 0/58 is the clearest case: the keywords are the *right words* and Prowler's 58 backup checks are the *right checks* — they just do not share literal substrings, because **Prowler maps by intent and we match by text**.

One check belongs to many requirements: `apigateway_restapi_logging_enabled` is mapped to 800-171 §3.1, §3.3, §3.6 **and** §3.14 simultaneously. Every miss rate and every collision this cycle — `sso`/"associated", `sast`/"disaster", `change` at 97.5% wrong, `edr` at 100% wrong — is a symptom of approximating that with substrings.

## CMMC 2.0 Level 2 — planned, not guessed

`docs/plans/compliance-native-mapping-and-cmmc.md`.

CMMC L2's 110 practices derive from NIST SP 800-171, and Prowler ships `nist_800_171_revision_2_aws.json`: 50 requirements, 94 checks.

| 800-171 | CMMC domain | checks |
|---|---|---|
| 3.13 | SC — System & Communications Protection | 52 |
| 3.1 | AC — Access Control | 43 |
| 3.5 | IA — Identification & Authentication | 25 |
| 3.4 | CM — Configuration Management | 22 |
| 3.3 | AU — Audit & Accountability | 21 |
| 3.6 / 3.14 / 3.12 / 3.11 | IR / SI / CA / RA | 14 / 13 / 9 / 3 |

A prototype keyword set drawn from the vocabulary of the *target checks themselves* measured **34.2%** coverage (CM 1/22, SI 1/13). That is the ceiling this approach reaches under ideal conditions. So the plan loads Prowler's mapping as data first and adds CMMC on top, rather than writing an eighth keyword set.

Coverage caveat the dashboard must state: Prowler ships 800-171 for **AWS only**.

`2176 passed`. `markdownlint` clean. No behavior change — comments, a plan, and three pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)