### PR TITLE
fix(compliance): a control failing on 88 hits, none of them real

### DIFF
--- a/scanner/lib/compliance-map.py
+++ b/scanner/lib/compliance-map.py
@@ -208,7 +208,13 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "보안 요구사항 정의 (Security requirements)",
             "desc": "정보시스템 도입·개발 시 보안 요구사항 명세",
             "action": "보안 요구사항 체크리스트; 위협 모델링; 보안 설계 검토.",
-            "checks": ["security_policy", "requirement", "design"],
+            # SDLC security-requirements documentation — structurally the same
+            # governance control as 1.1.1 / 2.1.1 / 2.2.4, which are already
+            # carved out. Measured: 23 corpus hits, ~0 relevant. `design` is 6/7
+            # "designated"/"by design" (a homonym, same class as sso/associated)
+            # and `requirement` is 15/15 generic "requires X" policy phrasing.
+            "checks": ["security_policy", "requirement"],
+            "assessable": False,
             "status": "",
         },
         {
@@ -325,7 +331,7 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "사고 분석 및 공유 (Post-incident analysis)",
             "desc": "침해사고 원인 분석 및 재발 방지 대책 수립",
             "action": "사고 보고서 작성; 원인 분석; 재발 방지 대책; 교훈 공유.",
-            "checks": ["incident", "post_mortem", "analysis"],
+            "checks": ["incident", "ssmincidents", "detection"],
             "status": "",
         },
         {
@@ -445,7 +451,7 @@ COMPLIANCE_CONTROL_MAP = {
         {"control": "S-1.2", "name": "위험 관리", "desc": "자산 식별 및 위험 평가·관리", "action": "자산 목록 관리; 위험 평가; 위험 처리 계획.", "checks": ["inventory", "asset", "vulnerab", "risk"], "status": ""},
         # governance — no automated NIST 800-53A Test method
         {"control": "S-2.1", "name": "정보보호 정책", "desc": "정보보호 정책 수립·시행·검토", "action": "정책 문서화; 전 직원 숙지; 연 1회 이상 검토.", "checks": ["security_policy", "governance"], "assessable": False, "status": ""},
-        {"control": "S-2.2", "name": "인적 보안", "desc": "직무 분리, 보안 서약, 교육", "action": "직무 분리(SoD); 입사/퇴사 절차; 연 1회 보안 교육.", "checks": ["admin", "permission", "training", "account"], "status": ""},
+        {"control": "S-2.2", "name": "인적 보안", "desc": "직무 분리, 보안 서약, 교육", "action": "직무 분리(SoD); 입사/퇴사 절차; 연 1회 보안 교육.", "checks": ["admin", "permission", "account"], "status": ""},
         {"control": "S-2.3", "name": "외부자 보안", "desc": "외부자(위탁, 협력사) 보안 관리", "action": "위탁 계약 시 보안 요구사항; 접근 통제; 주기적 점검.", "checks": ["third_party", "vendor", "external"], "status": ""},
         {"control": "S-2.4", "name": "사용자 인증 관리", "desc": "계정·비밀번호·인증 관리", "action": "MFA 적용; 비밀번호 복잡도; 미사용 계정 비활성화.", "checks": ["mfa", "authentication", "password", "account", "_sso"], "status": ""},
         {"control": "S-2.5", "name": "접근권한 관리", "desc": "최소 권한 부여 및 주기적 검토", "action": "RBAC; 권한 검토; 퇴직자 즉시 회수.", "checks": ["branch_protection", "access", "permission", "restrict", "rbac"], "status": ""},
@@ -678,7 +684,15 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "ArgoCD RBAC and security configuration",
             "desc": "Verify ArgoCD RBAC policies, SSO integration, and project-level access restrictions",
             "action": "Enforce ArgoCD RBAC with least privilege; enable SSO; restrict project sources and destinations; disable anonymous access.",
-            "checks": ["argocd", "argo", "gitops", "rbac", "_sso", "project"],
+            # Prowler 5.38 ships NO ArgoCD provider — measured across all 1561
+            # checks. So `argocd`/`argo`/`gitops` have zero corpus hits, and the
+            # three survivors (`rbac`, `_sso`, `project`) matched 88 checks with
+            # ZERO true positives: Vercel `project_*`, GCP `compute_project_*`,
+            # Azure Key Vault RBAC, AWS CodeBuild projects. A control deciding
+            # PASS/FAIL on 100% wrong evidence is worse than one with none, so
+            # it renders N/A until something can actually scan ArgoCD.
+            "checks": ["argocd", "argo", "gitops"],
+            "assessable": False,
             "status": "",
         },
     ],

--- a/scanner/lib/prowler_native_map.py
+++ b/scanner/lib/prowler_native_map.py
@@ -110,6 +110,18 @@ FRAMEWORK_SOURCES = {
     "SOC 2 (TSC)": ("soc2_*.json", _soc2_series),
     "NIST 800-53 Rev5": ("nist_800_53_revision_5_*.json", _nist_control),
     "PCI-DSS v4.0.1": ("pci_4.0_*.json", _pci_requirement),
+    # DELIBERATELY ABSENT: "CIS Benchmarks".
+    #
+    # Prowler ships 34 `cis_*.json` files with real check arrays, so wiring this
+    # in looks like a one-line win. It is not. The repo's CIS control ids are a
+    # hand-rolled scheme that matches no real CIS Controls version: `CIS-6.1`
+    # here is "Audit log management", which in CIS Controls v8 is Safeguard
+    # **8.1** — v8's 6.1 is "Establish an Access Granting Process". An identity
+    # normalizer would therefore attach real checks to the WRONG controls
+    # silently, which is worse than the keyword approximation it replaced.
+    #
+    # Adding CIS needs a control-id remap pass first, done against a named CIS
+    # Controls version. See docs/plans/compliance-native-mapping-and-cmmc.md.
 }
 
 

--- a/scanner/tests/test_ci_compliance_keyword_guard.py
+++ b/scanner/tests/test_ci_compliance_keyword_guard.py
@@ -97,6 +97,12 @@ BENIGN_WORDS = [
     # extend it whenever a real corpus turns up a new collision.
     "associated",
     "disaster",
+    # 2026-08-18: `review` is embedded in Vercel "preview deployment" checks —
+    # 4 of its 51 corpus hits. Far smaller than sso/associated (70/74), and
+    # `review` is still carrying real signal, so this is registered to keep the
+    # token honest rather than to force its removal: if someone later shortens
+    # `review`, the collision surfaces instead of quietly widening.
+    "preview",
 ]
 
 # Intentional short acronyms that are ALLOWED to be a proper substring of a
@@ -105,7 +111,16 @@ BENIGN_WORDS = [
 # BENIGN_WORDS entry. Kept as an explicit hook so a future benign-word addition
 # that legitimately collides has a documented place to be recorded.
 ALLOWLIST = {
-    # token: reason  (currently none needed)
+    # `review` is a proper substring of "preview", but only 4 of its 51 real
+    # corpus hits are Vercel preview-deployment checks — 8%, against 70/74 for
+    # `sso`/"associated" and 308/316 for `change`. It carries real
+    # code-review signal for KISA 2.9.1 / S-2.9, so removing it would cost more
+    # than the noise it admits. Recorded here rather than dropped, which is what
+    # this hook exists for; `preview` stays in BENIGN_WORDS so that shortening
+    # `review` to anything narrower surfaces the collision instead of widening
+    # it quietly.
+    "review": "8% collision with 'preview' (4/51), measured 2026-08-18; "
+    "the other 47 hits are genuine code-review signal",
 }
 
 

--- a/scanner/tests/test_compliance_map.py
+++ b/scanner/tests/test_compliance_map.py
@@ -194,11 +194,20 @@ class TestMapCompliance(unittest.TestCase):
         self.assertEqual(pci["Req 1"]["status"], "FAIL")
         self.assertEqual(nist["SC-8"]["status"], "FAIL")
 
-    def test_argocd_rbac_triggers_cis_k8s_argocd(self):
+    def test_argocd_finding_is_recorded_but_control_stays_na(self):
+        """CIS-K8s-ArgoCD renders N/A: Prowler ships no ArgoCD provider.
+
+        Measured against the real 5.38 catalog, this control had 88 hits and
+        ZERO true positives — its `argocd`/`argo`/`gitops` tokens match nothing
+        in the corpus, and the `rbac`/`_sso`/`project` tokens it used to carry
+        matched Vercel/GCP/Azure text instead. A synthetic ArgoCD finding still
+        matches its keywords and is still recorded as evidence for a human, but
+        the control no longer claims a PASS/FAIL it cannot support.
+        """
         findings = [_make_finding(check="argocd_rbac", title="ArgoCD default admin", message="ArgoCD RBAC allows admin to all projects")]
         result = map_compliance(findings)
         cis_controls = {c["control"]: c for c in result["CIS Benchmarks"]}
-        self.assertEqual(cis_controls["CIS-K8s-ArgoCD"]["status"], "FAIL")
+        self.assertEqual(cis_controls["CIS-K8s-ArgoCD"]["status"], "N/A")
         self.assertGreaterEqual(cis_controls["CIS-K8s-ArgoCD"]["count"], 1)
 
     def test_result_preserves_control_metadata(self):

--- a/scanner/tests/test_compliance_map_ismsp_na.py
+++ b/scanner/tests/test_compliance_map_ismsp_na.py
@@ -48,7 +48,9 @@ ISMSP_PII_CONTROL_IDS = {
 # Frameworks absent from this dict MUST have zero non-assessable controls.
 EXPECTED_NON_ASSESSABLE = {
     # 11 PII 3.x controls + management commitment, policy management, awareness.
-    "KISA ISMS-P": ISMSP_PII_CONTROL_IDS | {"1.1.1", "2.1.1", "2.2.4"},
+    # 2.8.1 (SDLC security requirements) joins the governance set on measurement:
+    # 23 corpus hits, ~0 relevant — `design` is 6/7 "designated"/"by design".
+    "KISA ISMS-P": ISMSP_PII_CONTROL_IDS | {"1.1.1", "2.1.1", "2.2.4", "2.8.1"},
     # governance/policy + PII/legal.
     "KISA ISMS Simple": {"S-1.1", "S-2.1", "S-3.1", "S-3.2", "S-3.3", "S-3.4"},
     # the sole Organizational-theme ISO control (all others are A.8 Technological).
@@ -57,6 +59,12 @@ EXPECTED_NON_ASSESSABLE = {
     # (CC2), and vendor/business-partner risk mitigation (CC9) are assessed by an
     # auditor from evidence a scanner cannot produce.
     "SOC 2 (TSC)": {"CC1", "CC2", "CC9"},
+    # Not governance — UNSCANNABLE. Prowler 5.38 ships no ArgoCD provider at all,
+    # so this control had 88 corpus hits and ZERO true positives: its three intent
+    # tokens are dead and the survivors matched Vercel/GCP/Azure "project" and
+    # "rbac" text. Deciding PASS/FAIL on 100% wrong evidence is worse than
+    # deciding nothing. Revisit if Prowler adds ArgoCD checks.
+    "CIS Benchmarks": {"CIS-K8s-ArgoCD"},
 }
 
 # Tokens verified 0-emission across `scanner/checks/**`.
@@ -253,8 +261,10 @@ class TestComplianceSummaryExcludesNa(unittest.TestCase):
         total_controls = len(COMPLIANCE_CONTROL_MAP["KISA ISMS-P"])
         self.assertEqual(stats["total"], total_controls - stats["na"])
         self.assertEqual(total_controls, 42)
-        self.assertEqual(stats["na"], 14)
-        self.assertEqual(stats["total"], 28)
+        # 15, not 14: 2.8.1 (SDLC security requirements) joined the governance
+        # carve-out on measurement — 23 corpus hits, ~0 relevant.
+        self.assertEqual(stats["na"], 15)
+        self.assertEqual(stats["total"], 27)
 
     def test_totals_are_allowlist_aware_for_every_framework(self):
         summary = compliance_summary(map_compliance([]))


### PR DESCRIPTION
With #451 merged, **three frameworks (PCI, NIST, SOC 2) are now 100% exact** and have no keyword controls left at all. The residual population is **56 of 104 controls, 36 assessable** — and measuring only those, rather than averaging across frameworks that no longer guess, surfaced two controls deciding PASS/FAIL on evidence that is **100% wrong**.

| framework | total | native (exact) | residual keyword |
|---|---|---|---|
| PCI-DSS v4.0.1 | 7 | 7 | **0** |
| NIST 800-53 Rev5 | 10 | 10 | **0** |
| SOC 2 (TSC) | 9 | 9 | **0** |
| ISO 27001:2022 | 7 | 6 | 1 |
| KISA ISMS-P | 42 | 16 | 26 |
| KISA ISMS Simple | 20 | 0 | 20 |
| CIS Benchmarks | 9 | 0 | 9 |

## `CIS-K8s-ArgoCD` → N/A

**Prowler 5.38 ships no ArgoCD provider.** Measured across all 1561 checks: `argocd`, `argo` and `gitops` have **zero hits each**.

The control was surviving entirely on `rbac`, `_sso` and `project`, which matched **88 checks with zero true positives** — Vercel `project_*`, GCP `compute_project_*`, Azure Key Vault RBAC, AWS CodeBuild projects.

A control reporting PASS/FAIL from 100% wrong evidence is worse than one reporting nothing, because `count: 0` is at least visibly empty. Revisit if Prowler adds ArgoCD checks.

## `KISA 2.8.1` → N/A

SDLC security-requirements documentation — structurally identical to 1.1.1 / 2.1.1 / 2.2.4, which were already carved out. It just wasn't.

Measured: 23 hits, ~0 relevant. `design` is **6/7** "designated" / "by design" (a homonym, same class as `sso`/"associated"); `requirement` is **15/15** generic "requires X" password-policy phrasing.

## Dead tokens dropped

| control | token | measurement |
|---|---|---|
| S-2.2 | `training` | **0/4** — every hit is `sagemaker_training_jobs_*`, ML model training, not employee security-awareness training |
| 2.11.5 | `post_mortem` | 0 hits |
| 2.11.5 | `analysis` | **0/10** relevant — product names: "Container Analysis API", "Access Analyzer" |

2.11.5 gets `ssmincidents` + `detection` instead, which are real.

## `review` inside "preview"

A third collision of the `sso`/`sast` class — but only **4 of 51 hits (8%)**, against 70/74 for `sso` and 308/316 for `change`. `review` carries real code-review signal, so removing it costs more than the noise it admits.

`preview` goes into `BENIGN_WORDS` and `review` into `ALLOWLIST` **with the measurement** — which is what that hook exists for. Shortening `review` later now surfaces the collision instead of widening it quietly.

## CIS is deliberately NOT wired into the native loader

Prowler ships 34 `cis_*.json` files with real check arrays, so adding `"CIS Benchmarks"` to `FRAMEWORK_SOURCES` looks like a one-line win.

**It is not.** The repo's CIS ids are a hand-rolled scheme matching no real CIS Controls version: `CIS-6.1` here is *"Audit log management"*, which in CIS Controls v8 is Safeguard **8.1** — v8's 6.1 is *"Establish an Access Granting Process"*. An identity normalizer would attach real checks to the **wrong** controls silently, worse than the keyword approximation it replaced.

Recorded as a comment at the exact site someone would edit.

## Verification

`2202 passed`, coverage **99.34%** under the now-enforcing floor from #453.

Two existing assertions were updated rather than deleted, with the reason inline: `test_argocd_rbac_triggers_cis_k8s_argocd` now asserts the finding is still **recorded as evidence** while the control stays N/A, and the ISMS-P N/A count moves 14 → 15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)