### PR TITLE
feat(compliance): CMMC scored 9/9 on an estate it had never looked at

### DIFF
--- a/docs/guides/compliance-mapping.md
+++ b/docs/guides/compliance-mapping.md
@@ -20,6 +20,7 @@ This guide maps ClaudeSec security controls to major compliance frameworks, help
 | **GDPR** | EU personal data | Mandatory (EU) | Any org handling EU data |
 | **HIPAA** | Health information | Mandatory (US healthcare) | Healthcare, Healthtech |
 | **KISA ISMS-P** | Information security (Korea) | Mandatory (Korea, conditions) | Korean organizations |
+| **CMMC 2.0 Level 2** | Controlled unclassified information (CUI) | Mandatory (US DoD contracts handling CUI) | Defense industrial base |
 
 ---
 
@@ -112,6 +113,58 @@ series FAIL. The framework is therefore registered as `SOC 2 (TSC)`, which does
 not substring-match Prowler's bare `SOC2` key, keeping per-criterion signal
 intact. Renaming it would silently change that behavior; a regression test pins
 it.
+
+---
+
+## CMMC 2.0 Level 2 domain coverage
+
+CMMC 2.0 Level 2's 110 practices are NIST SP 800-171 Rev. 2's requirements
+verbatim ([NIST SP 800-171 Rev. 2][sp800-171], incorporated by the CMMC program
+rule at 32 CFR Part 170), so ClaudeSec maps the framework from
+Prowler's `nist_800_171_revision_2_aws.json` rather than a CMMC-specific file.
+Controls are rendered per **domain** (800-171 requirement family), not per
+practice: Prowler's file carries 50 of the 110 requirements, so a
+practice-level table would be 60 rows of "no data".
+
+Measured against the pinned Prowler 5.30.1 file — 50 requirements, 49 with
+checks, 87 distinct checks:
+
+| Domain | 800-171 family | Mapped checks |
+|--------|----------------|---------------|
+| SC — System and Communications Protection | 3.13 | 50 |
+| AC — Access Control | 3.1 | 43 |
+| AU — Audit and Accountability | 3.3 | 21 |
+| CM — Configuration Management | 3.4 | 21 |
+| IA — Identification and Authentication | 3.5 | 21 |
+| IR — Incident Response | 3.6 | 14 |
+| SI — System and Information Integrity | 3.14 | 13 |
+| CA — Security Assessment | 3.12 | 9 |
+| RA — Risk Assessment | 3.11 | 3 |
+| AT, MA, MP, PE, PS | 3.2, 3.7, 3.8, 3.9, 3.10 | **none** |
+
+**These controls carry no keywords, deliberately.** Every other framework in
+`COMPLIANCE_CONTROL_MAP` falls back to substring matching when Prowler ships no
+mapping. CMMC does not: a prototype keyword set built from the vocabulary of the
+target checks themselves measured 34.2% coverage (CM 1/22, SI 1/13), so keywords
+here would manufacture wrong answers rather than approximate right ones. The
+controls are tagged `native_only`, and a `native_only` control with no Prowler
+mapping reports **N/A** (`match_source: "unmapped"`) instead of taking the
+`count == 0 → PASS` default — a domain that was never evaluated must not read as
+compliant. That is why AT/MA/MP/PE/PS are always N/A today.
+
+**Coverage limit: AWS only.** Prowler ships 800-171 for AWS and no other
+provider, and the mapping is read from the installed Prowler package rather
+than from the scan — so on a Kubernetes-only run it stays fully populated with
+AWS check ids, matches nothing, and would otherwise score all nine mapped
+domains PASS on zero evidence. The framework is therefore scoped to the `aws`
+provider: a run that did not scan AWS reports **every** domain N/A, and the
+dashboard states the limit under the framework heading.
+
+The same false-PASS exists today for **NIST 800-53 Rev5**, which is also
+AWS-only in Prowler. It is left unscoped for now because changing it is a
+separate, separately-measured behaviour change.
+
+[sp800-171]: https://csrc.nist.gov/pubs/sp/800/171/r2/upd1/final
 
 ---
 

--- a/docs/plans/compliance-native-mapping-and-cmmc.md
+++ b/docs/plans/compliance-native-mapping-and-cmmc.md
@@ -80,6 +80,24 @@ mapping for KISA ISMS-P and SOC 2, versus 41.5% today.
 
 ### Phase 2 — CMMC 2.0 Level 2 on that foundation
 
+**Status: landed.** `CMMC 2.0 Level 2` is registered in `FRAMEWORK_SOURCES` and
+renders 14 domain controls, all `native_only` with empty keyword lists. Two
+corrections to what is written below, both from re-measuring against the pinned
+Prowler **5.30.1** rather than the 5.38 used for the original survey:
+
+- Prowler writes 800-171 requirement ids with **underscores** (`3_13_5`), not
+  the dotted form the standard prints. The normalizer accepts both.
+- 5.30.1 carries 50 requirements / 49 with checks / **87** distinct checks, and
+  the per-family counts differ slightly: SC 50 (not 52), IA 21 (not 25), CM 21
+  (not 22), AU 21, AC 43, IR 14, SI 13, CA 9, RA 3. The nine-domain shape and
+  the five empty domains (AT/MA/MP/PE/PS) are unchanged.
+
+The "do not hand-write keywords" instruction was followed literally: a
+`native_only` control skips the keyword branch entirely and reports N/A
+(`match_source: "unmapped"`) when Prowler ships no mapping, rather than falling
+through to the `count == 0 → PASS` default. The AWS-only caveat is rendered in
+the dashboard under the framework heading.
+
 CMMC 2.0 Level 2's 110 practices are drawn directly from NIST SP 800-171, so
 `nist_800_171_revision_2_aws.json` is the mapping basis. It carries 50 requirements
 over 94 distinct checks, grouped by 800-171 family:

--- a/scanner/lib/compliance-map.py
+++ b/scanner/lib/compliance-map.py
@@ -823,6 +823,157 @@ COMPLIANCE_CONTROL_MAP = {
             "status": "",
         },
     ],
+    # CMMC 2.0 Level 2, mapped at DOMAIN granularity (14 domains, not the 110
+    # individual practices) because that is the granularity Prowler's evidence
+    # supports: its `nist_800_171_revision_2_aws.json` carries 50 of the 110
+    # requirements, so a practice-level table would be 60 rows of "no data".
+    #
+    # Every control here is `native_only` with an EMPTY keyword list. That is
+    # deliberate and is the whole point of the framework's design: a prototype
+    # keyword set built from the vocabulary of the target checks themselves
+    # measured 34.2% coverage (CM 1/22, SI 1/13 — denominators from the Prowler
+    # 5.38 survey in the plan doc, not the 5.30.1 counts below), so keywords
+    # here would manufacture wrong answers rather than approximate right ones.
+    # With no Prowler mapping loaded, these report N/A — never PASS.
+    #
+    # COVERAGE LIMIT: Prowler ships 800-171 for AWS ONLY, and the mapping is
+    # loaded from the installed package rather than from the scan — so on a
+    # Kubernetes-only run it stays populated with AWS check ids, matches
+    # nothing, and would score all nine mapped domains PASS on no evidence.
+    # `prowler_native_map.FRAMEWORK_NATIVE_PROVIDERS` scopes the source to aws
+    # so those domains report N/A instead; the limit is also stated in the
+    # dashboard under the framework heading (COMP_FW_NOTES).
+    #
+    # Source: CMMC 2.0 Level 2 = NIST SP 800-171 Rev. 2 (32 CFR Part 170);
+    # domain codes per NIST SP 800-171 Rev. 2 requirement families 3.1–3.14.
+    "CMMC 2.0 Level 2": [
+        {
+            "control": "AC",
+            "name": "Access Control (800-171 §3.1)",
+            "desc": "Limit system access to authorized users, processes, and devices, and to the transactions they are permitted to execute",
+            "action": "Enforce least-privilege IAM, remove wildcard and unused permissions, and restrict public network exposure of data stores.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "AT",
+            "name": "Awareness and Training (800-171 §3.2)",
+            "desc": "Ensure personnel are aware of security risks and trained to carry out their assigned security duties",
+            "action": "Run role-based security awareness and insider-threat training; retain completion records for assessment.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "AU",
+            "name": "Audit and Accountability (800-171 §3.3)",
+            "desc": "Create, protect, and retain audit records sufficient to trace unlawful or unauthorized system activity",
+            "action": "Enable and centralize provider audit logs, protect them from modification, and set retention to the contractual period.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "CM",
+            "name": "Configuration Management (800-171 §3.4)",
+            "desc": "Establish and maintain baseline configurations and enforce security configuration settings",
+            "action": "Track a baseline inventory, block drift from it, and disable nonessential programs, ports, and services.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "IA",
+            "name": "Identification and Authentication (800-171 §3.5)",
+            "desc": "Identify users, processes, and devices and authenticate them as a prerequisite to system access",
+            "action": "Require MFA for privileged and network access; rotate or eliminate long-lived static credentials.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "IR",
+            "name": "Incident Response (800-171 §3.6)",
+            "desc": "Establish an operational incident-handling capability and track, document, and report incidents",
+            "action": "Wire detection findings into an on-call channel and exercise the reporting path against the contractual deadline.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "MA",
+            "name": "Maintenance (800-171 §3.7)",
+            "desc": "Perform maintenance on systems and control the tools, techniques, mechanisms, and personnel used",
+            "action": "Approve and log maintenance access, and require MFA plus session termination for remote maintenance.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "MP",
+            "name": "Media Protection (800-171 §3.8)",
+            "desc": "Protect, control, and sanitize system media containing controlled unclassified information",
+            "action": "Encrypt media at rest, control removable media, and sanitize or destroy media before disposal or reuse.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "PS",
+            "name": "Personnel Security (800-171 §3.9)",
+            "desc": "Screen individuals prior to authorizing access, and protect systems during personnel transfer and termination",
+            "action": "Screen before granting access and revoke all credentials as part of the offboarding checklist.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "PE",
+            "name": "Physical Protection (800-171 §3.10)",
+            "desc": "Limit physical access to systems, equipment, and the operating environments they reside in",
+            "action": "Rely on the provider's audited facility controls and apply equivalent controls to any self-managed site.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "RA",
+            "name": "Risk Assessment (800-171 §3.11)",
+            "desc": "Periodically assess risk, scan for vulnerabilities, and remediate in accordance with the assessment",
+            "action": "Run recurring vulnerability scans and remediate on a documented, risk-ranked schedule.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "CA",
+            "name": "Security Assessment (800-171 §3.12)",
+            "desc": "Assess security controls periodically, remediate deficiencies, and monitor controls on an ongoing basis",
+            "action": "Keep a system security plan and POA&M current, and monitor controls continuously rather than at audit time.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "SC",
+            "name": "System and Communications Protection (800-171 §3.13)",
+            "desc": "Monitor, control, and protect communications at external and key internal system boundaries",
+            "action": "Terminate TLS with current ciphers, encrypt data at rest, and segment boundaries away from default-open access.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+        {
+            "control": "SI",
+            "name": "System and Information Integrity (800-171 §3.14)",
+            "desc": "Identify, report, and correct system flaws, and provide protection from malicious code",
+            "action": "Patch on a defined timeline, enable provider threat detection, and monitor for malicious code and unauthorized change.",
+            "checks": [],
+            "native_only": True,
+            "status": "",
+        },
+    ],
 }
 
 
@@ -844,36 +995,68 @@ def _match_prowler_compliance(finding, framework_key):
 
 
 _NATIVE_CACHE = None
+_NATIVE_PROVIDER_SCOPE = None
 
 
-def _native_mapping():
-    """Prowler's own requirement->check data, loaded once. `{}` when unavailable.
+def _load_native_module():
+    """Import the sibling `prowler_native_map.py`, or None when unavailable.
 
     Import is deferred and failure is swallowed on purpose: compliance-map.py is
     loaded by output.sh via importlib in a bare scan, where a missing sibling or
     a missing Prowler install must not break the run.
     """
-    global _NATIVE_CACHE
-    if _NATIVE_CACHE is None:
-        try:
-            import importlib.util
-            import os
+    try:
+        import importlib.util
+        import os
 
-            spec = importlib.util.spec_from_file_location(
-                "prowler_native_map",
-                os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)), "prowler_native_map.py"
-                ),
-            )
-            module = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(module)
-            _NATIVE_CACHE = module.load_all()
+        spec = importlib.util.spec_from_file_location(
+            "prowler_native_map",
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)), "prowler_native_map.py"
+            ),
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    except Exception:
+        return None
+
+
+def _native_mapping():
+    """Prowler's own requirement->check data, loaded once. `{}` when unavailable."""
+    global _NATIVE_CACHE, _NATIVE_PROVIDER_SCOPE
+    if _NATIVE_CACHE is None:
+        module = _load_native_module()
+        try:
+            _NATIVE_CACHE = module.load_all() if module else {}
         except Exception:
             _NATIVE_CACHE = {}
+        # Read separately and defensively: a sibling predating
+        # FRAMEWORK_NATIVE_PROVIDERS must cost only the provider scope, not the
+        # whole mapping. Losing the scope re-opens the AWS-only false-PASS, so
+        # this degrades toward "unscoped", which is the pre-CMMC behaviour.
+        try:
+            _NATIVE_PROVIDER_SCOPE = dict(
+                getattr(module, "FRAMEWORK_NATIVE_PROVIDERS", {}) or {}
+            )
+        except Exception:
+            _NATIVE_PROVIDER_SCOPE = {}
     return _NATIVE_CACHE
 
 
-def map_compliance(all_findings):
+def _native_provider_scope(framework):
+    """Providers this framework's native file can evidence, or None if unscoped.
+
+    See `prowler_native_map.FRAMEWORK_NATIVE_PROVIDERS`: the mapping comes from
+    the installed Prowler package, not from the scan, so an AWS-only source
+    stays populated on a Kubernetes run and would score every mapped control
+    PASS on zero evidence.
+    """
+    _native_mapping()  # primes both caches
+    return (_NATIVE_PROVIDER_SCOPE or {}).get(framework)
+
+
+def map_compliance(all_findings, scanned_providers=None):
     """Map findings to compliance framework controls. Returns {framework: [ctrl_with_status]}.
 
     A control is matched by EXACT check-id membership when Prowler ships a
@@ -881,11 +1064,39 @@ def map_compliance(all_findings):
     — its KISA file maps only 26 of 101 requirements — so the keyword path is a
     fallback, not dead code. Each control reports which source decided it via
     `match_source`, so a reader can tell an exact mapping from an approximation.
+
+    A control tagged `native_only` opts OUT of the keyword fallback: with no
+    Prowler mapping it reports `match_source="unmapped"` and status N/A. Falling
+    through to keywords would be the failure the CMMC framework exists to avoid
+    — a prototype keyword set built from the target checks' own vocabulary
+    measured 34.2% coverage — and defaulting to PASS on zero matches would read
+    as "compliant" when it means "never looked".
+
+    `scanned_providers` is the set of provider slugs the run actually covered
+    (e.g. `{"aws", "kubernetes"}`). It matters because the native mapping is
+    loaded from the INSTALLED Prowler package rather than from the scan: an
+    AWS-only source such as 800-171 stays fully populated on a Kubernetes run,
+    matches nothing, and would score every mapped control PASS on no evidence.
+    Pass it from the caller when the provider list is known independently of the
+    findings — a clean provider contributes zero FAIL findings, so deriving it
+    from `all_findings` alone cannot distinguish "clean" from "not scanned" and
+    resolves that ambiguity conservatively, toward N/A.
     """
     native = _native_mapping()
+    if scanned_providers is None:
+        scanned = {
+            str(f.get("provider", "")) for f in all_findings if f.get("provider")
+        }
+    else:
+        scanned = {str(p) for p in scanned_providers if p}
     result = {}
     for framework, controls in COMPLIANCE_CONTROL_MAP.items():
         fw_native = native.get(framework, {})
+        covered = _native_provider_scope(framework)
+        if covered is not None and not (scanned & set(covered)):
+            # No evidence can reach this framework's native mapping: drop it so
+            # `native_only` controls report "unmapped" instead of a free PASS.
+            fw_native = {}
         mapped = []
         for ctrl in controls:
             native_checks = fw_native.get(ctrl["control"])
@@ -895,6 +1106,8 @@ def map_compliance(all_findings):
                 for f in all_findings:
                     if str(f.get("check", "")) in native_checks:
                         matching.append(f)
+            elif ctrl.get("native_only"):
+                match_source = "unmapped"
             else:
                 match_source = "keyword"
                 for f in all_findings:
@@ -903,7 +1116,7 @@ def map_compliance(all_findings):
                     native_match = _match_prowler_compliance(f, framework)
                     if keyword_match or native_match:
                         matching.append(f)
-            if not ctrl.get("assessable", True):
+            if not ctrl.get("assessable", True) or match_source == "unmapped":
                 status = "N/A"
             else:
                 status = "PASS" if len(matching) == 0 else "FAIL"

--- a/scanner/lib/dashboard-gen.py
+++ b/scanner/lib/dashboard-gen.py
@@ -204,7 +204,11 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
     prov_summary, all_findings = analyze_prowler(providers)
     history = load_scan_history(history_dir)
     owasp_map = map_findings_to_owasp(all_findings)
-    compliance_map = map_compliance(all_findings)
+    # Pass the scanned provider list explicitly: a provider with zero FAIL
+    # findings is invisible in `all_findings`, and a provider-scoped native
+    # source (800-171 is AWS-only) must not be credited to a run that could
+    # not have produced its evidence.
+    compliance_map = map_compliance(all_findings, scanned_providers=set(providers))
     arch_domains = map_architecture(all_findings)
     gh_finds = github_findings(all_findings)
     aws_finds = aws_findings(all_findings)

--- a/scanner/lib/dashboard-template.html
+++ b/scanner/lib/dashboard-template.html
@@ -322,6 +322,7 @@ tr.arch-highlight td{animation:archPulseTd 1.2s ease 2}
 .comp-body{display:none;padding:0}
 .comp-section.expanded .comp-body{display:block}
 .comp-arch-links{padding:.5rem 1rem;background:rgba(255,255,255,.02);border-bottom:1px solid var(--border)}
+.comp-fw-note{padding:.5rem 1rem;background:rgba(255,255,255,.02);border-bottom:1px solid var(--border);color:var(--muted);font-size:.8rem;line-height:1.5}
 .comp-pass td{opacity:.7}.comp-fail td{}.comp-st-pass{color:#22c55e;font-weight:700}.comp-st-fail{color:#ef4444;font-weight:700}.comp-na td{opacity:.6}.comp-st-na{color:#94a3b8;font-weight:700}
 /* Trend */
 .trend-section{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;margin-bottom:1.5rem}

--- a/scanner/lib/dashboard_compliance.py
+++ b/scanner/lib/dashboard_compliance.py
@@ -59,6 +59,15 @@ COMPLIANCE_FRAMEWORKS = [
         "desc": "AICPA Trust Services Criteria — service organization attestation",
     },
     {
+        "name": "CMMC 2.0 Level 2",
+        # NIST SP 800-171 Rev. 2 — the normative source for Level 2's practices,
+        # and the only candidate that answers cleanly to an automated client.
+        # Measured 2026-08-18: dodcio.defense.gov/CMMC 403s even with a browser
+        # UA, and ecfr.gov 302s Part 170 to a federalregister.gov unblock page.
+        "url": "https://csrc.nist.gov/pubs/sp/800/171/r2/upd1/final",
+        "desc": "US DoD contractor cybersecurity maturity — NIST SP 800-171 Rev. 2 practices",
+    },
+    {
         "name": "PCI-DSS v4.0.1",
         "url": "https://www.pcisecuritystandards.org/document_library/?category=pcidss",
         "desc": "Payment Card Industry Data Security Standard",

--- a/scanner/lib/dashboard_html_compliance.py
+++ b/scanner/lib/dashboard_html_compliance.py
@@ -18,6 +18,19 @@ if _LIB_DIR not in sys.path:
 from dashboard_utils import h, sev_badge, comp_slug
 from dashboard_mapping import COMPLIANCE_FRAMEWORKS, ARCH_DOMAINS
 
+# Framework-level coverage caveats, rendered under the heading. A limit that
+# only lives in a source comment is a limit the reader of the dashboard never
+# sees, and an unevidenced domain reads as a passing one.
+COMP_FW_NOTES = {
+    "CMMC 2.0 Level 2": (
+        "Evidence comes from Prowler's NIST SP 800-171 Rev. 2 mapping, which "
+        "Prowler ships for AWS only. A run that did not scan AWS reports every "
+        "domain N/A — it cannot produce CMMC evidence, and a domain that was "
+        "never evaluated must not read as passing. On an AWS run, the five "
+        "domains Prowler maps no check to (AT, MA, MP, PE, PS) stay N/A."
+    ),
+}
+
 
 def _build_compliance_html(compliance_map) -> str:
     """Build the Compliance tab HTML from the compliance_map."""
@@ -50,6 +63,9 @@ def _build_compliance_html(compliance_map) -> str:
         comp_html += f'<div class="comp-section" id="{comp_id}"><div class="comp-title" data-action="toggleComp">{h(framework)} <span class="comp-stat"><span class="cs-pass">{pass_c} pass</span> / <span class="cs-fail">{fail_c} fail</span>{na_stat_html}</span><span class="comp-arrow">▸</span></div>'
         if comp_arch_row:
             comp_html += comp_arch_row
+        fw_note = COMP_FW_NOTES.get(framework)
+        if fw_note:
+            comp_html += f'<div class="comp-fw-note">{h(fw_note)}</div>'
         comp_html += '<div class="comp-body"><table><thead><tr><th>Control</th><th>Name</th><th>Status</th><th>Related</th><th>Summary · Remediation</th></tr></thead><tbody>'
         for ctrl in controls:
             if ctrl["status"] == "PASS":

--- a/scanner/lib/prowler_compliance_summary.py
+++ b/scanner/lib/prowler_compliance_summary.py
@@ -43,14 +43,35 @@ def _load_compliance_map():
     return module
 
 
+def _provider_of(file_path):
+    """`.../prowler-aws.ocsf.json` -> `aws`, with k8s variants merged.
+
+    Mirrors `dashboard_data_loader._normalize_provider` so a provider-scoped
+    compliance source (800-171 is AWS-only) sees the same slugs on both the
+    dashboard path and this one.
+    """
+    name = os.path.basename(file_path)
+    name = name[len("prowler-"):] if name.startswith("prowler-") else name
+    name = name.split(".ocsf.json")[0]
+    if name.startswith("k8s") or name.startswith("kubernetes") or "eks" in name:
+        return "kubernetes"
+    return name
+
+
 def _read_findings(prowler_dir):
     """Collect FAIL findings from every prowler-*.ocsf.json file in prowler_dir.
 
     Each OCSF file may be a JSON array or newline-delimited JSON (NDJSON).
     A malformed or unreadable file is skipped rather than aborting the whole
     scan — one bad Prowler artifact should not blank the compliance summary.
+
+    Returns `(findings, providers)`. `providers` is every provider that produced
+    a readable artifact, including ones with zero FAIL findings: a clean
+    provider is invisible in the findings list, and a provider-scoped native
+    mapping must be able to tell "clean" from "not scanned".
     """
     findings = []
+    providers = set()
     for file_path in glob.glob(os.path.join(prowler_dir, "prowler-*.ocsf.json")):
         try:
             with open(file_path, encoding="utf-8") as fh:
@@ -60,6 +81,8 @@ def _read_findings(prowler_dir):
                 if raw.startswith("[")
                 else [json.loads(line) for line in raw.splitlines() if line.strip()]
             )
+            provider = _provider_of(file_path)
+            providers.add(provider)
             for item in data:
                 if item.get("status_code") != "FAIL":
                     continue
@@ -69,11 +92,12 @@ def _read_findings(prowler_dir):
                         "title": item.get("finding_info", {}).get("title", ""),
                         "message": item.get("message", ""),
                         "compliance": item.get("unmapped", {}).get("compliance", {}),
+                        "provider": provider,
                     }
                 )
         except Exception:
             pass
-    return findings
+    return findings, providers
 
 
 def build_summary(prowler_dir):
@@ -82,11 +106,13 @@ def build_summary(prowler_dir):
     Returns "" when there are no FAIL findings — no OCSF artifacts, only
     PASS findings, or every file was malformed.
     """
-    findings = _read_findings(prowler_dir)
+    findings, providers = _read_findings(prowler_dir)
     if not findings:
         return ""
     compliance_map = _load_compliance_map()
-    summary = compliance_map.compliance_summary(compliance_map.map_compliance(findings))
+    summary = compliance_map.compliance_summary(
+        compliance_map.map_compliance(findings, scanned_providers=providers)
+    )
     return json.dumps(summary, separators=(",", ":"))
 
 

--- a/scanner/lib/prowler_native_map.py
+++ b/scanner/lib/prowler_native_map.py
@@ -37,6 +37,7 @@ normalizer:
     SOC 2 (TSC)      `cc_6_1`     -> `CC6`   (the repo maps at series level)
     NIST 800-53      `ac_2_1`     -> `AC-2`
     PCI-DSS v4.0.1   `1.2.5.1`    -> `Req 1`
+    CMMC 2.0 L2      `3_1_1`      -> `AC`    (800-171 family -> CMMC domain)
 
 stdlib only. No network.
 """
@@ -103,6 +104,39 @@ def _pci_requirement(rid):
     return f"Req {m.group(1)}" if m else None
 
 
+# 800-171 requirement family -> CMMC 2.0 domain. CMMC 2.0 Level 2's 110
+# practices ARE NIST SP 800-171 rev2's requirements, so the family number is the
+# domain — no interpretation step, unlike the CIS case rejected below.
+CMMC_DOMAINS = {
+    "3_1": "AC",   # Access Control
+    "3_2": "AT",   # Awareness and Training
+    "3_3": "AU",   # Audit and Accountability
+    "3_4": "CM",   # Configuration Management
+    "3_5": "IA",   # Identification and Authentication
+    "3_6": "IR",   # Incident Response
+    "3_7": "MA",   # Maintenance
+    "3_8": "MP",   # Media Protection
+    "3_9": "PS",   # Personnel Security
+    "3_10": "PE",  # Physical Protection
+    "3_11": "RA",  # Risk Assessment
+    "3_12": "CA",  # Security Assessment
+    "3_13": "SC",  # System and Communications Protection
+    "3_14": "SI",  # System and Information Integrity
+}
+
+
+def _cmmc_domain(rid):
+    """`3_1_1` -> `AC`. The repo maps CMMC at domain granularity.
+
+    Prowler writes 800-171 ids with underscores (`3_13_5`), not the dotted form
+    the standard prints (`3.13.5`); both are accepted so a future Prowler
+    re-spelling does not silently drop every requirement. The family is taken
+    greedily so `3_13_*` reads as family 13 (SC) and not family 1 (AC).
+    """
+    m = re.match(r"3[_.](\d+)[_.]", rid.strip())
+    return CMMC_DOMAINS.get(f"3_{m.group(1)}") if m else None
+
+
 # framework name -> (filename glob, requirement-id normalizer)
 FRAMEWORK_SOURCES = {
     "KISA ISMS-P": ("kisa_isms_p_*_[!k]*.json", _identity),
@@ -110,6 +144,15 @@ FRAMEWORK_SOURCES = {
     "SOC 2 (TSC)": ("soc2_*.json", _soc2_series),
     "NIST 800-53 Rev5": ("nist_800_53_revision_5_*.json", _nist_control),
     "PCI-DSS v4.0.1": ("pci_4.0_*.json", _pci_requirement),
+    # CMMC has no `cmmc_*.json` of its own — 800-171 rev2 IS its practice set.
+    # Measured against the pinned Prowler 5.30.1 file (50 requirements, 49 with
+    # checks, 87 distinct checks): 9 of the 14 domains carry checks — SC 50,
+    # AC 43, AU 21, CM 21, IA 21, IR 14, SI 13, CA 9, RA 3 — and AT/MA/MP/PE/PS
+    # carry none, which is why the repo's CMMC controls are `native_only` and
+    # report N/A rather than a keyword guess. See
+    # docs/plans/compliance-native-mapping-and-cmmc.md (its per-family counts
+    # were measured on 5.38 and differ slightly from the pinned version).
+    "CMMC 2.0 Level 2": ("nist_800_171_revision_2_*.json", _cmmc_domain),
     # DELIBERATELY ABSENT: "CIS Benchmarks".
     #
     # Prowler ships 34 `cis_*.json` files with real check arrays, so wiring this
@@ -122,6 +165,26 @@ FRAMEWORK_SOURCES = {
     #
     # Adding CIS needs a control-id remap pass first, done against a named CIS
     # Controls version. See docs/plans/compliance-native-mapping-and-cmmc.md.
+}
+
+
+# framework -> the providers its native file can produce evidence for.
+#
+# WHY THIS EXISTS. `load_framework()` reads the INSTALLED Prowler package, not
+# the scan. Prowler ships 800-171 for AWS and nothing else, so the mapping is
+# populated with AWS check ids whenever Prowler is installed — including on a
+# Kubernetes-only run, where no finding can ever match one and all nine mapped
+# domains would fall through to `count == 0 -> PASS`. That is a perfect CMMC
+# score for an estate that produced no CMMC evidence, and the shipped image
+# makes it reachable: Dockerfile strips `prowler/providers/{azure,gcp,...}` but
+# never `prowler/compliance/**`, so a k8s scan carries the AWS 800-171 file.
+#
+# A framework absent from this dict is unscoped and keeps the pre-existing
+# behaviour. `NIST 800-53 Rev5` is AWS-only in Prowler too and has the same
+# false-PASS today; it is deliberately NOT scoped here because it is a
+# pre-existing, separately-measured behaviour change, not part of adding CMMC.
+FRAMEWORK_NATIVE_PROVIDERS = {
+    "CMMC 2.0 Level 2": frozenset({"aws"}),
 }
 
 

--- a/scanner/tests/test_cmmc_native_map.py
+++ b/scanner/tests/test_cmmc_native_map.py
@@ -1,0 +1,522 @@
+"""
+Tests for the CMMC 2.0 Level 2 framework and its `native_only` contract.
+
+WHY CMMC IS DIFFERENT FROM THE OTHER SEVEN FRAMEWORKS
+-----------------------------------------------------
+Every other framework in `COMPLIANCE_CONTROL_MAP` carries a keyword list and
+falls back to substring matching when Prowler ships no mapping. CMMC carries
+none, on measurement: a prototype keyword set built from the vocabulary of the
+target checks themselves reached 34.2% coverage (CM 1/22, SI 1/13). Keywords
+here would manufacture wrong answers rather than approximate right ones, so the
+controls are tagged `native_only` and report N/A — never PASS — when Prowler's
+`nist_800_171_revision_2_*.json` is unavailable.
+
+The three properties pinned below are the ones that make that safe:
+
+1. **The id normalizer maps to the right family.** Prowler writes 800-171 ids
+   with underscores (`3_13_5`), and a non-greedy family read would file every
+   `3_1x_*` requirement under family 1 (AC) instead of 13 (SC) / 14 (SI) — real
+   checks attached to the wrong domain, silently.
+2. **Absence is N/A, not PASS.** The `count == 0 -> PASS` default is a false
+   compliance assurance for a control that was never evaluated.
+3. **Presence flips it back.** With a mapping loaded the domain scores
+   PASS/FAIL by exact check-id membership, like every other native control.
+
+Hermetic: fixtures are written to a tmpdir and pointed at with
+`CLAUDESEC_PROWLER_COMPLIANCE_DIR`. Prowler is not required, in CI or locally.
+
+Reference: CMMC 2.0 Level 2 practices are NIST SP 800-171 Rev. 2 requirements
+(32 CFR Part 170); domains correspond to requirement families 3.1–3.14.
+"""
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+
+_LIB = os.path.join(os.path.dirname(__file__), "..", "lib")
+
+FRAMEWORK = "CMMC 2.0 Level 2"
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_LIB, filename))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pnm = _load("prowler_native_map_cmmc", "prowler_native_map.py")
+
+
+def _write_fixture(root, provider, filename, requirements):
+    d = os.path.join(root, provider)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, filename), "w", encoding="utf-8") as fh:
+        json.dump({"Requirements": requirements}, fh)
+
+
+class TestCmmcDomainNormalizer(unittest.TestCase):
+    def test_underscore_ids_map_to_their_family_domain(self):
+        for raw, want in (
+            ("3_1_1", "AC"),
+            ("3_3_8", "AU"),
+            ("3_4_6", "CM"),
+            ("3_5_10", "IA"),
+            ("3_6_2", "IR"),
+            ("3_11_3", "RA"),
+            ("3_12_4", "CA"),
+            ("3_13_16", "SC"),
+            ("3_14_7", "SI"),
+        ):
+            self.assertEqual(pnm._cmmc_domain(raw), want, raw)
+
+    def test_two_digit_family_is_not_read_as_family_one(self):
+        """The bug this exists for: `3_13_5` filed under AC instead of SC would
+        attach 50 boundary-protection checks to Access Control."""
+        self.assertEqual(pnm._cmmc_domain("3_13_5"), "SC")
+        self.assertEqual(pnm._cmmc_domain("3_14_1"), "SI")
+        self.assertEqual(pnm._cmmc_domain("3_10_1"), "PE")
+        self.assertNotEqual(pnm._cmmc_domain("3_13_5"), pnm._cmmc_domain("3_1_5"))
+
+    def test_dotted_form_is_accepted(self):
+        """The standard prints `3.13.5`; Prowler writes `3_13_5`. Accepting both
+        means a Prowler re-spelling degrades to nothing, not to silence."""
+        self.assertEqual(pnm._cmmc_domain("3.13.5"), "SC")
+        self.assertEqual(pnm._cmmc_domain("3.1.1"), "AC")
+
+    def test_unparseable_or_unknown_family_returns_none(self):
+        # None omits the requirement; a guess would attach checks to a wrong
+        # domain, which is worse than having no opinion.
+        for bad in ("", "governance", "3_1", "3_99_1", "4_1_1", "x_1_1"):
+            self.assertIsNone(pnm._cmmc_domain(bad), bad)
+
+    def test_domain_table_covers_families_3_1_through_3_14(self):
+        self.assertEqual(
+            set(pnm.CMMC_DOMAINS), {f"3_{n}" for n in range(1, 15)}
+        )
+        self.assertEqual(len(set(pnm.CMMC_DOMAINS.values())), 14)
+
+
+class TestCmmcSourceRegistration(unittest.TestCase):
+    def test_framework_reads_the_800_171_file(self):
+        pattern, normalize = pnm.FRAMEWORK_SOURCES[FRAMEWORK]
+        self.assertEqual(pattern, "nist_800_171_revision_2_*.json")
+        self.assertIs(normalize, pnm._cmmc_domain)
+
+    def test_cis_stays_deliberately_absent(self):
+        """Adding CIS needs a control-id remap first; regression pin so the
+        CMMC addition is not read as permission to wire CIS in the same way."""
+        self.assertNotIn("CIS Benchmarks", pnm.FRAMEWORK_SOURCES)
+
+
+class TestCmmcLoader(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+        prev = os.environ.get("CLAUDESEC_PROWLER_COMPLIANCE_DIR")
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = self.root
+        self.addCleanup(self._restore, prev)
+
+    @staticmethod
+    def _restore(prev):
+        if prev is None:
+            os.environ.pop("CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
+        else:
+            os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = prev
+
+    def test_requirements_collapse_into_domain_unions(self):
+        _write_fixture(
+            self.root,
+            "aws",
+            "nist_800_171_revision_2_aws.json",
+            [
+                {"Id": "3_1_1", "Checks": ["iam_a"]},
+                {"Id": "3_1_2", "Checks": ["iam_b"]},
+                {"Id": "3_13_1", "Checks": ["vpc_a"]},
+            ],
+        )
+        native = pnm.load_framework(FRAMEWORK)
+        self.assertEqual(native["AC"], frozenset({"iam_a", "iam_b"}))
+        self.assertEqual(native["SC"], frozenset({"vpc_a"}))
+
+    def test_families_without_checks_are_absent_not_empty(self):
+        _write_fixture(
+            self.root,
+            "aws",
+            "nist_800_171_revision_2_aws.json",
+            [
+                {"Id": "3_2_1", "Checks": []},
+                {"Id": "3_7_1"},
+                {"Id": "3_1_1", "Checks": ["iam_a"]},
+            ],
+        )
+        native = pnm.load_framework(FRAMEWORK)
+        self.assertEqual(sorted(native), ["AC"])
+        self.assertNotIn("AT", native)
+        self.assertNotIn("MA", native)
+
+    def test_other_frameworks_do_not_pick_up_the_800_171_file(self):
+        """`nist_800_53_revision_5_*.json` and `nist_800_171_revision_2_*.json`
+        share a prefix; the 800-53 glob must not swallow the 171 file."""
+        _write_fixture(
+            self.root,
+            "aws",
+            "nist_800_171_revision_2_aws.json",
+            [{"Id": "3_1_1", "Checks": ["iam_a"]}],
+        )
+        self.assertEqual(pnm.load_framework("NIST 800-53 Rev5"), {})
+        self.assertEqual(pnm.load_framework(FRAMEWORK)["AC"], frozenset({"iam_a"}))
+
+
+class TestCmmcControlMapShape(unittest.TestCase):
+    def setUp(self):
+        self.cm = _load("compliance_map_cmmc_shape", "compliance-map.py")
+
+    def test_controls_are_exactly_the_fourteen_domains(self):
+        controls = self.cm.COMPLIANCE_CONTROL_MAP[FRAMEWORK]
+        self.assertEqual(
+            {c["control"] for c in controls}, set(pnm.CMMC_DOMAINS.values())
+        )
+        self.assertEqual(len(controls), 14)
+
+    def test_every_control_is_native_only_with_no_keywords(self):
+        for ctrl in self.cm.COMPLIANCE_CONTROL_MAP[FRAMEWORK]:
+            with self.subTest(control=ctrl["control"]):
+                self.assertTrue(ctrl.get("native_only"))
+                self.assertEqual(ctrl["checks"], [])
+
+    def test_no_control_is_declared_non_assessable(self):
+        """CMMC's N/A is conditional on Prowler's data, not declared — tagging a
+        domain `assessable: False` would freeze it N/A even once mapped."""
+        for ctrl in self.cm.COMPLIANCE_CONTROL_MAP[FRAMEWORK]:
+            self.assertTrue(ctrl.get("assessable", True), ctrl["control"])
+
+
+class TestCmmcWithoutProwlerMapping(unittest.TestCase):
+    """Property 2: absence is N/A, not PASS."""
+
+    def setUp(self):
+        prev = os.environ.get("CLAUDESEC_PROWLER_COMPLIANCE_DIR")
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = os.path.join(
+            os.path.dirname(__file__), "no-such-prowler-compliance-dir"
+        )
+        self.addCleanup(TestCmmcLoader._restore, prev)
+        self.cm = _load("compliance_map_cmmc_absent", "compliance-map.py")
+        self.cm._native_mapping()
+
+    def _cmmc(self, findings):
+        return {c["control"]: c for c in self.cm.map_compliance(findings)[FRAMEWORK]}
+
+    def test_every_domain_is_na_and_marked_unmapped(self):
+        for control, ctrl in self._cmmc([]).items():
+            with self.subTest(control=control):
+                self.assertEqual(ctrl["status"], "N/A")
+                self.assertEqual(ctrl["match_source"], "unmapped")
+
+    def test_a_finding_full_of_domain_vocabulary_still_does_not_score(self):
+        """The keyword path is not merely empty for CMMC, it is not taken. A
+        finding whose text is saturated with access-control language must not
+        flip AC to FAIL, because nothing authorised that association."""
+        finding = {
+            "check": "iam_policy_allows_privilege_escalation",
+            "title": "Access control failure: IAM policy grants admin",
+            "message": "access control audit logging encryption incident media",
+        }
+        ctrl = self._cmmc([finding])["AC"]
+        self.assertEqual(ctrl["status"], "N/A")
+        self.assertEqual(ctrl["count"], 0)
+
+    def test_summary_scores_nothing_rather_than_scoring_a_perfect_pass(self):
+        summary = self.cm.compliance_summary(self.cm.map_compliance([]))[FRAMEWORK]
+        self.assertEqual(summary["na"], 14)
+        self.assertEqual(summary["pass"], 0)
+        self.assertEqual(summary["fail"], 0)
+        self.assertEqual(summary["total"], 0)
+
+
+class TestCmmcWithProwlerMapping(unittest.TestCase):
+    """Property 3: presence flips the domain back to exact scoring."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        prev = os.environ.get("CLAUDESEC_PROWLER_COMPLIANCE_DIR")
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = self._tmp.name
+        self.addCleanup(TestCmmcLoader._restore, prev)
+        _write_fixture(
+            self._tmp.name,
+            "aws",
+            "nist_800_171_revision_2_aws.json",
+            [
+                {"Id": "3_1_1", "Checks": ["iam_root_mfa_enabled"]},
+                {"Id": "3_13_1", "Checks": ["ec2_securitygroup_default_restrict"]},
+            ],
+        )
+        self.cm = _load("compliance_map_cmmc_present", "compliance-map.py")
+
+    def _cmmc(self, findings):
+        # `provider: aws` throughout: 800-171 is an AWS-only source, so a
+        # finding from anywhere else cannot evidence it (TestCmmcProviderScope).
+        return {
+            c["control"]: c
+            for c in self.cm.map_compliance(findings, scanned_providers={"aws"})[
+                FRAMEWORK
+            ]
+        }
+
+    def test_mapped_domain_fails_on_exact_check_id(self):
+        finding = {
+            "check": "iam_root_mfa_enabled",
+            "title": "",
+            "message": "",
+            "provider": "aws",
+        }
+        ctrl = self._cmmc([finding])["AC"]
+        self.assertEqual(ctrl["status"], "FAIL")
+        self.assertEqual(ctrl["match_source"], "prowler")
+        self.assertEqual(ctrl["count"], 1)
+
+    def test_mapped_domain_passes_when_its_checks_are_clean(self):
+        finding = {
+            "check": "some_unrelated_check",
+            "title": "",
+            "message": "",
+            "provider": "aws",
+        }
+        ctrl = self._cmmc([finding])["AC"]
+        self.assertEqual(ctrl["status"], "PASS")
+        self.assertEqual(ctrl["match_source"], "prowler")
+
+    def test_matching_is_by_check_id_only_not_by_text(self):
+        finding = {
+            "check": "unrelated",
+            "title": "iam_root_mfa_enabled",
+            "message": "iam_root_mfa_enabled",
+            "provider": "aws",
+        }
+        self.assertEqual(self._cmmc([finding])["AC"]["status"], "PASS")
+
+    def test_unmapped_domains_stay_na_alongside_mapped_ones(self):
+        """Partial coverage must not promote the rest of the framework: with
+        only AC and SC mapped, the other 12 domains remain N/A."""
+        controls = self._cmmc([])
+        self.assertEqual(controls["AC"]["status"], "PASS")
+        self.assertEqual(controls["SC"]["status"], "PASS")
+        for domain in ("AT", "AU", "CA", "CM", "IA", "IR", "MA", "MP", "PE", "PS", "RA", "SI"):
+            with self.subTest(control=domain):
+                self.assertEqual(controls[domain]["status"], "N/A")
+                self.assertEqual(controls[domain]["match_source"], "unmapped")
+
+
+class TestCmmcProviderScope(unittest.TestCase):
+    """The false-PASS this scope exists to stop.
+
+    `load_framework()` reads the INSTALLED Prowler package, not the scan.
+    Prowler ships 800-171 for AWS only, and the shipped image strips
+    `prowler/providers/{azure,gcp,...}` while keeping `prowler/compliance/**` —
+    so a Kubernetes scan carries a fully-populated AWS mapping that matches
+    none of its findings. Without the provider scope all nine mapped domains
+    take the `prowler` branch, match 0, and fall through to `count == 0 -> PASS`:
+    a perfect CMMC score for an estate that produced no CMMC evidence.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        prev = os.environ.get("CLAUDESEC_PROWLER_COMPLIANCE_DIR")
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = self._tmp.name
+        self.addCleanup(TestCmmcLoader._restore, prev)
+        _write_fixture(
+            self._tmp.name,
+            "aws",
+            "nist_800_171_revision_2_aws.json",
+            [
+                {"Id": "3_1_1", "Checks": ["iam_root_mfa_enabled"]},
+                {"Id": "3_13_1", "Checks": ["ec2_securitygroup_default_restrict"]},
+            ],
+        )
+        self.cm = _load("compliance_map_cmmc_scope", "compliance-map.py")
+
+    def _cmmc(self, findings, providers=None):
+        return {
+            c["control"]: c
+            for c in self.cm.map_compliance(findings, scanned_providers=providers)[
+                FRAMEWORK
+            ]
+        }
+
+    def test_scope_is_declared_as_aws_only(self):
+        self.assertEqual(pnm.FRAMEWORK_NATIVE_PROVIDERS[FRAMEWORK], frozenset({"aws"}))
+
+    def test_kubernetes_only_run_reports_na_not_a_perfect_score(self):
+        findings = [
+            {
+                "check": "core_minimize_admission_privileged_containers",
+                "title": "t",
+                "message": "m",
+                "provider": "kubernetes",
+            }
+        ]
+        controls = self._cmmc(findings)
+        for control, ctrl in controls.items():
+            with self.subTest(control=control):
+                self.assertEqual(ctrl["status"], "N/A")
+                self.assertEqual(ctrl["match_source"], "unmapped")
+        summary = self.cm.compliance_summary(self.cm.map_compliance(findings))[FRAMEWORK]
+        self.assertEqual(summary, {"pass": 0, "fail": 0, "na": 14, "total": 0})
+
+    def test_azure_only_run_is_equally_unevidenced(self):
+        findings = [
+            {"check": "aks_something", "title": "t", "message": "m", "provider": "azure"}
+        ]
+        self.assertEqual(self._cmmc(findings)["AC"]["status"], "N/A")
+
+    def test_an_aws_run_still_scores(self):
+        findings = [
+            {
+                "check": "iam_root_mfa_enabled",
+                "title": "t",
+                "message": "m",
+                "provider": "aws",
+            }
+        ]
+        controls = self._cmmc(findings)
+        self.assertEqual(controls["AC"]["status"], "FAIL")
+        self.assertEqual(controls["AC"]["match_source"], "prowler")
+
+    def test_a_mixed_run_containing_aws_still_scores(self):
+        findings = [
+            {"check": "x", "title": "t", "message": "m", "provider": "kubernetes"},
+            {
+                "check": "iam_root_mfa_enabled",
+                "title": "t",
+                "message": "m",
+                "provider": "aws",
+            },
+        ]
+        self.assertEqual(self._cmmc(findings)["AC"]["status"], "FAIL")
+
+    def test_explicit_provider_list_credits_a_clean_aws_scan(self):
+        """A clean provider emits zero FAIL findings and so is invisible in the
+        findings list. The caller knows better, and PASS is the right answer
+        there — this is why `scanned_providers` exists as a parameter."""
+        derived = self._cmmc([])
+        self.assertEqual(derived["AC"]["status"], "N/A")
+        explicit = self._cmmc([], providers={"aws"})
+        self.assertEqual(explicit["AC"]["status"], "PASS")
+        self.assertEqual(explicit["AC"]["match_source"], "prowler")
+
+    def test_explicit_non_aws_provider_list_does_not_credit_the_framework(self):
+        controls = self._cmmc([], providers={"kubernetes", "gcp"})
+        self.assertEqual(controls["AC"]["status"], "N/A")
+        self.assertEqual(controls["SC"]["status"], "N/A")
+
+    def test_unscoped_frameworks_are_left_alone(self):
+        """Only CMMC is scoped. NIST 800-53 is AWS-only in Prowler too and has
+        the same latent false-PASS, deliberately not changed here."""
+        self.assertEqual(set(pnm.FRAMEWORK_NATIVE_PROVIDERS), {FRAMEWORK})
+        result = self.cm.map_compliance(
+            [{"check": "x", "title": "t", "message": "m", "provider": "kubernetes"}]
+        )
+        iso = {c["control"]: c for c in result["ISO 27001:2022"]}
+        self.assertNotEqual(iso["A.8.9"]["status"], "N/A")
+
+
+class TestCmmcIsRendered(unittest.TestCase):
+    """The framework has to reach the dashboard, with its coverage limit stated."""
+
+    def setUp(self):
+        import sys
+
+        if _LIB not in sys.path:
+            sys.path.insert(0, os.path.abspath(_LIB))
+
+    def test_compliance_html_renders_the_framework_and_its_domains(self):
+        from dashboard_html_compliance import _build_compliance_html
+
+        cmap = {
+            FRAMEWORK: [
+                {
+                    "control": "AC",
+                    "name": "Access Control (800-171 §3.1)",
+                    "desc": "d",
+                    "action": "a",
+                    "checks": [],
+                    "native_only": True,
+                    "status": "N/A",
+                    "count": 0,
+                    "findings": [],
+                    "match_source": "unmapped",
+                }
+            ]
+        }
+        html = _build_compliance_html(cmap)
+        self.assertIn("CMMC 2.0 Level 2", html)
+        self.assertIn("Access Control (800-171 §3.1)", html)
+        self.assertIn("N/A", html)
+
+    def test_the_aws_only_coverage_limit_is_stated_in_the_output(self):
+        """A limit that only lives in a source comment is one the dashboard's
+        reader never sees."""
+        from dashboard_html_compliance import COMP_FW_NOTES, _build_compliance_html
+
+        self.assertIn(FRAMEWORK, COMP_FW_NOTES)
+        self.assertIn("AWS only", COMP_FW_NOTES[FRAMEWORK])
+        html = _build_compliance_html(
+            {
+                FRAMEWORK: [
+                    {
+                        "control": "AC",
+                        "name": "n",
+                        "desc": "d",
+                        "action": "a",
+                        "checks": [],
+                        "status": "N/A",
+                        "count": 0,
+                        "findings": [],
+                        "match_source": "unmapped",
+                    }
+                ]
+            }
+        )
+        self.assertIn("comp-fw-note", html)
+        self.assertIn("AWS only", html)
+
+    def test_a_framework_without_a_note_renders_none(self):
+        from dashboard_html_compliance import _build_compliance_html
+
+        html = _build_compliance_html(
+            {
+                "ISO 27001:2022": [
+                    {
+                        "control": "A.8.5",
+                        "name": "n",
+                        "desc": "d",
+                        "action": "a",
+                        "checks": ["mfa"],
+                        "status": "PASS",
+                        "count": 0,
+                        "findings": [],
+                        "match_source": "keyword",
+                    }
+                ]
+            }
+        )
+        self.assertNotIn("comp-fw-note", html)
+
+    def test_the_note_style_exists_in_the_dashboard_template(self):
+        with open(os.path.join(_LIB, "dashboard-template.html"), encoding="utf-8") as fh:
+            self.assertIn(".comp-fw-note{", fh.read())
+
+    def test_the_framework_chip_list_carries_cmmc(self):
+        from dashboard_compliance import COMPLIANCE_FRAMEWORKS
+
+        names = {f["name"] for f in COMPLIANCE_FRAMEWORKS}
+        self.assertIn(FRAMEWORK, names)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_compliance_map.py
+++ b/scanner/tests/test_compliance_map.py
@@ -29,8 +29,8 @@ def _make_finding(check="chk", title="", message="", compliance=None):
 class TestComplianceControlMap(unittest.TestCase):
     """Verify the structure of the compliance control map."""
 
-    def test_has_seven_frameworks(self):
-        self.assertEqual(len(COMPLIANCE_CONTROL_MAP), 7)
+    def test_has_eight_frameworks(self):
+        self.assertEqual(len(COMPLIANCE_CONTROL_MAP), 8)
 
     def test_expected_framework_names(self):
         expected = {
@@ -41,6 +41,7 @@ class TestComplianceControlMap(unittest.TestCase):
             "CIS Benchmarks",
             "KISA ISMS Simple",
             "SOC 2 (TSC)",
+            "CMMC 2.0 Level 2",
         }
         self.assertEqual(set(COMPLIANCE_CONTROL_MAP.keys()), expected)
 
@@ -54,7 +55,20 @@ class TestComplianceControlMap(unittest.TestCase):
                         f"Missing fields in {fw}/{ctrl['control']}",
                     )
                     self.assertIsInstance(ctrl["checks"], list)
-                    self.assertGreater(len(ctrl["checks"]), 0)
+                    if ctrl.get("native_only"):
+                        # The inverse of the rule below, and load-bearing: a
+                        # native_only control that grew a keyword list would
+                        # still never consult it (map_compliance skips the
+                        # keyword branch), so the list would be silent dead
+                        # data that reads like an active matcher.
+                        self.assertEqual(
+                            ctrl["checks"],
+                            [],
+                            f"{fw}/{ctrl['control']} is native_only but carries "
+                            "keywords, which map_compliance will never read.",
+                        )
+                    else:
+                        self.assertGreater(len(ctrl["checks"]), 0)
 
     def test_control_counts_per_framework(self):
         counts = {fw: len(ctrls) for fw, ctrls in COMPLIANCE_CONTROL_MAP.items()}
@@ -65,6 +79,8 @@ class TestComplianceControlMap(unittest.TestCase):
         self.assertEqual(counts["CIS Benchmarks"], 9)
         self.assertEqual(counts["KISA ISMS Simple"], 20)
         self.assertEqual(counts["SOC 2 (TSC)"], 9)
+        # 14 CMMC domains = NIST SP 800-171 Rev. 2 requirement families 3.1–3.14.
+        self.assertEqual(counts["CMMC 2.0 Level 2"], 14)
 
 
 class TestMatchProwlerCompliance(unittest.TestCase):
@@ -123,12 +139,30 @@ class TestMapCompliance(unittest.TestCase):
         """With no findings, every assessable control is PASS; every
         non-assessable control (e.g. the 11 ISMS-P 3.x PII controls) is
         always N/A regardless of findings."""
+        # No findings means no provider was scanned, so a provider-scoped
+        # native source cannot apply: every CMMC domain must be unmapped.
+        # Anchored on the framework rather than derived from the output —
+        # `status`/`match_source` are co-produced, so asserting only their
+        # mutual consistency stays green if the whole native_only path is
+        # deleted and the domains revert to a keyword PASS.
         result = map_compliance([])
+        cmmc = result["CMMC 2.0 Level 2"]
+        self.assertEqual(len(cmmc), 14)
+        self.assertTrue(all(c["match_source"] == "unmapped" for c in cmmc))
+        self.assertTrue(all(c["status"] == "N/A" for c in cmmc))
+
         for fw, controls in result.items():
             for ctrl in controls:
                 with self.subTest(framework=fw, control=ctrl["control"]):
-                    expected_status = "N/A" if not ctrl.get("assessable", True) else "PASS"
-                    self.assertEqual(ctrl["status"], expected_status)
+                    # Two routes to N/A: declared non-assessable, or a
+                    # `native_only` control with no Prowler mapping to consult
+                    # (match_source "unmapped"). Both are pinned in detail by
+                    # test_compliance_map_ismsp_na.py.
+                    na = (
+                        not ctrl.get("assessable", True)
+                        or ctrl["match_source"] == "unmapped"
+                    )
+                    self.assertEqual(ctrl["status"], "N/A" if na else "PASS")
                     self.assertEqual(ctrl["count"], 0)
                     self.assertEqual(ctrl["findings"], [])
 
@@ -233,7 +267,12 @@ class TestComplianceSummary(unittest.TestCase):
             with self.subTest(framework=fw):
                 self.assertEqual(stats["fail"], 0)
                 self.assertEqual(stats["pass"], stats["total"])
-                self.assertGreater(stats["total"], 0)
+                # total is 0 only when EVERY control is N/A — true for a
+                # fully `native_only` framework with no Prowler mapping loaded.
+                if any(c["status"] != "N/A" for c in cmap[fw]):
+                    self.assertGreater(stats["total"], 0)
+                else:
+                    self.assertEqual(stats["total"], 0)
 
     def test_mixed_pass_fail(self):
         findings = [_make_finding(check="mfa_off", title="MFA disabled", message="No MFA")]
@@ -244,15 +283,15 @@ class TestComplianceSummary(unittest.TestCase):
         self.assertTrue(any_fail)
 
     def test_summary_totals_match_controls(self):
-        """total = pass + fail, excluding non-assessable (N/A) controls."""
+        """total = pass + fail, excluding every N/A control."""
         cmap = map_compliance([])
         summary = compliance_summary(cmap)
         for fw, controls in COMPLIANCE_CONTROL_MAP.items():
-            assessable_count = sum(1 for c in controls if c.get("assessable", True))
-            na_count = len(controls) - assessable_count
-            self.assertEqual(summary[fw]["total"], assessable_count)
+            na_count = sum(1 for c in cmap[fw] if c["status"] == "N/A")
+            scored = len(controls) - na_count
+            self.assertEqual(summary[fw]["total"], scored)
             self.assertEqual(summary[fw]["na"], na_count)
-            self.assertEqual(summary[fw]["pass"] + summary[fw]["fail"], assessable_count)
+            self.assertEqual(summary[fw]["pass"] + summary[fw]["fail"], scored)
 
     def test_summary_keys_match_frameworks(self):
         cmap = map_compliance([])

--- a/scanner/tests/test_compliance_map_ismsp_na.py
+++ b/scanner/tests/test_compliance_map_ismsp_na.py
@@ -67,6 +67,64 @@ EXPECTED_NON_ASSESSABLE = {
     "CIS Benchmarks": {"CIS-K8s-ArgoCD"},
 }
 
+# ── The SECOND source of N/A ─────────────────────────────────────────────────
+#
+# `assessable: False` above declares "no automated test method exists". A
+# `native_only` control declares something different: "decided by Prowler's
+# requirement->check data or not at all". It carries no keyword list, so with no
+# Prowler mapping loaded it has nothing to match and reports N/A
+# (`match_source == "unmapped"`) instead of the `count==0 -> PASS` default,
+# which would read as "compliant" when it means "never looked".
+#
+# Unlike EXPECTED_NON_ASSESSABLE, this N/A is CONDITIONAL: the same control is
+# PASS/FAIL once Prowler's mapping is present. Every count-based assertion over
+# it therefore pins the Prowler-absent condition explicitly via
+# `_load_map_without_prowler()` rather than inheriting it from whether the test
+# host happens to have Prowler installed — inside the scanner image it does.
+EXPECTED_NATIVE_ONLY = {
+    # All 14 CMMC 2.0 domains. Prowler's 800-171 rev2 file maps 9 of them
+    # (AC/AU/CA/CM/IA/IR/RA/SC/SI); AT/MA/MP/PE/PS carry no checks at all.
+    "CMMC 2.0 Level 2": {
+        "AC", "AT", "AU", "CM", "IA", "IR", "MA",
+        "MP", "PS", "PE", "RA", "CA", "SC", "SI",
+    },
+}
+
+
+def _expected_na_ids(framework):
+    """Control ids that are N/A when Prowler's mapping is absent."""
+    return EXPECTED_NON_ASSESSABLE.get(framework, set()) | EXPECTED_NATIVE_ONLY.get(
+        framework, set()
+    )
+
+
+def _load_map_without_prowler():
+    """A fresh compliance-map module with Prowler's data pinned absent.
+
+    `map_compliance` caches the native mapping per module instance, so the
+    override must be in place before the module is loaded and a fresh instance
+    is needed per call. The cache is primed here, while the override still
+    holds, so the caller cannot observe a differently-configured environment.
+    """
+    prev = os.environ.get("CLAUDESEC_PROWLER_COMPLIANCE_DIR")
+    os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = os.path.join(
+        os.path.dirname(__file__), "no-such-prowler-compliance-dir"
+    )
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "compliance_map_no_prowler",
+            os.path.join(os.path.dirname(__file__), "..", "lib", "compliance-map.py"),
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        mod._native_mapping()
+        return mod
+    finally:
+        if prev is None:
+            os.environ.pop("CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
+        else:
+            os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = prev
+
 # Tokens verified 0-emission across `scanner/checks/**`.
 #
 # SCOPE CORRECTION (2026-08-14). This list said "never appear in any scanner
@@ -137,6 +195,27 @@ class TestNonAssessableControlsTagged(unittest.TestCase):
                         "— it is not in EXPECTED_NON_ASSESSABLE.",
                     )
 
+    def test_each_framework_native_only_set_matches_expected(self):
+        for fw, controls in COMPLIANCE_CONTROL_MAP.items():
+            with self.subTest(framework=fw):
+                actual = {c["control"] for c in controls if c.get("native_only")}
+                self.assertEqual(
+                    actual,
+                    EXPECTED_NATIVE_ONLY.get(fw, set()),
+                    f"{fw} native_only set drifted from EXPECTED_NATIVE_ONLY.",
+                )
+
+    def test_native_only_and_non_assessable_never_overlap(self):
+        """The two N/A sources answer different questions; a control claiming
+        both would make its N/A unattributable."""
+        for fw in COMPLIANCE_CONTROL_MAP:
+            with self.subTest(framework=fw):
+                self.assertEqual(
+                    EXPECTED_NON_ASSESSABLE.get(fw, set())
+                    & EXPECTED_NATIVE_ONLY.get(fw, set()),
+                    set(),
+                )
+
     def test_nist_ca7_stays_assessable(self):
         nist = {c["control"]: c for c in COMPLIANCE_CONTROL_MAP["NIST 800-53 Rev5"]}
         self.assertTrue(nist["CA-7"].get("assessable", True))
@@ -177,12 +256,32 @@ class TestMapComplianceNaStatus(unittest.TestCase):
                     self.assertEqual(controls[control_id]["status"], "N/A")
 
     def test_assessable_control_never_reports_na(self):
+        """An assessable control is N/A only when it is `native_only` and Prowler
+        shipped no mapping for it — never from the keyword path."""
         result = map_compliance([])
         for fw, controls in result.items():
             for ctrl in controls:
-                if ctrl.get("assessable", True):
-                    with self.subTest(framework=fw, control=ctrl["control"]):
-                        self.assertNotEqual(ctrl["status"], "N/A")
+                if not ctrl.get("assessable", True) or ctrl.get("native_only"):
+                    continue
+                with self.subTest(framework=fw, control=ctrl["control"]):
+                    self.assertNotEqual(ctrl["status"], "N/A")
+
+    def test_na_comes_from_exactly_two_declared_sources(self):
+        """No third route to N/A. A control is N/A iff it is tagged
+        non-assessable or it is an unmapped `native_only` control."""
+        result = map_compliance([])
+        for fw, controls in result.items():
+            for ctrl in controls:
+                with self.subTest(framework=fw, control=ctrl["control"]):
+                    declared = not ctrl.get("assessable", True)
+                    unmapped = ctrl["match_source"] == "unmapped"
+                    self.assertEqual(ctrl["status"] == "N/A", declared or unmapped)
+                    if unmapped:
+                        self.assertTrue(
+                            ctrl.get("native_only"),
+                            f"{fw}/{ctrl['control']} reports match_source="
+                            "'unmapped' without being native_only.",
+                        )
 
     def test_matching_keyword_does_not_flip_na_control_to_fail(self):
         """A finding whose text contains an N/A control's own keyword must not
@@ -248,11 +347,11 @@ class TestComplianceSummaryExcludesNa(unittest.TestCase):
     N/A controls from total (total = pass + fail)."""
 
     def test_na_counts_match_expected_per_framework(self):
-        summary = compliance_summary(map_compliance([]))
+        cm = _load_map_without_prowler()
+        summary = cm.compliance_summary(cm.map_compliance([]))
         for fw in COMPLIANCE_CONTROL_MAP:
             with self.subTest(framework=fw):
-                expected_na = len(EXPECTED_NON_ASSESSABLE.get(fw, set()))
-                self.assertEqual(summary[fw]["na"], expected_na)
+                self.assertEqual(summary[fw]["na"], len(_expected_na_ids(fw)))
 
     def test_ismsp_total_excludes_na_controls(self):
         summary = compliance_summary(map_compliance([]))
@@ -267,11 +366,12 @@ class TestComplianceSummaryExcludesNa(unittest.TestCase):
         self.assertEqual(stats["total"], 27)
 
     def test_totals_are_allowlist_aware_for_every_framework(self):
-        summary = compliance_summary(map_compliance([]))
+        cm = _load_map_without_prowler()
+        summary = cm.compliance_summary(cm.map_compliance([]))
         for fw, controls in COMPLIANCE_CONTROL_MAP.items():
             with self.subTest(framework=fw):
                 stats = summary[fw]
-                expected_na = len(EXPECTED_NON_ASSESSABLE.get(fw, set()))
+                expected_na = len(_expected_na_ids(fw))
                 self.assertEqual(stats["na"], expected_na)
                 self.assertEqual(stats["total"], stats["pass"] + stats["fail"])
                 self.assertEqual(stats["total"], len(controls) - expected_na)

--- a/scanner/tests/test_dashboard_mapping_pure.py
+++ b/scanner/tests/test_dashboard_mapping_pure.py
@@ -314,13 +314,25 @@ class TestMapCompliance(unittest.TestCase):
 
     def test_empty_findings_every_control_passes(self):
         """Assessable controls PASS with no findings; non-assessable controls
-        (the 11 ISMS-P 3.x PII controls) are always N/A."""
+        (the 11 ISMS-P 3.x PII controls) and unmapped `native_only` controls
+        (the CMMC domains, when Prowler ships no mapping) are always N/A."""
         result = dm.map_compliance([])
+        # Independent anchor: `status` and `match_source` are co-produced, so
+        # the derived check below alone would stay green if native_only were
+        # deleted entirely and the CMMC domains reverted to a keyword PASS.
+        cmmc = result["CMMC 2.0 Level 2"]
+        assert len(cmmc) == 14
+        assert all(c["status"] == "N/A" for c in cmmc)
+        assert all(c["match_source"] == "unmapped" for c in cmmc)
+
         for framework, controls in result.items():
             assert framework in dm.COMPLIANCE_CONTROL_MAP
             for ctrl in controls:
-                expected_status = "N/A" if not ctrl.get("assessable", True) else "PASS"
-                assert ctrl["status"] == expected_status
+                na = (
+                    not ctrl.get("assessable", True)
+                    or ctrl["match_source"] == "unmapped"
+                )
+                assert ctrl["status"] == ("N/A" if na else "PASS")
                 assert ctrl["count"] == 0
                 assert ctrl["findings"] == []
 

--- a/scanner/tests/test_prowler_compliance_summary.py
+++ b/scanner/tests/test_prowler_compliance_summary.py
@@ -74,6 +74,30 @@ def _write(tmp_path, name, content):
     return path
 
 
+def test_provider_of_matches_the_dashboard_loaders_slugs():
+    """A provider-scoped compliance source (800-171 is AWS-only) must see the
+    same slug here as on the dashboard path, or the same scan would score
+    differently depending on which caller ran it."""
+    assert pcs._provider_of("/x/prowler-aws.ocsf.json") == "aws"
+    assert pcs._provider_of("/x/prowler-gcp.ocsf.json") == "gcp"
+    for name in ("prowler-k8s.ocsf.json", "prowler-kubernetes.ocsf.json",
+                 "prowler-eks-prod.ocsf.json"):
+        assert pcs._provider_of("/x/" + name) == "kubernetes", name
+    # No `prowler-` prefix: keep the stem rather than inventing a provider.
+    assert pcs._provider_of("/x/aws.ocsf.json") == "aws"
+
+
+def test_read_findings_reports_a_clean_provider_that_has_no_fail_findings(tmp_path):
+    """A clean provider is invisible in the findings list, so the provider set
+    is what tells "scanned and clean" from "not scanned at all"."""
+    _write(tmp_path, "prowler-aws.ocsf.json", PASS_ONLY_ARRAY)
+
+    findings, providers = pcs._read_findings(str(tmp_path))
+
+    assert findings == []
+    assert providers == {"aws"}
+
+
 def test_build_summary_json_array_fail_findings(tmp_path):
     _write(tmp_path, "prowler-aws.ocsf.json", FAIL_ARRAY)
 

--- a/scanner/tests/test_prowler_native_map.py
+++ b/scanner/tests/test_prowler_native_map.py
@@ -293,6 +293,62 @@ class TestNativeLoadFailureIsInert(unittest.TestCase):
         finally:
             os.path.dirname = original
 
+    def test_a_missing_sibling_module_yields_none_not_an_exception(self):
+        """Directly, because the path-rewriting test above passes vacuously on a
+        host with no Prowler installed — `load_all()` returns {} either way, so
+        it cannot tell a broken loader from an absent Prowler."""
+        cm = _load("compliance_map_missing_sibling", "compliance-map.py")
+        original = os.path.abspath
+        os.path.abspath = lambda p: "/nonexistent-lib-dir/compliance-map.py"
+        try:
+            self.assertIsNone(cm._load_native_module())
+        finally:
+            os.path.abspath = original
+
+    def test_a_module_that_raises_degrades_to_empty_not_a_crash(self):
+        class Exploding:
+            FRAMEWORK_NATIVE_PROVIDERS = {}
+
+            @staticmethod
+            def load_all():
+                raise RuntimeError("prowler package is half-installed")
+
+        cm = _load("compliance_map_exploding_loader", "compliance-map.py")
+        cm._NATIVE_CACHE = None
+        cm._load_native_module = lambda: Exploding()
+        self.assertEqual(cm._native_mapping(), {})
+        self.assertIsNone(cm._native_provider_scope("CMMC 2.0 Level 2"))
+
+    def test_a_malformed_provider_scope_table_degrades_to_unscoped(self):
+        class Malformed:
+            FRAMEWORK_NATIVE_PROVIDERS = ["not", "a", "mapping"]
+
+            @staticmethod
+            def load_all():
+                return {"SOC 2 (TSC)": {"CC6": frozenset({"x"})}}
+
+        cm = _load("compliance_map_malformed_scope", "compliance-map.py")
+        cm._NATIVE_CACHE = None
+        cm._load_native_module = lambda: Malformed()
+        self.assertEqual(cm._native_mapping(), {"SOC 2 (TSC)": {"CC6": frozenset({"x"})}})
+        self.assertIsNone(cm._native_provider_scope("CMMC 2.0 Level 2"))
+
+    def test_a_module_without_the_provider_scope_table_keeps_its_mapping(self):
+        """Version skew between the two sibling files costs the provider scope
+        and nothing else — discarding the whole mapping would blank every
+        natively-mapped control across all frameworks."""
+
+        class OldModule:
+            @staticmethod
+            def load_all():
+                return {"SOC 2 (TSC)": {"CC6": frozenset({"x"})}}
+
+        cm = _load("compliance_map_old_sibling", "compliance-map.py")
+        cm._NATIVE_CACHE = None
+        cm._load_native_module = lambda: OldModule()
+        self.assertEqual(cm._native_mapping(), {"SOC 2 (TSC)": {"CC6": frozenset({"x"})}})
+        self.assertIsNone(cm._native_provider_scope("CMMC 2.0 Level 2"))
+
 
 class TestAbsenceIsInert(unittest.TestCase):
     def test_without_prowler_every_control_uses_keywords(self):
@@ -300,8 +356,19 @@ class TestAbsenceIsInert(unittest.TestCase):
         self.addCleanup(os.environ.pop, "CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
         cm = _load("compliance_map_absent_under_test", "compliance-map.py")
         result = cm.map_compliance([])
-        sources = {c["match_source"] for controls in result.values() for c in controls}
-        self.assertEqual(sources, {"keyword"})
+        # Two sources, and only two: every keyword-bearing control falls back to
+        # keywords, and every `native_only` control reports "unmapped". A third
+        # value here would mean a control found some other way to be decided.
+        by_source = {}
+        for controls in result.values():
+            for c in controls:
+                by_source.setdefault(c["match_source"], []).append(c)
+        self.assertEqual(set(by_source), {"keyword", "unmapped"})
+        for c in by_source["unmapped"]:
+            self.assertTrue(c.get("native_only"))
+            self.assertEqual(c["status"], "N/A")
+        for c in by_source["keyword"]:
+            self.assertFalse(c.get("native_only"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
CMMC 2.0 Level 2's 110 practices are NIST SP 800-171 Rev. 2's requirements verbatim, so Prowler already ships the mapping. This registers `nist_800_171_revision_2_*.json` as an 8th framework — Phase 2 of `docs/plans/compliance-native-mapping-and-cmmc.md` (#450).

Rendered at **domain** granularity (14 domains = 800-171 families 3.1–3.14), because that is the granularity the evidence supports: Prowler carries 50 of the 110 requirements, so a practice-level table would be 60 rows of "no data".

Measured against the **pinned Prowler 5.30.1** file — 50 requirements, 49 with checks, 87 distinct checks:

| Domain | Family | Checks |
|---|---|---|
| SC | 3.13 | 50 |
| AC | 3.1 | 43 |
| AU / CM / IA | 3.3 / 3.4 / 3.5 | 21 each |
| IR | 3.6 | 14 |
| SI | 3.14 | 13 |
| CA | 3.12 | 9 |
| RA | 3.11 | 3 |
| AT, MA, MP, PE, PS | 3.2, 3.7–3.10 | **none** |

The plan doc's per-family numbers were measured on 5.38; they are corrected in place.

## Two ways this silently reports "compliant", both closed

### 1. Keywords → `native_only`

Every other framework falls back to substring matching when Prowler has no mapping. CMMC does not. A prototype keyword set built from the vocabulary of the target checks *themselves* measured **34.2%** coverage (CM 1/22, SI 1/13) — keywords here manufacture wrong answers rather than approximate right ones.

The 14 controls carry **empty** keyword lists and a `native_only` tag. A `native_only` control with no mapping reports `N/A` (`match_source: "unmapped"`) instead of taking the `count == 0 → PASS` default. A domain that was never evaluated must not read as passing.

### 2. Provider → `FRAMEWORK_NATIVE_PROVIDERS`

Caught in review. `load_framework()` reads the **installed Prowler package**, not the scan. Prowler ships 800-171 for AWS only, and the image strips `prowler/providers/{azure,gcp,...}` but never `prowler/compliance/**` — so a Kubernetes run carries a fully-populated AWS mapping that matches none of its findings, and all nine mapped domains fell through to PASS.

A k8s scan read **9 pass / 0 fail: a perfect CMMC score with zero CMMC evidence.** Verified against the real 5.30.1 file:

```text
before   k8s-only -> {'pass': 9, 'fail': 0, 'na':  5, 'total':  9}
after    k8s-only -> {'pass': 0, 'fail': 0, 'na': 14, 'total':  0}
         azure    -> {'pass': 0, 'fail': 0, 'na': 14, 'total':  0}
         aws      -> {'pass': 4, 'fail': 5, 'na':  5, 'total':  9}
```

`map_compliance` now takes `scanned_providers` so a **clean** AWS scan still scores PASS: a clean provider emits no FAIL findings and is invisible in the findings list, so deriving the set from findings alone cannot tell "clean" from "not scanned" and resolves conservatively toward N/A. Both callers pass it — `dashboard-gen` from `load_prowler_files`, `prowler_compliance_summary` from the artifact filenames (findings there now also carry `provider`).

`NIST 800-53 Rev5` is AWS-only in Prowler too and has the same false-PASS today. **Deliberately left unscoped** — pre-existing, and its own measurement.

## The N/A model now has two declared sources

It had assumed N/A ⟺ `assessable: False`. So:

- `EXPECTED_NATIVE_ONLY` joins `EXPECTED_NON_ASSESSABLE` as a single source of truth, with a drift guard and a no-overlap guard.
- The count-based guards pin the Prowler-absent condition explicitly via `_load_map_without_prowler()` instead of inheriting it from whether the host has Prowler installed (it does, inside the scanner image).
- A new guard pins that there is **no third route** to N/A.

## Test plan

- [x] `pytest scanner/tests/` — **2240 passed, 8 skipped**
- [x] `scanner/lib` coverage **99.40%** at the CI gate (`--cov-precision=2 --cov-fail-under=99`; floor 99, baseline 99.12) — `compliance-map.py`, `prowler_native_map.py`, `prowler_compliance_summary.py` all **100%**
- [x] Shell: `test_dashboard_control_liveness` 14/14 live, `test_asset_dashboard_control_liveness` 20/20 live, `test_generate_html_dashboard` 36/36, `test_prowler_dashboard_summary` 24/24, `test_prowler_dashboard_summary_provider_label` 20/20, `test_output_prowler_severity` — all rc=0
- [x] `markdownlint` clean, `lychee` 0 errors / 0 redirects
- [x] `gitleaks protect --staged` clean
- [x] End-to-end against the real pinned `nist_800_171_revision_2_aws.json` (fetched at tag 5.30.1), not a fixture
- [x] **Six mutations** of the new logic each caught by the suite: non-greedy family regex (`3_13_*` → AC), `native_only` fallthrough, `native_only` branch removal, wrong glob, provider-scope removal, N/A status clause

Independent `sec-reviewer` pass found the provider false-PASS (HIGH) and two circular guards (MEDIUM); both are fixed here and re-verified with the reviewer's own defeating mutation, which now fails the two guards it previously passed (89 → 2 failed).

### Reference

CMMC 2.0 Level 2 practices are [NIST SP 800-171 Rev. 2](https://csrc.nist.gov/pubs/sp/800/171/r2/upd1/final) requirements, incorporated by the CMMC program rule at 32 CFR Part 170.

### Known, not fixed here

- `NIST 800-53 Rev5` carries the same AWS-only false-PASS (pre-existing).
- `docs/guides/compliance-mapping.md` still says "SOC 2 is keyword-driven, not Prowler-native", which #451 made stale — untouched to keep this diff scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)