### PR TITLE
fix(compliance): "vulnerability" never matched "vulnerabilities"

### DIFF
--- a/scanner/lib/compliance-map.py
+++ b/scanner/lib/compliance-map.py
@@ -62,7 +62,7 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "Technical vulnerability management",
             "desc": "Dependency, CVE detection, and patching in place",
             "action": "Dependabot and CVE scanning; patch policy and SBOM.",
-            "checks": ["dependabot", "cve", "vulnerability", "outdated"],
+            "checks": ["dependabot", "cve", "vulnerab", "outdated"],
             "status": "",
         },
     ],
@@ -91,7 +91,7 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "위험 평가 (Risk assessment)",
             "desc": "정보자산에 대한 위험을 평가하고 관리 계획 수립",
             "action": "연간 위험 평가; 위험 수용 기준; 잔여 위험 관리 및 경영진 승인.",
-            "checks": ["vulnerability", "risk", "assessment", "scan"],
+            "checks": ["vulnerab", "risk", "assessment", "scan"],
             "status": "",
         },
         # ── 2. 보호대책 요구사항 ──
@@ -280,7 +280,20 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "패치 관리 (Patch management)",
             "desc": "운영체제, 응용프로그램 보안 패치 적용",
             "action": "Dependabot/CVE 모니터링; 긴급 패치 절차; SBOM 관리.",
-            "checks": ["dependabot", "cve", "vulnerability", "outdated", "patch"],
+            "checks": [
+                "dependabot",
+                "cve",
+                "vulnerab",
+                "outdated",
+                "patch",
+                "latest",
+                "_upgrade",
+                "supported_version",
+                "extended_support",
+                "managed_updates",
+                "deprecated_engine",
+                "system_updates",
+            ],
             "status": "",
         },
         {
@@ -304,7 +317,7 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "취약점 점검 및 조치 (Vulnerability management)",
             "desc": "정기적 취약점 점검 및 조치 이행",
             "action": "분기별 취약점 점검; Prowler/OWASP 스캔; 조치 결과 보고.",
-            "checks": ["vulnerability", "scan", "prowler", "pentest", "assessment"],
+            "checks": ["vulnerab", "scan", "prowler", "pentest", "assessment"],
             "status": "",
         },
         {
@@ -429,7 +442,7 @@ COMPLIANCE_CONTROL_MAP = {
     "KISA ISMS Simple": [
         # governance — no automated NIST 800-53A Test method
         {"control": "S-1.1", "name": "관리체계 기반 마련", "desc": "정보보호 정책 수립 및 경영진 참여", "action": "정보보호 정책 승인; 담당자 지정; 예산 확보.", "checks": ["security_policy", "governance"], "assessable": False, "status": ""},
-        {"control": "S-1.2", "name": "위험 관리", "desc": "자산 식별 및 위험 평가·관리", "action": "자산 목록 관리; 위험 평가; 위험 처리 계획.", "checks": ["inventory", "asset", "vulnerability", "risk"], "status": ""},
+        {"control": "S-1.2", "name": "위험 관리", "desc": "자산 식별 및 위험 평가·관리", "action": "자산 목록 관리; 위험 평가; 위험 처리 계획.", "checks": ["inventory", "asset", "vulnerab", "risk"], "status": ""},
         # governance — no automated NIST 800-53A Test method
         {"control": "S-2.1", "name": "정보보호 정책", "desc": "정보보호 정책 수립·시행·검토", "action": "정책 문서화; 전 직원 숙지; 연 1회 이상 검토.", "checks": ["security_policy", "governance"], "assessable": False, "status": ""},
         {"control": "S-2.2", "name": "인적 보안", "desc": "직무 분리, 보안 서약, 교육", "action": "직무 분리(SoD); 입사/퇴사 절차; 연 1회 보안 교육.", "checks": ["admin", "permission", "training", "account"], "status": ""},
@@ -441,7 +454,7 @@ COMPLIANCE_CONTROL_MAP = {
         {"control": "S-2.8", "name": "시큐어 코딩", "desc": "안전한 소프트웨어 개발", "action": "SAST/CodeQL; 코드 리뷰; OWASP Top 10 대응.", "checks": ["code_scanning", "injection", "codeql"], "status": ""},
         {"control": "S-2.9", "name": "변경 관리", "desc": "시스템 변경 승인·이행·기록", "action": "PR 기반 변경; 변경 이력 추적; 롤백 절차.", "checks": ["review", "_approval", "branch_protection", "codeowners", "status_checks", "force_push", "signed_commits"], "status": ""},
         {"control": "S-2.10", "name": "로그 관리", "desc": "접근·이용 기록 수집·보관", "action": "감사 로그 6개월 보관; CloudTrail 활성화; 무결성 보장.", "checks": ["logging", "audit", "cloudtrail", "retention"], "status": ""},
-        {"control": "S-2.11", "name": "취약점 관리", "desc": "정기 취약점 점검 및 조치", "action": "Prowler/OWASP 스캔; 패치 관리; CVE 모니터링.", "checks": ["vulnerability", "scan", "prowler", "cve", "patch"], "status": ""},
+        {"control": "S-2.11", "name": "취약점 관리", "desc": "정기 취약점 점검 및 조치", "action": "Prowler/OWASP 스캔; 패치 관리; CVE 모니터링.", "checks": ["vulnerab", "scan", "prowler", "cve", "patch", "latest", "_upgrade", "owasp"], "status": ""},
         {"control": "S-2.12", "name": "침해사고 대응", "desc": "사고 탐지·대응·신고·복구", "action": "SIEM 모니터링; 24시간 내 신고(정보통신망법); 대응 플레이북.", "checks": ["monitoring", "alert", "incident", "logging"], "status": ""},
         {"control": "S-2.13", "name": "악성코드 대응", "desc": "악성코드 예방·탐지", "action": "EDR/AV 운영; 실시간 탐지; 격리 및 복구.", "checks": ["malware", "antivirus", "endpoint_protection", "antimalware", "wdatp"], "status": ""},
         {"control": "S-2.14", "name": "백업 및 복구", "desc": "주요 정보 백업 및 복구 절차", "action": "정기 백업; 복구 테스트; 백업 암호화.", "checks": ["backup", "recovery", "snapshot", "restore"], "status": ""},
@@ -484,7 +497,7 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "Secure software development",
             "desc": "Secure SDLC and vulnerability management",
             "action": "SAST and dependency checks; patching and code review.",
-            "checks": ["code_scanning", "injection", "vulnerability"],
+            "checks": ["code_scanning", "injection", "vulnerab"],
             "status": "",
         },
         {
@@ -543,7 +556,7 @@ COMPLIANCE_CONTROL_MAP = {
             # stays assessable: monitoring/scan/vulnerability keywords carry real technical signal; only the strategy-doc half is unverifiable (accepted documented residual)
             "desc": "Develop a continuous monitoring strategy and implement a continuous monitoring program",
             "action": "Deploy SIEM/monitoring tools; continuous vulnerability scanning; automated alerts.",
-            "checks": ["monitoring", "alert", "scan", "vulnerability", "continuous"],
+            "checks": ["monitoring", "alert", "scan", "vulnerab", "continuous"],
             "status": "",
         },
         {
@@ -567,7 +580,7 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "Vulnerability monitoring and scanning",
             "desc": "Monitor and scan for vulnerabilities in the system and hosted applications",
             "action": "Run SAST/DAST scans; dependency vulnerability checks; prioritize by CVSS severity.",
-            "checks": ["vulnerability", "code_scanning", "dependency", "cve"],
+            "checks": ["vulnerab", "code_scanning", "dependency", "cve"],
             "status": "",
         },
         {
@@ -633,7 +646,7 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "Vulnerability management process",
             "desc": "Establish and maintain a vulnerability management process",
             "action": "Automate vulnerability scanning; track remediation SLAs; prioritize critical CVEs.",
-            "checks": ["vulnerability", "scan", "patch", "cve", "remediation"],
+            "checks": ["vulnerab", "scan", "patch", "cve", "remediation"],
             "status": "",
         },
         {
@@ -701,7 +714,7 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "Risk assessment",
             "desc": "Risks to objectives identified and analyzed, including changes and fraud risk",
             "action": "Maintain a risk register; threat model changes; track dependency and CVE exposure with severity ratings.",
-            "checks": ["vulnerability", "dependency", "dependabot", "scan", "cve"],
+            "checks": ["vulnerab", "dependency", "dependabot", "scan", "cve"],
             "status": "",
         },
         {


### PR DESCRIPTION
```python
>>> "vulnerability" in "vulnerabilities"
False
```

They diverge at `-ility` vs `-ities`, so the singular is **not** a substring of the plural — and the plural is the form Prowler actually uses in check ids: `defender_container_images_resolved_vulnerabilities`, `ecr_repositories_scan_vulnerabilities_in_latest_image`.

**Eleven controls across all seven frameworks** carried the singular and were blind to it: ISO A.8.8, PCI Req 6, NIST CA-7 + RA-5, CIS-7.1, SOC 2 CC3, KISA 1.2.2 / 2.10.7 / 2.11.2, KISA Simple S-1.2 / S-2.11.

The stem `vulnerab` matches both forms: corpus-wide coverage **17 → 32** checks.

Guarded — including the substring fact itself, because it is the kind of thing a reader assumes works and does not check — plus a non-vacuity assertion, since *"no control uses the singular"* would also pass if every control had dropped the token entirely.

## 2.10.7 patch management

Prowler ships **no** native mapping for this control (verified against its own `kisa_isms_p_2023_aws.json`), so it stays keyword-driven and the redesign applies.

Coverage of Prowler's `vulnerabilities` category: **16/54 → 35/54**.

Tokens measured individually against the full 1561-check corpus: `latest` (8 TP), `_upgrade` (7), `supported_version`, `extended_support`, `managed_updates`, `deprecated_engine`, `system_updates` (1 each).

**Measured and rejected as too broad** — the same trap as `change` and `edr`:

| rejected | hits | why |
|---|---|---|
| `waf` | 20 | 18 outside the category — WAF-ACL config, not scanning |
| `deprecated` | 7 | 5 are Prowler's own `[DEPRECATED]` check **titles**, meaning the check is retired — a different sense of the word |
| `defender*` | — | any Defender-rooted token pulls in ~15 unrelated checks tagged email-security / identity-access / secrets / container-security |

`S-2.11` gets the same treatment: KISA ISMS Simple is not a framework Prowler ships **at all**, so all 20 of its controls are keyword-only, permanently.

## What was deliberately not changed

`2.11.2` and `2.9.3` both **do** receive native Prowler mappings (3 and 24 checks). A proposed `_alert` addition for 2.9.3, measured at 55.6% → 38.8% miss, was dropped: exact check-id membership supersedes it.

Half of this review's recommendations were superseded by reading the mapping rather than approximating it — which is the argument for #451.

`2173 passed`.

## Coverage note, not diagnosed

This branch measures **98.79%** locally under CI's own invocation (`PYTHONPATH=. pytest --cov=scanner/lib --cov-fail-under=99`) — and so does **unmodified main**, at the identical 43 missing statements. The change is coverage-neutral. The floor is passing in CI while failing locally on the same commit, which is the mirror image of the ADR-guard problem #442 fixed. Worth a look, separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)