### PR TITLE
fix(ci): the 99% coverage floor accepted 98.50% and exited 0

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -322,12 +322,20 @@ jobs:
           # CLOSED (an unset output is `!= '0'`), so a lost GITHUB_OUTPUT write
           # still blocks. What would be silently lost: deleting that final step,
           # which is the ONLY thing turning pytest + the 99% floor into a verdict.
+          # --cov-precision=2 is LOAD-BEARING, not cosmetic. coverage compares the
+          # DISPLAYED percentage, and at the default precision of 0 anything from
+          # 98.50% up prints as "99%" and satisfies --cov-fail-under=99. Measured
+          # 2026-08-14 on main: 98.79% printed "FAIL Required test coverage of 99%
+          # not reached", pytest still exited 0, the re-raise step below saw
+          # test_exit_code=0 and skipped, and the job went green. The floor had
+          # been decorative — its real value was 98.5%.
           set +e
           python3 -m pytest scanner/tests/ \
             --junitxml=test-reports/pytest-junit.xml \
             --cov=scanner/lib \
             --cov-report=term \
             --cov-report=xml:test-reports/coverage.xml \
+            --cov-precision=2 \
             --cov-fail-under=99 \
             -q
           test_exit_code=$?

--- a/scanner/tests/test_ci_coverage_thresholds.py
+++ b/scanner/tests/test_ci_coverage_thresholds.py
@@ -67,6 +67,36 @@ class TestCiCoverageThresholds(unittest.TestCase):
             f"CI workflow not found at {LINT_YML} — path assumption broke",
         )
 
+    def test_python_cov_precision_makes_the_floor_real(self):
+        """`--cov-fail-under=99` alone enforces 98.5%, not 99%.
+
+        coverage compares the DISPLAYED percentage, and at the default precision
+        of 0 anything from 98.50% up prints as "99%" and satisfies the flag.
+        Measured 2026-08-14 on main: 98.79% printed "FAIL Required test coverage
+        of 99% not reached", pytest STILL EXITED 0, the re-raise step saw
+        test_exit_code=0 and skipped, and the job went green.
+
+        This guard's sibling above pins the NUMBER. That was not enough — the
+        number was right and inert for as long as it has existed. This pins the
+        thing that makes the number mean something.
+        """
+        self.assertIn(
+            "--cov-precision=2",
+            self.text,
+            "lint.yml sets --cov-fail-under without --cov-precision. At the "
+            "default precision the floor rounds, so a 99 floor accepts 98.50% "
+            "and pytest exits 0 while printing FAIL.",
+        )
+
+    def test_precision_is_at_least_as_fine_as_the_floor_implies(self):
+        # precision=1 would still accept 98.95%. Two decimals is what makes a
+        # whole-number floor exact.
+        matches = [int(m) for m in re.findall(r"--cov-precision=(\d+)", self.text)]
+        self.assertTrue(matches, "no --cov-precision=N found")
+        self.assertGreaterEqual(
+            min(matches), 2, f"--cov-precision lowered to {min(matches)}"
+        )
+
     def test_python_cov_fail_under_present_and_not_lowered(self):
         matches = [int(m) for m in re.findall(r"--cov-fail-under=(\d+)", self.text)]
         self.assertTrue(

--- a/scanner/tests/test_lib_import_bootstrap.py
+++ b/scanner/tests/test_lib_import_bootstrap.py
@@ -1,0 +1,101 @@
+"""
+Exercise the sibling-import bootstrap every `scanner/lib` module carries.
+
+    _LIB_DIR = os.path.dirname(os.path.abspath(__file__))
+    if _LIB_DIR not in sys.path:
+        sys.path.insert(0, _LIB_DIR)
+
+That `insert` is real production code — it is what lets `output.sh` load these
+modules via importlib in a fresh interpreter, where `scanner/lib` is not on the
+path. Under pytest it never ran: the first test to import anything from
+`scanner/lib` puts the directory on `sys.path`, and every module loaded
+afterwards takes the `if` as false.
+
+Nine modules were each missing exactly that one line, which is most of the gap
+between the measured 98.79% and the documented 99% floor. Marking them
+`# pragma: no cover` would have been a fudge — the line executes in production.
+So this drops the directory from `sys.path`, re-imports each module fresh, and
+lets the branch run for real.
+
+The path is restored afterwards, because leaving `scanner/lib` off `sys.path`
+would break every later test that imports a sibling by bare name.
+"""
+
+import importlib.util
+import os
+import sys
+import unittest
+
+_LIB = os.path.normpath(os.path.join(os.path.dirname(__file__), "..", "lib"))
+
+# Every module carrying the bootstrap. Kept explicit rather than globbed: a new
+# module that adds the bootstrap should be a visible line in this list, and a
+# glob would silently pick up modules that make network calls on import.
+BOOTSTRAP_MODULES = [
+    "dashboard_html_arch.py",
+    "dashboard_html_audit_points.py",
+    "dashboard_html_audit_sources.py",
+    "dashboard_html_builders.py",
+    "dashboard_html_compliance.py",
+    "dashboard_html_helpers.py",
+    "dashboard_html_network.py",
+    "dashboard_html_owasp.py",
+    "dashboard_html_sections.py",
+]
+
+
+class TestSiblingImportBootstrap(unittest.TestCase):
+    def setUp(self):
+        self._saved = list(sys.path)
+        self.addCleanup(self._restore)
+
+    def _restore(self):
+        sys.path[:] = self._saved
+
+    def _import_fresh(self, filename):
+        name = "bootstrap_probe_" + filename.replace(".py", "")
+        spec = importlib.util.spec_from_file_location(
+            name, os.path.join(_LIB, filename)
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    def test_each_module_puts_its_own_directory_on_the_path(self):
+        for filename in BOOTSTRAP_MODULES:
+            with self.subTest(module=filename):
+                # Drop every spelling of the lib dir, so the guard's `not in`
+                # is genuinely true and the insert executes.
+                sys.path[:] = [
+                    p for p in sys.path if os.path.normpath(p) != _LIB
+                ]
+                self.assertNotIn(_LIB, [os.path.normpath(p) for p in sys.path])
+                self._import_fresh(filename)
+                self.assertIn(
+                    _LIB,
+                    [os.path.normpath(p) for p in sys.path],
+                    f"{filename} did not add its own directory to sys.path — "
+                    "loading it from output.sh in a fresh interpreter would fail "
+                    "on the first sibling import.",
+                )
+
+    def test_bootstrap_is_idempotent(self):
+        # The guard exists so a repeated import does not grow sys.path without
+        # bound. Importing twice with the directory already present must not
+        # add a second copy.
+        before = [os.path.normpath(p) for p in sys.path].count(_LIB)
+        self._import_fresh(BOOTSTRAP_MODULES[0])
+        self._import_fresh(BOOTSTRAP_MODULES[0])
+        after = [os.path.normpath(p) for p in sys.path].count(_LIB)
+        self.assertLessEqual(after, max(before, 1))
+
+    def test_the_list_is_not_stale(self):
+        # Non-vacuity: if a module were renamed away, the loop above would
+        # silently test fewer things.
+        for filename in BOOTSTRAP_MODULES:
+            with self.subTest(module=filename):
+                self.assertTrue(os.path.isfile(os.path.join(_LIB, filename)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
```console
TOTAL                    3544   43   99%
FAIL Required test coverage of 99% not reached. Total coverage: 98.79%
$ echo $?
0
```

Both lines are from the **same run**. `coverage` compares the *displayed* percentage, and at the default precision of `0` anything from **98.50%** up prints as `99%` and satisfies `--cov-fail-under=99`. pytest printed the failure and exited 0 anyway.

## The consequence, on main, in CI, on every run

```
"Run scanner pytest + coverage gate (>=99%)"        success
"Fail workflow on scanner unittest / coverage..."   SKIPPED
```

The re-raise step is conditioned on `test_exit_code != '0'`. It never fired because **pytest never reported a failure**. That step's own comment says it *"is the only thing enforcing pytest + the 99% floor here"* — it does enforce the pytest half (verified on #448, where a real test failure did turn the job red), and it has **never once** seen the coverage half.

So the floor's real value has been **98.5%** for as long as it has existed, and main has been sitting at 98.79% — below its own documented floor — invisibly.

> I previously reported this as a local-vs-CI discrepancy. **It is not one.** CI prints the identical `3544 / 43 / 98.79%` and also fails to act on it. Corrected here and in #452's description.

## Fix

`--cov-precision=2` in `lint.yml`. With it, `98.79 < 99.00` is compared as written and pytest exits 1.

`test_ci_coverage_thresholds.py` already pinned the **number** (`>= 99`) and had never noticed the number was inert. It now also pins the precision — and pins that precision cannot be lowered to `1`, which would still accept 98.95%.

## And the 9 lines that were missing

Turning the floor on fails at 98.79%, so the gap had to close.

Nine `scanner/lib` modules were each missing **exactly one line** — the `sys.path.insert(0, _LIB_DIR)` in their sibling-import bootstrap. That line is real production code: it is what lets `output.sh` load them via importlib in a fresh interpreter. It never ran under pytest because the first test to import anything from `scanner/lib` puts the directory on `sys.path`, and every module loaded after takes the guard as false.

`# pragma: no cover` would have been a fudge on code that executes in production. `test_lib_import_bootstrap.py` drops the directory from `sys.path`, re-imports each module fresh, lets the branch run for real — and asserts the module actually put its own directory back, which is the behaviour `output.sh` depends on.

```
before: 3544 statements, 43 missing, 98.79%  -> exit 0 (floor inert)
after : 3544 statements, 34 missing, 99.04%  -> exit 0 (floor enforcing)
```

`2178 passed`.

## Why this matters beyond the number

This is the same shape as three other things found this week: a guard that reads green while doing nothing. `paths-ignore` hiding required checks, the `|| schedule` arm that could never evaluate, `test_scan_report_baseline` skipping itself forever, and now a coverage floor defeated by rounding. Each pinned the artifact and not the effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)