### PR TITLE
feat(compliance): read Prowler's mapping instead of guessing at it

### DIFF
--- a/scanner/lib/compliance-map.py
+++ b/scanner/lib/compliance-map.py
@@ -791,19 +791,66 @@ def _match_prowler_compliance(finding, framework_key):
     return False
 
 
+_NATIVE_CACHE = None
+
+
+def _native_mapping():
+    """Prowler's own requirement->check data, loaded once. `{}` when unavailable.
+
+    Import is deferred and failure is swallowed on purpose: compliance-map.py is
+    loaded by output.sh via importlib in a bare scan, where a missing sibling or
+    a missing Prowler install must not break the run.
+    """
+    global _NATIVE_CACHE
+    if _NATIVE_CACHE is None:
+        try:
+            import importlib.util
+            import os
+
+            spec = importlib.util.spec_from_file_location(
+                "prowler_native_map",
+                os.path.join(
+                    os.path.dirname(os.path.abspath(__file__)), "prowler_native_map.py"
+                ),
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            _NATIVE_CACHE = module.load_all()
+        except Exception:
+            _NATIVE_CACHE = {}
+    return _NATIVE_CACHE
+
+
 def map_compliance(all_findings):
-    """Map findings to compliance framework controls. Returns {framework: [ctrl_with_status]}."""
+    """Map findings to compliance framework controls. Returns {framework: [ctrl_with_status]}.
+
+    A control is matched by EXACT check-id membership when Prowler ships a
+    mapping for it, and by keyword substring otherwise. Prowler's data is sparse
+    — its KISA file maps only 26 of 101 requirements — so the keyword path is a
+    fallback, not dead code. Each control reports which source decided it via
+    `match_source`, so a reader can tell an exact mapping from an approximation.
+    """
+    native = _native_mapping()
     result = {}
     for framework, controls in COMPLIANCE_CONTROL_MAP.items():
+        fw_native = native.get(framework, {})
         mapped = []
         for ctrl in controls:
+            native_checks = fw_native.get(ctrl["control"])
             matching = []
-            for f in all_findings:
-                text = f"{f['check']} {f['title']} {f['message']}".lower()
-                keyword_match = any(kw in text for kw in ctrl["checks"])
-                native_match = _match_prowler_compliance(f, framework)
-                if keyword_match or native_match:
-                    matching.append(f)
+            if native_checks:
+                match_source = "prowler"
+                for f in all_findings:
+                    if str(f.get("check", "")) in native_checks:
+                        matching.append(f)
+            else:
+                match_source = "keyword"
+                for f in all_findings:
+                    text = f"{f['check']} {f['title']} {f['message']}".lower()
+                    keyword_match = any(kw in text for kw in ctrl["checks"])
+                    native_match = _match_prowler_compliance(f, framework)
+                    if keyword_match or native_match:
+                        matching.append(f)
             if not ctrl.get("assessable", True):
                 status = "N/A"
             else:
@@ -814,6 +861,7 @@ def map_compliance(all_findings):
                     "status": status,
                     "count": len(matching),
                     "findings": matching[:5],
+                    "match_source": match_source,
                 }
             )
         result[framework] = mapped

--- a/scanner/lib/prowler_native_map.py
+++ b/scanner/lib/prowler_native_map.py
@@ -1,0 +1,165 @@
+"""
+ClaudeSec — load Prowler's own compliance requirement→check mapping.
+
+WHY
+---
+`COMPLIANCE_CONTROL_MAP` assigns a finding to a control by substring-matching
+keywords against the finding's text. Prowler assigns checks to requirements by
+INTENT, in data it ships. Those are different functions, and measurement showed
+how different: on the 16 KISA ISMS-P controls where both have an opinion, the
+keyword lists reproduce 41.5% of Prowler's mapping — with `2.9.4` (백업·복구)
+scoring 0 of 58 despite listing `backup`, `snapshot` and `restore`, because
+Prowler's backup checks do not contain those literal substrings.
+
+Every miss rate and every false positive found in this file's history is a
+symptom of that approximation: `sso` inside "associated", `sast` inside
+"disaster", `change` at 97.5% wrong. Exact check-id membership has nothing to
+approximate.
+
+WHAT THIS IS NOT
+----------------
+A replacement. Prowler's mapping is SPARSE: its KISA file carries 101
+requirements, only 26 of which map to any check at all — governance and process
+requirements a scanner cannot evidence. Of the repo's 42 KISA controls, 16 have
+native checks and 26 do not. Those 26 keep the keyword path, which is why
+`map_compliance()` treats this as a preferred source rather than the only one.
+
+Prowler is also an optional dependency. Everything here degrades to an empty
+mapping when it is absent, so the scanner and its tests run unchanged without it.
+
+ID ALIGNMENT
+------------
+Requirement ids do not agree across frameworks, so each source carries a
+normalizer:
+
+    KISA ISMS-P      `2.9.4`      identical to the repo's ids
+    ISO 27001:2022   `A.8.5`      identical
+    SOC 2 (TSC)      `cc_6_1`     -> `CC6`   (the repo maps at series level)
+    NIST 800-53      `ac_2_1`     -> `AC-2`
+    PCI-DSS v4.0.1   `1.2.5.1`    -> `Req 1`
+
+stdlib only. No network.
+"""
+
+import glob
+import json
+import os
+import re
+
+# ── Locating the installed Prowler package ───────────────────────────────────
+
+
+def prowler_compliance_dirs():
+    """Directories holding Prowler's `<framework>_<provider>.json` files.
+
+    `CLAUDESEC_PROWLER_COMPLIANCE_DIR` overrides discovery — used by the tests,
+    which must not depend on Prowler being installed, and useful when Prowler
+    lives outside the interpreter running the dashboard.
+    """
+    override = os.environ.get("CLAUDESEC_PROWLER_COMPLIANCE_DIR", "").strip()
+    if override:
+        return [override] if os.path.isdir(override) else []
+    try:
+        import importlib.util
+
+        spec = importlib.util.find_spec("prowler")
+    except Exception:
+        return []
+    if spec is None:
+        return []
+    roots = list(getattr(spec, "submodule_search_locations", []) or [])
+    if not roots and spec.origin:
+        roots = [os.path.dirname(spec.origin)]
+    out = []
+    for root in roots:
+        d = os.path.join(root, "compliance")
+        if os.path.isdir(d):
+            out.append(d)
+    return out
+
+
+# ── Requirement-id normalizers ───────────────────────────────────────────────
+
+
+def _identity(rid):
+    return rid
+
+
+def _soc2_series(rid):
+    """`cc_6_1` / `CC6.1` -> `CC6`. The repo maps SOC 2 at series granularity."""
+    m = re.match(r"cc[_\-. ]?(\d)", rid.strip().lower())
+    return "CC" + m.group(1) if m else None
+
+
+def _nist_control(rid):
+    """`ac_2_1` / `ac-2(1)` -> `AC-2`."""
+    m = re.match(r"([a-z]{2})[_\-]?(\d+)", rid.strip().lower())
+    return f"{m.group(1).upper()}-{m.group(2)}" if m else None
+
+
+def _pci_requirement(rid):
+    """`1.2.5.1` -> `Req 1`."""
+    m = re.match(r"(\d+)\.", rid.strip())
+    return f"Req {m.group(1)}" if m else None
+
+
+# framework name -> (filename glob, requirement-id normalizer)
+FRAMEWORK_SOURCES = {
+    "KISA ISMS-P": ("kisa_isms_p_*_[!k]*.json", _identity),
+    "ISO 27001:2022": ("iso27001_2022_*.json", _identity),
+    "SOC 2 (TSC)": ("soc2_*.json", _soc2_series),
+    "NIST 800-53 Rev5": ("nist_800_53_revision_5_*.json", _nist_control),
+    "PCI-DSS v4.0.1": ("pci_4.0_*.json", _pci_requirement),
+}
+
+
+# ── Loading ──────────────────────────────────────────────────────────────────
+
+
+def _requirements(path):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return []
+    reqs = data.get("Requirements")
+    return reqs if isinstance(reqs, list) else []
+
+
+def load_framework(framework):
+    """`{control_id: frozenset(check_ids)}` for one framework, `{}` if unavailable.
+
+    Merges every provider file for the framework (aws + azure + gcp + ...), since
+    a control is satisfied by evidence from whichever provider was scanned.
+    Requirements with no checks are omitted rather than stored empty: an empty
+    set and "no native opinion" must not be confused, because the first would
+    silently mark a control as having zero evidence.
+    """
+    source = FRAMEWORK_SOURCES.get(framework)
+    if not source:
+        return {}
+    pattern, normalize = source
+    merged = {}
+    for directory in prowler_compliance_dirs():
+        for path in sorted(glob.glob(os.path.join(directory, "*", pattern))):
+            for req in _requirements(path):
+                checks = req.get("Checks") or []
+                if not checks:
+                    continue
+                control = normalize(str(req.get("Id", "")))
+                if not control:
+                    continue
+                merged.setdefault(control, set()).update(
+                    c for c in checks if isinstance(c, str) and c
+                )
+    return {k: frozenset(v) for k, v in merged.items() if v}
+
+
+def load_all():
+    """`{framework: {control_id: frozenset(check_ids)}}` for every known source."""
+    out = {}
+    for framework in FRAMEWORK_SOURCES:
+        native = load_framework(framework)
+        if native:
+            out[framework] = native
+    return out

--- a/scanner/tests/test_dashboard_gen_smoke.py
+++ b/scanner/tests/test_dashboard_gen_smoke.py
@@ -137,6 +137,11 @@ class DashboardGenSmokeTest(unittest.TestCase):
                             datetime.now(timezone.utc) + timedelta(hours=36)
                         ).isoformat(),
                         "CLAUDESEC_DASHBOARD_OFFLINE": "1",
+                        # Exercise the scan-scope disclosure. Without this the
+                        # whole `scan_coverage_html` block is unreachable in the
+                        # suite — it only runs when the scanner reports which
+                        # categories executed, which no other test does.
+                        "CLAUDESEC_SCAN_CATEGORIES": "access-control,cicd,code",
                     },
                     clear=False,
                 ),
@@ -158,6 +163,11 @@ class DashboardGenSmokeTest(unittest.TestCase):
             self.assertIn("Best-practice flow", html)
             self.assertIn("Critical / High Queue", html)
             self.assertIn("Local scanner", html)
+            # The narrowed default must say what it did not scan: eight of the
+            # eleven categories did not run here, and a headline grade over 3/11
+            # of the checks reads as full coverage without this line.
+            self.assertIn("Not scanned in this run", html)
+            self.assertIn("8 of 11 categories", html)
             self.assertIn("scannerSearchInput", html)
             self.assertIn("prowlerSearchInput", html)
             self.assertIn("githubSearchInput", html)

--- a/scanner/tests/test_prowler_native_map.py
+++ b/scanner/tests/test_prowler_native_map.py
@@ -1,0 +1,308 @@
+"""
+Tests for `scanner/lib/prowler_native_map.py` and its use by `map_compliance()`.
+
+Prowler assigns checks to requirements by intent, in data it ships; the keyword
+map approximates that with substrings. Measured on the 16 KISA ISMS-P controls
+where both have an opinion, the keywords reproduced 41.5% — `2.9.4` (백업·복구)
+scoring 0 of 58 while listing `backup`, `snapshot` and `restore`, because
+Prowler's backup checks contain none of those literal substrings.
+
+These tests pin the three properties that make the native path safe to prefer:
+
+1. **Exactness.** A natively-mapped control matches on check-id membership and
+   NOTHING else. A finding whose text is full of the control's keywords does not
+   match if its check id is not in Prowler's list — that is the entire point, and
+   it is the one behaviour a reader is most likely to assume works the old way.
+2. **Fallback survives.** Prowler's data is sparse (26 of 101 KISA requirements
+   carry any check), so most controls still run on keywords. A change that
+   silently dropped the keyword path would blank them.
+3. **Absence is inert.** Prowler is optional. With it missing, every control must
+   behave exactly as before.
+
+Hermetic: fixtures are written to a tmpdir and pointed at with
+`CLAUDESEC_PROWLER_COMPLIANCE_DIR`. Nothing here requires Prowler to be
+installed, which is also true of CI.
+"""
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+
+_LIB = os.path.join(os.path.dirname(__file__), "..", "lib")
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_LIB, filename))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pnm = _load("prowler_native_map_under_test", "prowler_native_map.py")
+
+
+def _write_fixture(root, provider, filename, requirements):
+    d = os.path.join(root, provider)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, filename), "w", encoding="utf-8") as fh:
+        json.dump({"Requirements": requirements}, fh)
+
+
+class TestIdNormalizers(unittest.TestCase):
+    """Requirement ids do not agree across frameworks; each source normalizes."""
+
+    def test_soc2_collapses_to_series(self):
+        # The repo maps SOC 2 at series granularity, Prowler at sub-criterion.
+        for raw in ("cc_6_1", "CC6.1", "cc-6-7"):
+            self.assertEqual(pnm._soc2_series(raw), "CC6", raw)
+
+    def test_nist_control_form(self):
+        for raw, want in (("ac_2_1", "AC-2"), ("ac-17", "AC-17"), ("si_4", "SI-4")):
+            self.assertEqual(pnm._nist_control(raw), want, raw)
+
+    def test_pci_requirement_form(self):
+        self.assertEqual(pnm._pci_requirement("1.2.5.1"), "Req 1")
+        self.assertEqual(pnm._pci_requirement("10.7.2"), "Req 10")
+
+    def test_unparseable_ids_return_none_rather_than_a_wrong_control(self):
+        # Returning a guess here would attach real checks to the wrong control.
+        for bad in ("", "governance", "x_1"):
+            self.assertIsNone(pnm._soc2_series(bad))
+            self.assertIsNone(pnm._pci_requirement(bad))
+
+
+class TestLoader(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = self.root
+        self.addCleanup(self._tmp.cleanup)
+        self.addCleanup(os.environ.pop, "CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
+
+    def test_merges_providers_for_one_framework(self):
+        # A control is satisfied by evidence from whichever provider was scanned,
+        # so aws + azure files merge rather than the last one winning.
+        _write_fixture(self.root, "aws", "soc2_aws.json",
+                       [{"Id": "cc_6_1", "Checks": ["a_check"]}])
+        _write_fixture(self.root, "azure", "soc2_azure.json",
+                       [{"Id": "cc_6_6", "Checks": ["b_check"]}])
+        native = pnm.load_framework("SOC 2 (TSC)")
+        self.assertEqual(native["CC6"], frozenset({"a_check", "b_check"}))
+
+    def test_requirements_without_checks_are_omitted_not_stored_empty(self):
+        # An empty set and "no native opinion" must not be confused: the first
+        # would mark a control as having zero evidence, the second falls back to
+        # keywords. Prowler's KISA file has 75 such requirements.
+        _write_fixture(self.root, "aws", "soc2_aws.json", [
+            {"Id": "cc_1_1", "Checks": []},
+            {"Id": "cc_2_1"},
+            {"Id": "cc_6_1", "Checks": ["real_check"]},
+        ])
+        native = pnm.load_framework("SOC 2 (TSC)")
+        self.assertEqual(sorted(native), ["CC6"])
+
+    def test_unknown_framework_returns_empty(self):
+        self.assertEqual(pnm.load_framework("Not A Framework"), {})
+
+    def test_missing_directory_returns_empty(self):
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = os.path.join(self.root, "nope")
+        self.assertEqual(pnm.prowler_compliance_dirs(), [])
+        self.assertEqual(pnm.load_framework("SOC 2 (TSC)"), {})
+
+    def test_malformed_json_is_skipped_not_fatal(self):
+        d = os.path.join(self.root, "aws")
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "soc2_aws.json"), "w", encoding="utf-8") as fh:
+            fh.write("{not json")
+        self.assertEqual(pnm.load_framework("SOC 2 (TSC)"), {})
+
+
+class TestMapComplianceUsesNative(unittest.TestCase):
+    """The behaviour that makes the native path worth having."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = self._tmp.name
+        self.addCleanup(os.environ.pop, "CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
+        _write_fixture(self._tmp.name, "aws", "soc2_aws.json",
+                       [{"Id": "cc_6_1", "Checks": ["s3_bucket_public_access"]}])
+        # Fresh module each time: map_compliance caches the native mapping.
+        self.cm = _load("compliance_map_native_under_test", "compliance-map.py")
+
+    def _soc2(self, findings):
+        return {c["control"]: c for c in self.cm.map_compliance(findings)["SOC 2 (TSC)"]}
+
+    def test_native_control_matches_by_check_id(self):
+        f = {"check": "s3_bucket_public_access", "title": "", "message": ""}
+        ctrl = self._soc2([f])["CC6"]
+        self.assertEqual(ctrl["status"], "FAIL")
+        self.assertEqual(ctrl["match_source"], "prowler")
+
+    def test_native_control_ignores_keyword_text(self):
+        # THE point of this change. `mfa`, `encrypt` and `publicly` are all CC6
+        # keywords; under the old path this finding matched. With a native
+        # mapping present it must not, because its check id is not in the list.
+        f = {
+            "check": "some_unrelated_check",
+            "title": "mfa and encrypt and publicly accessible",
+            "message": "unrestricted ingress 0.0.0.0/0",
+        }
+        ctrl = self._soc2([f])["CC6"]
+        self.assertEqual(ctrl["status"], "PASS")
+        self.assertEqual(ctrl["count"], 0)
+
+    def test_controls_without_native_data_still_use_keywords(self):
+        # Only CC6 is in the fixture. CC7 must keep working on keywords, or the
+        # sparse half of every framework goes dark.
+        f = {"check": "cloudtrail_x", "title": "logging disabled", "message": ""}
+        ctrl = self._soc2([f])["CC7"]
+        self.assertEqual(ctrl["match_source"], "keyword")
+        self.assertEqual(ctrl["status"], "FAIL")
+
+    def test_non_assessable_stays_na_even_with_native_checks(self):
+        # CC1 is governance; a native mapping must not resurrect it as PASS/FAIL.
+        _write_fixture(self._tmp.name, "aws", "soc2_aws.json", [
+            {"Id": "cc_1_1", "Checks": ["some_check"]},
+        ])
+        cm = _load("compliance_map_na_under_test", "compliance-map.py")
+        ctrl = {c["control"]: c for c in cm.map_compliance(
+            [{"check": "some_check", "title": "", "message": ""}]
+        )["SOC 2 (TSC)"]}["CC1"]
+        self.assertEqual(ctrl["status"], "N/A")
+
+
+class TestPackageDiscovery(unittest.TestCase):
+    """The no-override path: find the installed Prowler package.
+
+    CI has no Prowler, so this is driven with a fake package injected into
+    `sys.modules` rather than by installing one — which also keeps the test
+    honest about what the code actually reads (`submodule_search_locations`,
+    then `origin`).
+    """
+
+    def setUp(self):
+        os.environ.pop("CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def _with_spec(self, spec):
+        import importlib.util as ilu
+
+        original = ilu.find_spec
+        ilu.find_spec = lambda name: spec if name == "prowler" else original(name)
+        self.addCleanup(setattr, ilu, "find_spec", original)
+
+    def test_uses_submodule_search_locations(self):
+        os.makedirs(os.path.join(self._tmp.name, "compliance"))
+        self._with_spec(type("S", (), {
+            "submodule_search_locations": [self._tmp.name], "origin": None})())
+        self.assertEqual(pnm.prowler_compliance_dirs(),
+                         [os.path.join(self._tmp.name, "compliance")])
+
+    def test_falls_back_to_origin_when_no_search_locations(self):
+        os.makedirs(os.path.join(self._tmp.name, "compliance"))
+        self._with_spec(type("S", (), {
+            "submodule_search_locations": [],
+            "origin": os.path.join(self._tmp.name, "__init__.py")})())
+        self.assertEqual(pnm.prowler_compliance_dirs(),
+                         [os.path.join(self._tmp.name, "compliance")])
+
+    def test_package_without_compliance_dir_yields_nothing(self):
+        self._with_spec(type("S", (), {
+            "submodule_search_locations": [self._tmp.name], "origin": None})())
+        self.assertEqual(pnm.prowler_compliance_dirs(), [])
+
+    def test_prowler_not_installed(self):
+        self._with_spec(None)
+        self.assertEqual(pnm.prowler_compliance_dirs(), [])
+
+    def test_find_spec_raising_is_not_fatal(self):
+        # A broken sys.path entry can make find_spec raise; the scanner must not
+        # die inside a compliance lookup because of it.
+        import importlib.util as ilu
+
+        original = ilu.find_spec
+
+        def boom(name):
+            if name == "prowler":
+                raise ImportError("broken meta path")
+            return original(name)
+
+        ilu.find_spec = boom
+        self.addCleanup(setattr, ilu, "find_spec", original)
+        self.assertEqual(pnm.prowler_compliance_dirs(), [])
+
+
+class TestIdentityAndSkips(unittest.TestCase):
+    """The two branches the framework-specific tests do not reach."""
+
+    def test_identity_normalizer(self):
+        # KISA and ISO ids are already in the repo's form.
+        self.assertEqual(pnm._identity("2.9.4"), "2.9.4")
+        self.assertEqual(pnm._identity("A.8.5"), "A.8.5")
+
+
+class TestUnnormalizableRequirement(unittest.TestCase):
+    def test_requirement_whose_id_cannot_normalize_is_dropped(self):
+        # A requirement Prowler ships with an id the normalizer cannot parse must
+        # be skipped, NOT attached to some fallback control — that would give a
+        # real control someone else's checks.
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = tmp.name
+        self.addCleanup(os.environ.pop, "CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
+        _write_fixture(tmp.name, "aws", "soc2_aws.json", [
+            {"Id": "not_a_cc_id", "Checks": ["orphan_check"]},
+            {"Id": "cc_6_1", "Checks": ["real_check"]},
+        ])
+        native = pnm.load_framework("SOC 2 (TSC)")
+        self.assertEqual(sorted(native), ["CC6"])
+        self.assertNotIn("orphan_check", native["CC6"])
+
+
+class TestLoadAll(unittest.TestCase):
+    def test_load_all_includes_only_frameworks_with_data(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = tmp.name
+        self.addCleanup(os.environ.pop, "CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
+        _write_fixture(tmp.name, "aws", "soc2_aws.json",
+                       [{"Id": "cc_6_1", "Checks": ["x"]}])
+        loaded = pnm.load_all()
+        # An empty framework must be absent, not present-and-empty: map_compliance
+        # treats "no key" as "fall back to keywords".
+        self.assertEqual(sorted(loaded), ["SOC 2 (TSC)"])
+        self.assertEqual(loaded["SOC 2 (TSC)"]["CC6"], frozenset({"x"}))
+
+
+class TestNativeLoadFailureIsInert(unittest.TestCase):
+    def test_map_compliance_survives_a_broken_loader(self):
+        # compliance-map.py is imported by output.sh via importlib during a bare
+        # scan. If the sibling module is missing or raises, the scan must still
+        # produce a compliance section rather than dying inside it.
+        cm = _load("compliance_map_broken_loader", "compliance-map.py")
+        lib = os.path.join(os.path.dirname(__file__), "..", "lib")
+        original = os.path.dirname
+        os.path.dirname = lambda p: "/nonexistent" if lib in str(p) else original(p)
+        try:
+            cm._NATIVE_CACHE = None
+            self.assertEqual(cm._native_mapping(), {})
+        finally:
+            os.path.dirname = original
+
+
+class TestAbsenceIsInert(unittest.TestCase):
+    def test_without_prowler_every_control_uses_keywords(self):
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = "/nonexistent-dir-for-test"
+        self.addCleanup(os.environ.pop, "CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
+        cm = _load("compliance_map_absent_under_test", "compliance-map.py")
+        result = cm.map_compliance([])
+        sources = {c["match_source"] for controls in result.values() for c in controls}
+        self.assertEqual(sources, {"keyword"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_scan_report_augment.py
+++ b/scanner/tests/test_scan_report_augment.py
@@ -128,6 +128,20 @@ class TestAugmentIsBestEffort(unittest.TestCase):
             _dgen._augment_scan_report(d, {}, {}, {})
             self.assertEqual([f for f in os.listdir(d) if f.endswith(".tmp")], [])
 
+    def test_unwritable_directory_returns_false_and_leaves_no_temp(self):
+        # The `except OSError` arm: the report exists and parses, but the write
+        # fails (read-only dir). A scan that already succeeded must not die here,
+        # and the half-written temp file must not survive to confuse the next run.
+        with tempfile.TemporaryDirectory() as d:
+            path = _write_report(d, '{"passed":1}')
+            os.chmod(d, 0o500)
+            try:
+                self.assertFalse(_dgen._augment_scan_report(d, {}, {}, {}))
+            finally:
+                os.chmod(d, 0o700)
+            self.assertEqual(_read(path), '{"passed":1}')
+            self.assertEqual([f for f in os.listdir(d) if f.endswith(".tmp")], [])
+
     def test_result_is_valid_json_not_a_truncated_write(self):
         # os.replace makes the swap atomic; assert the observable consequence
         # rather than the mechanism.


### PR DESCRIPTION
**41.5% → 100%** reproduction of Prowler's own KISA ISMS-P mapping, and **100%** of its SOC 2 mapping — by reading the requirement→check data Prowler already ships, in the image the scanner already runs.

## The problem

`COMPLIANCE_CONTROL_MAP` assigned findings to controls by substring-matching keywords. Prowler assigns checks to requirements **by intent, as data**. Those are different functions.

On the 16 KISA controls where both have an opinion, the keywords reproduced **237/571 = 41.5%**. `2.9.4` (백업·복구) scored **0 of 58** while listing `backup`, `snapshot` and `restore` — Prowler's 58 backup checks simply contain none of those literal substrings.

Every miss rate and every false positive in this file's history is a symptom of that approximation: `sso` inside "associated", `sast` inside "disaster", `change` at 97.5% wrong, `edr` at 100% wrong.

## What lands

`scanner/lib/prowler_native_map.py` — locate the installed Prowler package, load `compliance/<provider>/<framework>.json`, normalize requirement ids to the repo's control ids, merge across providers.

| framework | controls / checks | id normalization |
|---|---|---|
| KISA ISMS-P | 27 / 1261 | identical |
| ISO 27001:2022 | 58 / 1601 | identical |
| SOC 2 (TSC) | 9 / 442 | `cc_6_1` → `CC6` |
| NIST 800-53 Rev5 | 83 / 881 | `ac_2_1` → `AC-2` |
| PCI-DSS v4.0.1 | 11 / 779 | `1.2.5.1` → `Req 1` |

`map_compliance()` prefers exact check-id membership and falls back to keywords. Each control reports **`match_source`**, so a reader can tell an exact mapping from an approximation — and #446 already publishes compliance into `scan-report.json`, so the ISMS dashboard can surface it.

## The fallback is not dead code

Prowler's data is **sparse**: its KISA file carries 101 requirements, only **26** of which map to any check — governance and process requirements a scanner cannot evidence. Of the repo's 42 KISA controls, 16 get native data and **26 keep keywords**.

> Correction to an earlier note in #450: I wrote "16 of 42 ids align". Wrong — **all 42 align**; only 16 carry checks. Corrected here.

## Verified

```
KISA ISMS-P   573/573 = 100%   (16 prowler-sourced, 26 keyword)
SOC 2 (TSC)   442/442 = 100%   (all 9 CC series prowler-sourced)

2197 passed, coverage 99.09% (floor 99)
```

Two properties are pinned because they are the ones a reader will assume work the old way:

- **Exactness** — a finding stuffed with `mfa`, `encrypt`, `publicly`, `unrestricted` and `0.0.0.0` does **not** match a natively-mapped CC6, because its check id is not in Prowler's list.
- **Absence is inert** — with Prowler missing, every control reports `match_source = keyword` and behaves exactly as before. True of CI, which has no Prowler.

## Incidentally closed

Two pre-existing coverage holes: #445's scan-scope disclosure block was unreachable in the suite (nothing set `CLAUDESEC_SCAN_CATEGORIES`), and #446's `_augment_scan_report` `OSError` arm had no test.

## Follow-up this unblocks

CMMC 2.0 Level 2 — `nist_800_171_revision_2_aws.json` (50 requirements, 94 checks) can now be added as a source entry rather than an eighth hand-written keyword set, which a prototype measured at 34.2% coverage. See `docs/plans/compliance-native-mapping-and-cmmc.md` (#450).

🤖 Generated with [Claude Code](https://claude.com/claude-code)