### PR TITLE
fix(compliance): NIST 800-53 scored 10/10 on a Kubernetes estate

### DIFF
--- a/docs/guides/compliance-mapping.md
+++ b/docs/guides/compliance-mapping.md
@@ -153,18 +153,96 @@ mapping reports **N/A** (`match_source: "unmapped"`) instead of taking the
 compliant. That is why AT/MA/MP/PE/PS are always N/A today.
 
 **Coverage limit: AWS only.** Prowler ships 800-171 for AWS and no other
-provider, and the mapping is read from the installed Prowler package rather
-than from the scan — so on a Kubernetes-only run it stays fully populated with
-AWS check ids, matches nothing, and would otherwise score all nine mapped
-domains PASS on zero evidence. The framework is therefore scoped to the `aws`
-provider: a run that did not scan AWS reports **every** domain N/A, and the
-dashboard states the limit under the framework heading.
-
-The same false-PASS exists today for **NIST 800-53 Rev5**, which is also
-AWS-only in Prowler. It is left unscoped for now because changing it is a
-separate, separately-measured behaviour change.
+provider, so a run that did not scan AWS reports **every** CMMC domain N/A and
+the dashboard states the limit under the framework heading. This is one case of
+the general rule in [Native provider scope](#native-provider-scope) below.
 
 [sp800-171]: https://csrc.nist.gov/pubs/sp/800/171/r2/upd1/final
+
+---
+
+## Native provider scope
+
+The native mapping is read from the **installed Prowler package**, not from the
+scan. Prowler ships each framework for some providers and not others, so a
+mapping is populated whenever Prowler is installed — including on a run that
+scanned none of those providers. Every natively-mapped control then matches
+zero findings and takes the `count == 0 → PASS` default.
+
+Provider coverage at the pinned Prowler 5.30.1:
+
+| Framework | Providers Prowler ships it for |
+|-----------|-------------------------------|
+| ISO 27001:2022 | aws, azure, gcp, kubernetes, m365, nhn |
+| PCI-DSS v4.0.1 | aws, azure, gcp, kubernetes |
+| SOC 2 (TSC) | aws, azure, gcp |
+| KISA ISMS-P | aws |
+| NIST 800-53 Rev5 | aws |
+| CMMC 2.0 Level 2 (800-171) | aws |
+
+Measured on a Kubernetes-only scan, with 62 real Kubernetes check ids from
+Prowler's own `pci_4.0_kubernetes.json` and `iso27001_2022_kubernetes.json`
+supplied as FAIL findings:
+
+| Framework | Before scoping | After scoping |
+|-----------|----------------|---------------|
+| NIST 800-53 Rev5 | **10 pass / 0 fail** (all `prowler`) | 5 pass / 5 fail (all `keyword`) |
+| SOC 2 (TSC) | **6 pass / 0 fail** (all `prowler`) | 3 pass / 3 fail (all `keyword`) |
+| KISA ISMS-P | 20 pass / 7 fail (16 controls on `prowler`) | 9 pass / 18 fail |
+| PCI-DSS v4.0.1 | 0 pass / 7 fail | totals unchanged — Prowler ships a k8s file |
+| ISO 27001:2022 | 3 pass / 3 fail | totals unchanged, but one more control moves to `keyword` (see below) |
+
+NIST 800-53 and SOC 2 were reporting a perfect score on an estate whose
+evidence they could never read. Five NIST failures, three SOC 2 failures, and
+eleven KISA failures were hidden.
+
+**The gate is per control, not per framework.** The loader *merges* every
+provider file into one check set per control, so "ISO ships for kubernetes" can
+be true while an individual control's checks are all AWS. A framework-level
+scope would leave that case wide open, and it is not hypothetical — it reaches
+the flagship provider. Measured at 5.30.1, of the repo's seven ISO controls:
+
+| ISO control | Evidenced by |
+|-------------|--------------|
+| A.8.2 | aws, azure, gcp, kubernetes, m365, nhn |
+| A.5.1 | aws, azure, gcp, kubernetes, m365 |
+| A.8.5 | aws, azure, kubernetes, m365 |
+| A.8.24 | aws, azure, gcp, kubernetes |
+| A.8.9 | aws, azure, gcp, nhn |
+| **A.8.8** | **m365 only** |
+| A.8.28 | *(no native mapping — keywords)* |
+
+So on an **AWS** run, `A.8.8` used to report `PASS` from Prowler's exact
+mapping while every check backing it belongs to m365. It now reports `keyword`.
+On a Kubernetes run, `A.8.9` is gated the same way.
+
+**The scope is derived, not declared.** It is built in the same pass, from the
+same parsed content, as the mapping it scopes: a provider is recorded for a
+control only once one of its requirements survived the merge. Deriving it from
+filenames instead would let a file that exists but contributes nothing widen
+the scope past the evidence. A hand-written list — the shape #455 used for CMMC
+alone — would have to be revised on every Prowler release, and the table above
+shows it would have been incomplete from the day it was written.
+
+**Gating never invents an N/A.** A gated control falls back to its existing
+behaviour: keyword-bearing controls return to keywords, and `native_only`
+controls (CMMC's) report N/A. A GitHub-only run is out of scope for every
+framework — the only file under Prowler's `compliance/github/` is
+`cis_1.0_github.json`, and CIS is deliberately not registered as a native
+source — so it keeps the keyword path, which is the case that path exists for.
+
+**The dashboard says which path a framework took.** Each framework renders an
+*Evidence source* line counting its controls by provenance — `exact` (Prowler's
+requirement→check mapping), `keyword` (approximation, no reachable native
+mapping for this run), `not assessed` (N/A). Gating that nothing displays is
+gating an operator cannot audit, and the keyword path reproduces only 41.5% of
+Prowler's own mapping where both have an opinion.
+
+**Known limitation, not addressed by the scope.** On a *mixed* run (e.g. AWS +
+GitHub), a control whose native providers include AWS keeps its native mapping,
+and GitHub findings can never match an AWS check id — so they stay invisible to
+that control. Restoring them means matching per finding rather than gating per
+control, which is a separate change.
 
 ---
 

--- a/scanner/lib/compliance-map.py
+++ b/scanner/lib/compliance-map.py
@@ -840,9 +840,10 @@ COMPLIANCE_CONTROL_MAP = {
     # loaded from the installed package rather than from the scan — so on a
     # Kubernetes-only run it stays populated with AWS check ids, matches
     # nothing, and would score all nine mapped domains PASS on no evidence.
-    # `prowler_native_map.FRAMEWORK_NATIVE_PROVIDERS` scopes the source to aws
-    # so those domains report N/A instead; the limit is also stated in the
-    # dashboard under the framework heading (COMP_FW_NOTES).
+    # `prowler_native_map.native_control_providers()` records, per control, the
+    # providers that actually contributed a check, so those domains report N/A
+    # instead; the limit is also stated in the dashboard under the framework
+    # heading (COMP_FW_NOTES).
     #
     # Source: CMMC 2.0 Level 2 = NIST SP 800-171 Rev. 2 (32 CFR Part 170);
     # domain codes per NIST SP 800-171 Rev. 2 requirement families 3.1–3.14.
@@ -1032,28 +1033,27 @@ def _native_mapping():
         except Exception:
             _NATIVE_CACHE = {}
         # Read separately and defensively: a sibling predating
-        # FRAMEWORK_NATIVE_PROVIDERS must cost only the provider scope, not the
-        # whole mapping. Losing the scope re-opens the AWS-only false-PASS, so
-        # this degrades toward "unscoped", which is the pre-CMMC behaviour.
+        # `native_control_providers` must cost only the provider scope, not the
+        # whole mapping. Losing the scope re-opens the false-PASS, so this
+        # degrades toward "unscoped", which is the pre-#455 behaviour.
         try:
-            _NATIVE_PROVIDER_SCOPE = dict(
-                getattr(module, "FRAMEWORK_NATIVE_PROVIDERS", {}) or {}
-            )
+            scopes = getattr(module, "native_control_providers", None)
+            _NATIVE_PROVIDER_SCOPE = dict(scopes() if scopes else {})
         except Exception:
             _NATIVE_PROVIDER_SCOPE = {}
     return _NATIVE_CACHE
 
 
-def _native_provider_scope(framework):
-    """Providers this framework's native file can evidence, or None if unscoped.
+def _native_provider_scope(framework, control):
+    """Providers that can evidence this control, or None when nothing is known.
 
-    See `prowler_native_map.FRAMEWORK_NATIVE_PROVIDERS`: the mapping comes from
-    the installed Prowler package, not from the scan, so an AWS-only source
-    stays populated on a Kubernetes run and would score every mapped control
-    PASS on zero evidence.
+    See `prowler_native_map.native_control_providers()`: the mapping comes from
+    the installed Prowler package, not from the scan, so checks belonging to a
+    provider the run never touched stay in the control's list, match nothing,
+    and would score it PASS on evidence it could not have read.
     """
     _native_mapping()  # primes both caches
-    return (_NATIVE_PROVIDER_SCOPE or {}).get(framework)
+    return (_NATIVE_PROVIDER_SCOPE or {}).get(framework, {}).get(control)
 
 
 def map_compliance(all_findings, scanned_providers=None):
@@ -1074,13 +1074,22 @@ def map_compliance(all_findings, scanned_providers=None):
 
     `scanned_providers` is the set of provider slugs the run actually covered
     (e.g. `{"aws", "kubernetes"}`). It matters because the native mapping is
-    loaded from the INSTALLED Prowler package rather than from the scan: an
-    AWS-only source such as 800-171 stays fully populated on a Kubernetes run,
-    matches nothing, and would score every mapped control PASS on no evidence.
+    loaded from the INSTALLED Prowler package rather than from the scan: a
+    source Prowler ships for AWS only stays fully populated on a Kubernetes run,
+    matches nothing, and scores every natively-mapped control PASS on no
+    evidence. Measured on a k8s-only scan against Prowler 5.30.1, that was
+    NIST 800-53 at 10 pass / 0 fail and SOC 2 at 6 pass / 0 fail.
+
+    When a run reaches none of a framework's native providers, that framework's
+    mapping is dropped for the run. What each control does next is its existing
+    behaviour: a keyword-bearing control returns to keywords (NIST 800-53 goes
+    to 5 pass / 5 fail on the same scan), and a `native_only` control reports
+    "unmapped"/N/A. Gating never invents an N/A for a control that has keywords.
+
     Pass it from the caller when the provider list is known independently of the
     findings — a clean provider contributes zero FAIL findings, so deriving it
     from `all_findings` alone cannot distinguish "clean" from "not scanned" and
-    resolves that ambiguity conservatively, toward N/A.
+    resolves that ambiguity conservatively, away from the native path.
     """
     native = _native_mapping()
     if scanned_providers is None:
@@ -1092,14 +1101,15 @@ def map_compliance(all_findings, scanned_providers=None):
     result = {}
     for framework, controls in COMPLIANCE_CONTROL_MAP.items():
         fw_native = native.get(framework, {})
-        covered = _native_provider_scope(framework)
-        if covered is not None and not (scanned & set(covered)):
-            # No evidence can reach this framework's native mapping: drop it so
-            # `native_only` controls report "unmapped" instead of a free PASS.
-            fw_native = {}
         mapped = []
         for ctrl in controls:
             native_checks = fw_native.get(ctrl["control"])
+            covered = _native_provider_scope(framework, ctrl["control"])
+            if native_checks and covered and not (scanned & set(covered)):
+                # Every check evidencing this control belongs to a provider the
+                # run never touched, so the native list can only ever match
+                # zero. Drop it rather than let `count == 0` read as PASS.
+                native_checks = None
             matching = []
             if native_checks:
                 match_source = "prowler"

--- a/scanner/lib/dashboard-template.html
+++ b/scanner/lib/dashboard-template.html
@@ -323,6 +323,9 @@ tr.arch-highlight td{animation:archPulseTd 1.2s ease 2}
 .comp-section.expanded .comp-body{display:block}
 .comp-arch-links{padding:.5rem 1rem;background:rgba(255,255,255,.02);border-bottom:1px solid var(--border)}
 .comp-fw-note{padding:.5rem 1rem;background:rgba(255,255,255,.02);border-bottom:1px solid var(--border);color:var(--muted);font-size:.8rem;line-height:1.5}
+.comp-fw-source{display:flex;flex-wrap:wrap;align-items:center;gap:.5rem;padding:.4rem 1rem;background:rgba(255,255,255,.02);border-bottom:1px solid var(--border);color:var(--muted);font-size:.75rem}
+.comp-src-label{text-transform:uppercase;letter-spacing:.04em;font-size:.68rem;opacity:.75}
+.comp-src-prowler{color:var(--success)}.comp-src-keyword{color:var(--warning)}.comp-src-unmapped{color:#94a3b8}
 .comp-pass td{opacity:.7}.comp-fail td{}.comp-st-pass{color:#22c55e;font-weight:700}.comp-st-fail{color:#ef4444;font-weight:700}.comp-na td{opacity:.6}.comp-st-na{color:#94a3b8;font-weight:700}
 /* Trend */
 .trend-section{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius);padding:1.25rem;margin-bottom:1.5rem}

--- a/scanner/lib/dashboard_html_compliance.py
+++ b/scanner/lib/dashboard_html_compliance.py
@@ -32,6 +32,49 @@ COMP_FW_NOTES = {
 }
 
 
+# How each `match_source` should read to an operator, and in what order.
+#
+# WHY THIS IS RENDERED. `map_compliance()` decides every control by one of three
+# routes and records which, but nothing used to display it — so a control scored
+# by Prowler's exact requirement->check data and one scored by substring
+# matching looked identical. They are not: the keyword path reproduces 41.5% of
+# Prowler's own mapping where both have an opinion. The provider scope moves a
+# control onto that path on any run that did not scan a provider its checks
+# belong to, which makes an unlabelled table actively misleading.
+_MATCH_SOURCE_LABELS = (
+    ("prowler", "exact", "Prowler requirement→check mapping"),
+    ("keyword", "keyword", "keyword approximation — no native mapping reachable for this run"),
+    ("unmapped", "not assessed", "no reachable mapping and no keyword list — reported N/A"),
+)
+
+
+def _evidence_source_html(controls) -> str:
+    """A one-line evidence-provenance breakdown for one framework's controls."""
+    counts = {}
+    for ctrl in controls:
+        source = ctrl.get("match_source")
+        if source:
+            counts[source] = counts.get(source, 0) + 1
+    if not counts:
+        return ""
+    parts = []
+    for key, label, title in _MATCH_SOURCE_LABELS:
+        count = counts.get(key)
+        if count:
+            parts.append(
+                f'<span class="comp-src-{key}" title="{h(title)}">{count} {h(label)}</span>'
+            )
+    # A source this renderer does not know about is still counted: dropping it
+    # would silently understate the framework's control count.
+    for key in sorted(set(counts) - {k for k, _, _ in _MATCH_SOURCE_LABELS}):
+        parts.append(f"<span>{counts[key]} {h(key)}</span>")
+    return (
+        '<div class="comp-fw-source"><span class="comp-src-label">Evidence source</span>'
+        + " · ".join(parts)
+        + "</div>"
+    )
+
+
 def _build_compliance_html(compliance_map) -> str:
     """Build the Compliance tab HTML from the compliance_map."""
     comp_html = '<div class="comp-frameworks">'
@@ -66,6 +109,7 @@ def _build_compliance_html(compliance_map) -> str:
         fw_note = COMP_FW_NOTES.get(framework)
         if fw_note:
             comp_html += f'<div class="comp-fw-note">{h(fw_note)}</div>'
+        comp_html += _evidence_source_html(controls)
         comp_html += '<div class="comp-body"><table><thead><tr><th>Control</th><th>Name</th><th>Status</th><th>Related</th><th>Summary · Remediation</th></tr></thead><tbody>'
         for ctrl in controls:
             if ctrl["status"] == "PASS":

--- a/scanner/lib/prowler_native_map.py
+++ b/scanner/lib/prowler_native_map.py
@@ -168,24 +168,35 @@ FRAMEWORK_SOURCES = {
 }
 
 
-# framework -> the providers its native file can produce evidence for.
+# ── Provider scope ───────────────────────────────────────────────────────────
 #
 # WHY THIS EXISTS. `load_framework()` reads the INSTALLED Prowler package, not
-# the scan. Prowler ships 800-171 for AWS and nothing else, so the mapping is
-# populated with AWS check ids whenever Prowler is installed — including on a
-# Kubernetes-only run, where no finding can ever match one and all nine mapped
-# domains would fall through to `count == 0 -> PASS`. That is a perfect CMMC
-# score for an estate that produced no CMMC evidence, and the shipped image
-# makes it reachable: Dockerfile strips `prowler/providers/{azure,gcp,...}` but
-# never `prowler/compliance/**`, so a k8s scan carries the AWS 800-171 file.
+# the scan. Prowler ships each framework for some providers and not others, so
+# the mapping is populated whenever Prowler is installed — including on a run
+# that scanned none of those providers, where no finding can ever match a check
+# id and every natively-mapped control falls through to `count == 0 -> PASS`.
+# The shipped image makes this reachable: the Dockerfile strips
+# `prowler/providers/{azure,gcp,...}` but never `prowler/compliance/**`.
 #
-# A framework absent from this dict is unscoped and keeps the pre-existing
-# behaviour. `NIST 800-53 Rev5` is AWS-only in Prowler too and has the same
-# false-PASS today; it is deliberately NOT scoped here because it is a
-# pre-existing, separately-measured behaviour change, not part of adding CMMC.
-FRAMEWORK_NATIVE_PROVIDERS = {
-    "CMMC 2.0 Level 2": frozenset({"aws"}),
-}
+# Measured on a Kubernetes-only scan against Prowler 5.30.1 with 62 real k8s
+# check ids as FAIL findings:
+#
+#   NIST 800-53 Rev5   10 pass /  0 fail   all 10 from `prowler`, zero evidence
+#   SOC 2 (TSC)         6 pass /  0 fail   all 6 assessable, zero evidence
+#   KISA ISMS-P        16 of 42 controls decided by AWS check ids
+#   PCI-DSS v4.0.1      0 pass /  7 fail   correct — Prowler ships a k8s file
+#   ISO 27001:2022      3 pass /  3 fail   correct — ditto
+#
+# DERIVED, NOT DECLARED. This was a hand-written `{framework: providers}` dict
+# when #455 scoped CMMC alone. A dict cannot be right for long: the answer is
+# already on disk in the directory each file was loaded from, it differs per
+# Prowler version, and the measurement above shows a hand-list would have had
+# to name three more frameworks the moment it was written. Reading the layout
+# `load_framework()` already walks removes both the drift and the omission.
+
+
+# The scope itself is built by `load_framework_and_providers()` below, in the
+# same pass and by the same test as the mapping it scopes.
 
 
 # ── Loading ──────────────────────────────────────────────────────────────────
@@ -201,33 +212,85 @@ def _requirements(path):
     return reqs if isinstance(reqs, list) else []
 
 
-def load_framework(framework):
-    """`{control_id: frozenset(check_ids)}` for one framework, `{}` if unavailable.
+def load_framework_and_providers(framework):
+    """`({control: frozenset(checks)}, {control: frozenset(providers)})`.
 
     Merges every provider file for the framework (aws + azure + gcp + ...), since
     a control is satisfied by evidence from whichever provider was scanned.
     Requirements with no checks are omitted rather than stored empty: an empty
     set and "no native opinion" must not be confused, because the first would
     silently mark a control as having zero evidence.
+
+    The provider map is built PER CONTROL, in the same pass and by the same
+    test as the mapping: a provider is recorded for a control only once one of
+    its requirements survived into `merged`. Both properties are load-bearing.
+
+    Per control, because the merge is what hides the gap. A framework-level
+    scope says "ISO ships for kubernetes", which is true, while ISO `A.8.9`'s
+    twenty checks are all AWS — so on a Kubernetes run that control matches
+    nothing and reports PASS with no evidence it could ever have read. Measured
+    at 5.30.1, ISO alone has such controls in both directions: `A.8.9`, `A.8.4`,
+    `A.8.7` (aws-only) and `A.5.2` (kubernetes-only).
+
+    From content, because existence is not contribution. A file that parses to
+    no control (unparseable JSON, every requirement checkless, every id
+    unnormalizable) would otherwise widen the scope past the evidence.
     """
     source = FRAMEWORK_SOURCES.get(framework)
     if not source:
-        return {}
+        return {}, {}
     pattern, normalize = source
     merged = {}
+    providers = {}
     for directory in prowler_compliance_dirs():
         for path in sorted(glob.glob(os.path.join(directory, "*", pattern))):
+            provider = os.path.basename(os.path.dirname(path))
             for req in _requirements(path):
-                checks = req.get("Checks") or []
+                checks = [c for c in (req.get("Checks") or []) if isinstance(c, str) and c]
                 if not checks:
                     continue
                 control = normalize(str(req.get("Id", "")))
                 if not control:
                     continue
-                merged.setdefault(control, set()).update(
-                    c for c in checks if isinstance(c, str) and c
-                )
-    return {k: frozenset(v) for k, v in merged.items() if v}
+                merged.setdefault(control, set()).update(checks)
+                providers.setdefault(control, set()).add(provider)
+    return (
+        {k: frozenset(v) for k, v in merged.items() if v},
+        {k: frozenset(v) for k, v in providers.items() if merged.get(k)},
+    )
+
+
+def load_framework(framework):
+    """`{control_id: frozenset(check_ids)}` for one framework, `{}` if unavailable."""
+    return load_framework_and_providers(framework)[0]
+
+
+def control_providers(framework):
+    """`{control: frozenset(providers)}` — who can evidence each control."""
+    return load_framework_and_providers(framework)[1]
+
+
+def framework_providers(framework):
+    """Union of `control_providers()` — every provider this framework reads."""
+    out = set()
+    for provs in control_providers(framework).values():
+        out |= provs
+    return frozenset(out)
+
+
+def native_control_providers():
+    """`{framework: {control: frozenset(providers)}}` for every loaded framework.
+
+    A framework that contributed nothing is omitted rather than mapped empty:
+    it has no native mapping to gate, and an empty map would read as "reachable
+    by nobody" — which would gate a framework already running on keywords.
+    """
+    out = {}
+    for framework in FRAMEWORK_SOURCES:
+        mapping, providers = load_framework_and_providers(framework)
+        if mapping and providers:
+            out[framework] = providers
+    return out
 
 
 def load_all():

--- a/scanner/tests/test_cmmc_native_map.py
+++ b/scanner/tests/test_cmmc_native_map.py
@@ -348,8 +348,12 @@ class TestCmmcProviderScope(unittest.TestCase):
             ]
         }
 
-    def test_scope_is_declared_as_aws_only(self):
-        self.assertEqual(pnm.FRAMEWORK_NATIVE_PROVIDERS[FRAMEWORK], frozenset({"aws"}))
+    def test_scope_is_derived_from_the_file_that_supplied_the_mapping(self):
+        """Derived, not declared: the fixture lives in `aws/`, so that is the
+        scope. A hand-written constant would have to be kept in step with every
+        Prowler release."""
+        self.assertEqual(pnm.framework_providers(FRAMEWORK), frozenset({"aws"}))
+        self.assertEqual(pnm.framework_providers(FRAMEWORK), frozenset({"aws"}))
 
     def test_kubernetes_only_run_reports_na_not_a_perfect_score(self):
         findings = [
@@ -414,15 +418,16 @@ class TestCmmcProviderScope(unittest.TestCase):
         self.assertEqual(controls["AC"]["status"], "N/A")
         self.assertEqual(controls["SC"]["status"], "N/A")
 
-    def test_unscoped_frameworks_are_left_alone(self):
-        """Only CMMC is scoped. NIST 800-53 is AWS-only in Prowler too and has
-        the same latent false-PASS, deliberately not changed here."""
-        self.assertEqual(set(pnm.FRAMEWORK_NATIVE_PROVIDERS), {FRAMEWORK})
+    def test_a_framework_with_no_file_at_all_is_not_gated(self):
+        """Only frameworks that HAVE a native file get a scope. One running
+        purely on keywords must not be gated into silence by an empty set."""
+        self.assertEqual(set(pnm.native_control_providers()), {FRAMEWORK})
         result = self.cm.map_compliance(
             [{"check": "x", "title": "t", "message": "m", "provider": "kubernetes"}]
         )
         iso = {c["control"]: c for c in result["ISO 27001:2022"]}
         self.assertNotEqual(iso["A.8.9"]["status"], "N/A")
+        self.assertEqual(iso["A.8.9"]["match_source"], "keyword")
 
 
 class TestCmmcIsRendered(unittest.TestCase):

--- a/scanner/tests/test_native_provider_scope.py
+++ b/scanner/tests/test_native_provider_scope.py
@@ -1,0 +1,587 @@
+"""
+Tests for the provider scope on Prowler's native compliance mapping.
+
+THE FAILURE THIS EXISTS FOR
+---------------------------
+`load_framework()` reads the INSTALLED Prowler package, not the scan. Prowler
+ships each framework for some providers and not others, so a mapping is
+populated whenever Prowler is installed — including on a run that scanned none
+of those providers. Every natively-mapped control then matches zero findings
+and takes the `count == 0 -> PASS` default.
+
+Measured on a Kubernetes-only scan against Prowler 5.30.1, with 62 real
+Kubernetes check ids from Prowler's own `pci_4.0_kubernetes.json` and
+`iso27001_2022_kubernetes.json` supplied as FAIL findings:
+
+    framework            before (unscoped)      after (scoped)
+    NIST 800-53 Rev5     10 pass /  0 fail      5 pass /  5 fail
+    SOC 2 (TSC)           6 pass /  0 fail      3 pass /  3 fail
+    KISA ISMS-P          20 pass /  7 fail      9 pass / 18 fail
+    PCI-DSS v4.0.1        0 pass /  7 fail      unchanged (k8s file exists)
+    ISO 27001:2022        3 pass /  3 fail      unchanged (ditto)
+
+NIST 800-53 and SOC 2 were reporting a PERFECT score on an estate whose
+evidence they had never been able to read. Prowler ships both for AWS only
+(SOC 2 also azure and gcp — still not kubernetes). Five NIST failures, three
+SOC 2 failures and eleven KISA failures were hidden.
+
+WHY THE SCOPE IS DERIVED AND NOT DECLARED
+------------------------------------------
+#455 scoped CMMC with a hand-written `{framework: providers}` dict. The
+measurement above is why that shape cannot hold: it was already wrong for three
+more frameworks the moment it was written, and the correct answer differs per
+Prowler version. The provider is the directory each file was loaded from —
+already on disk, already walked by `load_framework()`.
+
+Hermetic: fixtures are written to a tmpdir and pointed at with
+`CLAUDESEC_PROWLER_COMPLIANCE_DIR`. Prowler is not required.
+"""
+
+import importlib.util
+import json
+import os
+import tempfile
+import unittest
+
+_LIB = os.path.join(os.path.dirname(__file__), "..", "lib")
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(_LIB, filename))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pnm = _load("prowler_native_map_scope", "prowler_native_map.py")
+
+
+def _write_fixture(root, provider, filename, requirements):
+    d = os.path.join(root, provider)
+    os.makedirs(d, exist_ok=True)
+    with open(os.path.join(d, filename), "w", encoding="utf-8") as fh:
+        json.dump({"Requirements": requirements}, fh)
+
+
+class _ScopedFixture(unittest.TestCase):
+    """Base: a tmpdir compliance tree with the env override restored on exit."""
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.root = self._tmp.name
+        self.addCleanup(self._tmp.cleanup)
+        prev = os.environ.get("CLAUDESEC_PROWLER_COMPLIANCE_DIR")
+        os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = self.root
+        self.addCleanup(self._restore, prev)
+
+    @staticmethod
+    def _restore(prev):
+        if prev is None:
+            os.environ.pop("CLAUDESEC_PROWLER_COMPLIANCE_DIR", None)
+        else:
+            os.environ["CLAUDESEC_PROWLER_COMPLIANCE_DIR"] = prev
+
+
+class TestScopeDerivation(_ScopedFixture):
+    def test_scope_is_the_directory_the_file_came_from(self):
+        _write_fixture(self.root, "aws", "nist_800_53_revision_5_aws.json",
+                       [{"Id": "ac_2", "Checks": ["iam_a"]}])
+        self.assertEqual(
+            pnm.framework_providers("NIST 800-53 Rev5"), frozenset({"aws"})
+        )
+
+    def test_multi_provider_frameworks_collect_every_directory(self):
+        for provider in ("aws", "azure", "gcp"):
+            _write_fixture(self.root, provider, f"soc2_{provider}.json",
+                           [{"Id": "cc_6_1", "Checks": [f"{provider}_check"]}])
+        self.assertEqual(
+            pnm.framework_providers("SOC 2 (TSC)"),
+            frozenset({"aws", "azure", "gcp"}),
+        )
+
+    def test_a_framework_with_no_file_scopes_to_nothing(self):
+        self.assertEqual(pnm.framework_providers("SOC 2 (TSC)"), frozenset())
+
+    def test_an_unregistered_framework_scopes_to_nothing(self):
+        self.assertEqual(pnm.framework_providers("Not A Framework"), frozenset())
+
+    def test_scopes_omit_frameworks_with_no_file_rather_than_mapping_them_empty(self):
+        """An empty set would read as "scoped to nothing" and gate a framework
+        that has no native mapping to gate — silencing its keyword path."""
+        _write_fixture(self.root, "aws", "soc2_aws.json",
+                       [{"Id": "cc_6_1", "Checks": ["x"]}])
+        scopes = pnm.native_control_providers()
+        self.assertEqual(set(scopes), {"SOC 2 (TSC)"})
+        self.assertNotIn("NIST 800-53 Rev5", scopes)
+
+    def test_derivation_agrees_with_the_mapping_it_scopes(self):
+        """A framework that loaded a mapping must have a non-empty scope, or the
+        gate would close on evidence that does exist."""
+        for provider in ("aws", "azure"):
+            _write_fixture(self.root, provider, f"soc2_{provider}.json",
+                           [{"Id": "cc_6_1", "Checks": [f"{provider}_check"]}])
+        for framework in pnm.load_all():
+            with self.subTest(framework=framework):
+                self.assertTrue(pnm.framework_providers(framework))
+
+    def test_a_file_that_contributes_nothing_does_not_widen_the_scope(self):
+        """Existence is not contribution. A provider file that parses to no
+        control must stay out of the scope, or the gate opens for a provider
+        whose evidence can never match — the very PASS this closes."""
+        _write_fixture(self.root, "aws", "soc2_aws.json",
+                       [{"Id": "cc_6_1", "Checks": ["real_check"]}])
+        # Every requirement checkless.
+        _write_fixture(self.root, "azure", "soc2_azure.json",
+                       [{"Id": "cc_6_2", "Checks": []}, {"Id": "cc_6_3"}])
+        # Present but unparseable.
+        d = os.path.join(self.root, "gcp")
+        os.makedirs(d, exist_ok=True)
+        with open(os.path.join(d, "soc2_gcp.json"), "w", encoding="utf-8") as fh:
+            fh.write("{not json")
+        self.assertEqual(pnm.framework_providers("SOC 2 (TSC)"), frozenset({"aws"}))
+
+
+class TestEveryFrameworkIsScoped(_ScopedFixture):
+    """A single-framework fixture cannot catch a scope that skips frameworks.
+
+    Measured defeat (2026-08-18): adding `if framework in ("PCI-DSS v4.0.1",
+    "ISO 27001:2022", "KISA ISMS-P"): continue` to `native_control_providers()`
+    left the whole suite at `2258 passed` while restoring KISA ISMS-P to
+    20 pass / 7 fail on a Kubernetes-only run — re-hiding the eleven failures
+    this change exists to expose. Every assertion here therefore runs against a
+    tree holding files for ALL six registered frameworks at once.
+    """
+
+    # Provider layout of Prowler 5.30.1, verified against the tag. This is the
+    # regression pin the doc table claims; a Prowler bump that moves a file
+    # must fail here rather than drift the docs silently.
+    EXPECTED = {
+        "ISO 27001:2022": {"aws", "azure", "gcp", "kubernetes", "m365", "nhn"},
+        "PCI-DSS v4.0.1": {"aws", "azure", "gcp", "kubernetes"},
+        "SOC 2 (TSC)": {"aws", "azure", "gcp"},
+        "KISA ISMS-P": {"aws"},
+        "NIST 800-53 Rev5": {"aws"},
+        "CMMC 2.0 Level 2": {"aws"},
+    }
+    FILENAMES = {
+        "ISO 27001:2022": "iso27001_2022_{p}.json",
+        "PCI-DSS v4.0.1": "pci_4.0_{p}.json",
+        "SOC 2 (TSC)": "soc2_{p}.json",
+        "KISA ISMS-P": "kisa_isms_p_2023_{p}.json",
+        "NIST 800-53 Rev5": "nist_800_53_revision_5_{p}.json",
+        "CMMC 2.0 Level 2": "nist_800_171_revision_2_{p}.json",
+    }
+    # One real requirement id per framework, so each file contributes a control.
+    REQ_ID = {
+        "ISO 27001:2022": "A.8.5",
+        "PCI-DSS v4.0.1": "1.2.5.1",
+        "SOC 2 (TSC)": "cc_6_1",
+        "KISA ISMS-P": "2.9.4",
+        "NIST 800-53 Rev5": "ac_2",
+        "CMMC 2.0 Level 2": "3_1_1",
+    }
+
+    def setUp(self):
+        super().setUp()
+        for framework, providers in self.EXPECTED.items():
+            for provider in providers:
+                _write_fixture(
+                    self.root,
+                    provider,
+                    self.FILENAMES[framework].format(p=provider),
+                    [{"Id": self.REQ_ID[framework], "Checks": [f"{provider}_check"]}],
+                )
+
+    def test_every_registered_framework_with_a_mapping_is_scoped(self):
+        scopes = pnm.native_control_providers()
+        self.assertEqual(set(scopes), set(pnm.FRAMEWORK_SOURCES))
+        self.assertEqual(set(scopes), set(pnm.load_all()))
+
+    def test_each_scope_matches_the_5_30_1_provider_layout(self):
+        for framework, providers in self.EXPECTED.items():
+            with self.subTest(framework=framework):
+                self.assertEqual(
+                    pnm.framework_providers(framework), frozenset(providers)
+                )
+
+    def test_no_framework_is_gated_off_a_provider_it_ships_for(self):
+        cm = _load("compliance_map_all_frameworks", "compliance-map.py")
+        for framework, providers in self.EXPECTED.items():
+            for provider in sorted(providers):
+                with self.subTest(framework=framework, provider=provider):
+                    result = cm.map_compliance([], scanned_providers={provider})
+                    sources = {c["match_source"] for c in result[framework]}
+                    self.assertIn("prowler", sources)
+
+    def test_every_framework_is_gated_off_a_provider_none_of_them_ship_for(self):
+        """`github` has no file for any registered framework, so no framework
+        may keep its native mapping on a GitHub-only run."""
+        cm = _load("compliance_map_all_gated", "compliance-map.py")
+        for framework in self.EXPECTED:
+            with self.subTest(framework=framework):
+                result = cm.map_compliance([], scanned_providers={"github"})
+                sources = {c["match_source"] for c in result[framework]}
+                self.assertNotIn("prowler", sources)
+
+
+class TestGatingIsPerControlNotPerFramework(_ScopedFixture):
+    """A framework-level scope leaves the same false-PASS inside the framework.
+
+    `load_framework()` MERGES every provider file into one check set per
+    control, so "ISO ships for kubernetes" can be true while an individual
+    control's checks are all AWS. Measured at 5.30.1, ISO has such controls in
+    both directions: `A.8.9`, `A.8.4`, `A.8.7` are aws-only and `A.5.2` is
+    kubernetes-only — so even an AWS run had controls reporting PASS on
+    evidence they could not read.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # `A.8.5` is evidenced by both providers, `A.8.9` only by aws.
+        _write_fixture(self.root, "aws", "iso27001_2022_aws.json", [
+            {"Id": "A.8.5", "Checks": ["aws_mfa"]},
+            {"Id": "A.8.9", "Checks": ["aws_config_baseline"]},
+        ])
+        _write_fixture(self.root, "kubernetes", "iso27001_2022_kubernetes.json", [
+            {"Id": "A.8.5", "Checks": ["apiserver_auth_mode_include_rbac"]},
+        ])
+        self.cm = _load("compliance_map_per_control", "compliance-map.py")
+
+    def _iso(self, findings, providers=None):
+        return {
+            c["control"]: c
+            for c in self.cm.map_compliance(findings, scanned_providers=providers)[
+                "ISO 27001:2022"
+            ]
+        }
+
+    def test_the_framework_is_in_scope_for_kubernetes(self):
+        self.assertIn("kubernetes", pnm.framework_providers("ISO 27001:2022"))
+
+    def test_a_control_only_aws_can_evidence_is_gated_off_a_kubernetes_run(self):
+        controls = self._iso([], providers={"kubernetes"})
+        # A.8.5 has a kubernetes check, so it stays on the exact mapping.
+        self.assertEqual(controls["A.8.5"]["match_source"], "prowler")
+        # A.8.9 does not. Reporting PASS here is the bug.
+        self.assertEqual(controls["A.8.9"]["match_source"], "keyword")
+
+    def test_the_same_control_keeps_the_native_path_on_an_aws_run(self):
+        controls = self._iso([], providers={"aws"})
+        self.assertEqual(controls["A.8.9"]["match_source"], "prowler")
+        self.assertEqual(controls["A.8.5"]["match_source"], "prowler")
+
+    def test_control_providers_records_each_control_separately(self):
+        per = pnm.control_providers("ISO 27001:2022")
+        self.assertEqual(per["A.8.5"], frozenset({"aws", "kubernetes"}))
+        self.assertEqual(per["A.8.9"], frozenset({"aws"}))
+
+
+class TestEvidenceSourceIsVisible(unittest.TestCase):
+    """Gating that nothing displays is gating an operator cannot audit.
+
+    Before this, `match_source` was produced by `map_compliance` and rendered
+    nowhere, so a control decided by Prowler's exact mapping and one decided by
+    a substring approximation — measured at 41.5% fidelity against that same
+    mapping — looked identical in the dashboard.
+    """
+
+    def setUp(self):
+        import sys
+
+        if _LIB not in sys.path:
+            sys.path.insert(0, os.path.abspath(_LIB))
+
+    @staticmethod
+    def _ctrl(control, source, status="PASS"):
+        return {
+            "control": control,
+            "name": control,
+            "desc": "d",
+            "action": "a",
+            "checks": [],
+            "status": status,
+            "count": 0,
+            "findings": [],
+            "match_source": source,
+        }
+
+    def _html(self, controls, framework="NIST 800-53 Rev5"):
+        from dashboard_html_compliance import _build_compliance_html
+
+        return _build_compliance_html({framework: controls})
+
+    def test_a_gated_framework_says_so(self):
+        html = self._html([self._ctrl("AC-2", "keyword"), self._ctrl("AU-2", "keyword")])
+        self.assertIn("comp-fw-source", html)
+        self.assertIn("2 keyword", html)
+        self.assertNotIn("exact", html)
+
+    def test_a_native_framework_reports_exact(self):
+        html = self._html([self._ctrl("AC-2", "prowler")])
+        self.assertIn("1 exact", html)
+
+    def test_a_mixed_framework_reports_both_in_a_stable_order(self):
+        html = self._html([
+            self._ctrl("AC-2", "prowler"),
+            self._ctrl("AU-2", "keyword"),
+            self._ctrl("CA-7", "keyword"),
+        ])
+        self.assertLess(html.index("1 exact"), html.index("2 keyword"))
+
+    def test_unmapped_controls_are_named_not_assessed(self):
+        html = self._html(
+            [self._ctrl("AC", "unmapped", status="N/A")], framework="CMMC 2.0 Level 2"
+        )
+        self.assertIn("1 not assessed", html)
+
+    def test_controls_without_a_source_render_no_row(self):
+        from dashboard_html_compliance import _evidence_source_html
+
+        self.assertEqual(_evidence_source_html([]), "")
+        bare = {"control": "X", "status": "PASS"}
+        self.assertEqual(_evidence_source_html([bare]), "")
+
+    def test_an_unknown_source_is_shown_rather_than_dropped(self):
+        """A source this renderer does not know about must still be counted —
+        silently omitting it would understate the framework's control count."""
+        from dashboard_html_compliance import _evidence_source_html
+
+        html = _evidence_source_html([self._ctrl("X", "some_future_source")])
+        self.assertIn("1 some_future_source", html)
+
+    def test_the_source_row_style_exists_in_the_template(self):
+        with open(os.path.join(_LIB, "dashboard-template.html"), encoding="utf-8") as fh:
+            template = fh.read()
+        for cls in (".comp-fw-source{", ".comp-src-prowler{", ".comp-src-keyword{"):
+            self.assertIn(cls, template)
+
+
+class TestProviderSlugsAgreeOnBothSides(_ScopedFixture):
+    """The scope speaks Prowler's COMPLIANCE DIRECTORY names; `scanned_providers`
+    speaks ClaudeSec's finding slugs. A pair that should match but does not
+    would gate away real evidence — a worse failure than the one being fixed,
+    because it is silent in the other direction.
+
+    The emitted set is read out of `integration.sh` rather than copied, and NOT
+    taken from `dashboard_providers.PROVIDER_LABELS` — that is a UI label table,
+    not the emitting side. The difference is load-bearing: `PROVIDER_LABELS` has
+    an `nhn` key, but the NHN block runs `_prowler_scan "openstack"`, so no run
+    ever emits `prowler-nhn.ocsf.json`. A test pinned to the label table would
+    assert a parity that is not the one the gate uses, and would not catch a
+    rename on the emitting side.
+
+    Prowler 5.30.1 compliance directories, verified against the tag (17):
+    alibabacloud, aws, azure, cloudflare, gcp, github, googleworkspace, iac,
+    kubernetes, llm, m365, mongodbatlas, nhn, okta, openstack, oraclecloud,
+    stackit.
+    """
+
+    PROWLER_COMPLIANCE_DIRS = {
+        "alibabacloud", "aws", "azure", "cloudflare", "gcp", "github",
+        "googleworkspace", "iac", "kubernetes", "llm", "m365",
+        "mongodbatlas", "nhn", "okta", "openstack", "oraclecloud", "stackit",
+    }
+    # Slugs ClaudeSec emits that Prowler has no compliance directory for.
+    # `image` is a container-image scan, not a cloud estate, so no compliance
+    # file can ever be scoped to it.
+    EXPECTED_UNMATCHED = {"image"}
+
+    @staticmethod
+    def _emitted_slugs():
+        """Every provider `integration.sh` actually scans, parsed from source."""
+        import re
+
+        path = os.path.join(
+            os.path.dirname(__file__), "..", "checks", "prowler", "integration.sh"
+        )
+        with open(path, encoding="utf-8") as fh:
+            return set(re.findall(r'_prowler_scan\s+"([a-z0-9]+)"', fh.read()))
+
+    def test_the_emitting_side_is_readable_and_non_trivial(self):
+        """Guard the extraction, not just the assertion: a regex that silently
+        matched nothing would make every parity check below vacuous."""
+        slugs = self._emitted_slugs()
+        self.assertGreaterEqual(len(slugs), 10)
+        self.assertIn("aws", slugs)
+        self.assertIn("kubernetes", slugs)
+
+    def test_every_emitted_slug_prowler_knows_is_spelled_identically(self):
+        unmatched = self._emitted_slugs() - self.PROWLER_COMPLIANCE_DIRS
+        self.assertEqual(
+            unmatched,
+            self.EXPECTED_UNMATCHED,
+            "A slug ClaudeSec emits no longer matches Prowler's compliance "
+            "directory name — the gate would drop that provider's evidence.",
+        )
+
+    def test_nhn_is_labelled_but_never_emitted(self):
+        """Pin the asymmetry so the `nhn` row of ISO's scope is understood as
+        unreachable rather than assumed live. If NHN ever scans under its own
+        name, this fails and the parity above starts covering it."""
+        dp = _load("dashboard_providers_scope", "dashboard_providers.py")
+        self.assertIn("nhn", dp.PROVIDER_LABELS)
+        self.assertNotIn("nhn", self._emitted_slugs())
+        self.assertIn("openstack", self._emitted_slugs())
+
+    def test_kubernetes_variants_normalise_to_prowlers_directory_name(self):
+        """`_normalize_provider` folds k8s/eks into `kubernetes`, which is
+        exactly Prowler's directory name. A mismatch here would gate every
+        framework off a Kubernetes scan."""
+        pcs = _load("prowler_compliance_summary_scope", "prowler_compliance_summary.py")
+        for name in ("prowler-k8s.ocsf.json", "prowler-kubernetes.ocsf.json",
+                     "prowler-eks-prod.ocsf.json"):
+            self.assertEqual(pcs._provider_of("/x/" + name), "kubernetes", name)
+        self.assertIn("kubernetes", self.PROWLER_COMPLIANCE_DIRS)
+
+    def test_a_scoped_framework_gates_on_slugs_the_scanner_can_emit(self):
+        for provider in ("aws", "azure", "gcp"):
+            _write_fixture(self.root, provider, f"soc2_{provider}.json",
+                           [{"Id": "cc_6_1", "Checks": ["x"]}])
+        self.assertTrue(
+            pnm.framework_providers("SOC 2 (TSC)") <= self._emitted_slugs()
+        )
+
+
+class TestForeignProviderRunDoesNotScoreAFreePass(_ScopedFixture):
+    """The regression this change is for, on a keyword-bearing framework."""
+
+    def setUp(self):
+        super().setUp()
+        _write_fixture(
+            self.root,
+            "aws",
+            "nist_800_53_revision_5_aws.json",
+            [
+                {"Id": "ac_2", "Checks": ["iam_user_mfa_enabled"]},
+                {"Id": "au_2", "Checks": ["cloudtrail_multi_region_enabled"]},
+            ],
+        )
+        self.cm = _load("compliance_map_scope_under_test", "compliance-map.py")
+
+    def _nist(self, findings, providers=None):
+        return {
+            c["control"]: c
+            for c in self.cm.map_compliance(findings, scanned_providers=providers)[
+                "NIST 800-53 Rev5"
+            ]
+        }
+
+    def test_kubernetes_run_falls_back_to_keywords_instead_of_passing(self):
+        finding = {
+            "check": "apiserver_audit_log_path_set",
+            "title": "API server audit log path not set",
+            "message": "audit logging is disabled on the api server",
+            "provider": "kubernetes",
+        }
+        ctrl = self._nist([finding])["AU-2"]
+        self.assertEqual(ctrl["match_source"], "keyword")
+        self.assertEqual(ctrl["status"], "FAIL")
+
+    def test_the_same_run_used_to_report_prowler_and_pass(self):
+        """Pin the direction of the change: with the scope removed the control
+        is decided by an AWS check list it can never match, i.e. PASS."""
+        finding = {
+            "check": "apiserver_audit_log_path_set",
+            "title": "audit log path not set",
+            "message": "audit logging disabled",
+            "provider": "kubernetes",
+        }
+        unscoped = self.cm._native_provider_scope
+        self.cm._native_provider_scope = lambda framework, control: None
+        try:
+            ctrl = self._nist([finding])["AU-2"]
+            self.assertEqual(ctrl["match_source"], "prowler")
+            self.assertEqual(ctrl["status"], "PASS")
+        finally:
+            self.cm._native_provider_scope = unscoped
+
+    def test_an_aws_run_is_unchanged(self):
+        finding = {
+            "check": "iam_user_mfa_enabled",
+            "title": "",
+            "message": "",
+            "provider": "aws",
+        }
+        ctrl = self._nist([finding])["AC-2"]
+        self.assertEqual(ctrl["match_source"], "prowler")
+        self.assertEqual(ctrl["status"], "FAIL")
+
+    def test_a_mixed_run_containing_a_covered_provider_keeps_the_native_path(self):
+        findings = [
+            {"check": "x", "title": "t", "message": "m", "provider": "kubernetes"},
+            {
+                "check": "iam_user_mfa_enabled",
+                "title": "",
+                "message": "",
+                "provider": "aws",
+            },
+        ]
+        self.assertEqual(self._nist(findings)["AC-2"]["match_source"], "prowler")
+
+    def test_a_clean_covered_provider_still_scores_when_declared(self):
+        derived = self._nist([])
+        self.assertEqual(derived["AC-2"]["match_source"], "keyword")
+        explicit = self._nist([], providers={"aws"})
+        self.assertEqual(explicit["AC-2"]["match_source"], "prowler")
+        self.assertEqual(explicit["AC-2"]["status"], "PASS")
+
+    def test_gating_never_turns_a_keyword_framework_into_na(self):
+        """Only `native_only` controls become N/A when gated. A control with
+        keywords must fall back to them, not disappear."""
+        finding = {
+            "check": "apiserver_x",
+            "title": "t",
+            "message": "m",
+            "provider": "kubernetes",
+        }
+        for control in self._nist([finding]).values():
+            with self.subTest(control=control["control"]):
+                self.assertNotEqual(control["status"], "N/A")
+
+
+class TestGithubFindingsKeepTheKeywordPath(_ScopedFixture):
+    """A GitHub-only run is out of scope for every REGISTERED framework, so it
+    keeps keywords — which the mapping plan requires, since GitHub findings are
+    the case that path exists for.
+
+    Prowler 5.30.1 does ship one file under `compliance/github/`,
+    `cis_1.0_github.json`, but CIS is deliberately absent from
+    `FRAMEWORK_SOURCES` (its control ids need a remap first), so no registered
+    framework has a github file. `test_no_registered_framework_matches_the_only
+    _github_file` pins that, because the day CIS is registered this class's
+    premise changes.
+    """
+
+    def setUp(self):
+        super().setUp()
+        _write_fixture(self.root, "aws", "soc2_aws.json",
+                       [{"Id": "cc_6_1", "Checks": ["s3_bucket_public_access"]}])
+        self.cm = _load("compliance_map_github_scope", "compliance-map.py")
+
+    def test_no_registered_framework_matches_the_only_github_file(self):
+        import fnmatch
+
+        for framework, (pattern, _) in pnm.FRAMEWORK_SOURCES.items():
+            with self.subTest(framework=framework):
+                self.assertFalse(
+                    fnmatch.fnmatch("cis_1.0_github.json", pattern),
+                    f"{framework} would claim Prowler's github file.",
+                )
+
+    def test_github_only_run_matches_on_keywords(self):
+        finding = {
+            "check": "branch_protection_disabled",
+            "title": "Branch protection is not enabled",
+            "message": "no required approval on the default branch",
+            "provider": "github",
+        }
+        ctrl = {
+            c["control"]: c
+            for c in self.cm.map_compliance([finding])["SOC 2 (TSC)"]
+        }["CC8"]
+        self.assertEqual(ctrl["match_source"], "keyword")
+        self.assertEqual(ctrl["status"], "FAIL")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_prowler_native_map.py
+++ b/scanner/tests/test_prowler_native_map.py
@@ -133,10 +133,22 @@ class TestMapComplianceUsesNative(unittest.TestCase):
         self.cm = _load("compliance_map_native_under_test", "compliance-map.py")
 
     def _soc2(self, findings):
-        return {c["control"]: c for c in self.cm.map_compliance(findings)["SOC 2 (TSC)"]}
+        # The fixture is `aws/soc2_aws.json`, so the native mapping is scoped to
+        # aws and only an aws run can reach it (TestNativeProviderScope below).
+        return {
+            c["control"]: c
+            for c in self.cm.map_compliance(findings, scanned_providers={"aws"})[
+                "SOC 2 (TSC)"
+            ]
+        }
 
     def test_native_control_matches_by_check_id(self):
-        f = {"check": "s3_bucket_public_access", "title": "", "message": ""}
+        f = {
+            "check": "s3_bucket_public_access",
+            "title": "",
+            "message": "",
+            "provider": "aws",
+        }
         ctrl = self._soc2([f])["CC6"]
         self.assertEqual(ctrl["status"], "FAIL")
         self.assertEqual(ctrl["match_source"], "prowler")
@@ -149,6 +161,7 @@ class TestMapComplianceUsesNative(unittest.TestCase):
             "check": "some_unrelated_check",
             "title": "mfa and encrypt and publicly accessible",
             "message": "unrestricted ingress 0.0.0.0/0",
+            "provider": "aws",
         }
         ctrl = self._soc2([f])["CC6"]
         self.assertEqual(ctrl["status"], "PASS")
@@ -157,7 +170,12 @@ class TestMapComplianceUsesNative(unittest.TestCase):
     def test_controls_without_native_data_still_use_keywords(self):
         # Only CC6 is in the fixture. CC7 must keep working on keywords, or the
         # sparse half of every framework goes dark.
-        f = {"check": "cloudtrail_x", "title": "logging disabled", "message": ""}
+        f = {
+            "check": "cloudtrail_x",
+            "title": "logging disabled",
+            "message": "",
+            "provider": "aws",
+        }
         ctrl = self._soc2([f])["CC7"]
         self.assertEqual(ctrl["match_source"], "keyword")
         self.assertEqual(ctrl["status"], "FAIL")
@@ -169,7 +187,7 @@ class TestMapComplianceUsesNative(unittest.TestCase):
         ])
         cm = _load("compliance_map_na_under_test", "compliance-map.py")
         ctrl = {c["control"]: c for c in cm.map_compliance(
-            [{"check": "some_check", "title": "", "message": ""}]
+            [{"check": "some_check", "title": "", "message": "", "provider": "aws"}]
         )["SOC 2 (TSC)"]}["CC1"]
         self.assertEqual(ctrl["status"], "N/A")
 
@@ -307,7 +325,9 @@ class TestNativeLoadFailureIsInert(unittest.TestCase):
 
     def test_a_module_that_raises_degrades_to_empty_not_a_crash(self):
         class Exploding:
-            FRAMEWORK_NATIVE_PROVIDERS = {}
+            @staticmethod
+            def native_control_providers():
+                return {}
 
             @staticmethod
             def load_all():
@@ -317,11 +337,13 @@ class TestNativeLoadFailureIsInert(unittest.TestCase):
         cm._NATIVE_CACHE = None
         cm._load_native_module = lambda: Exploding()
         self.assertEqual(cm._native_mapping(), {})
-        self.assertIsNone(cm._native_provider_scope("CMMC 2.0 Level 2"))
+        self.assertIsNone(cm._native_provider_scope("CMMC 2.0 Level 2", "AC"))
 
-    def test_a_malformed_provider_scope_table_degrades_to_unscoped(self):
+    def test_a_raising_provider_scope_degrades_to_unscoped(self):
         class Malformed:
-            FRAMEWORK_NATIVE_PROVIDERS = ["not", "a", "mapping"]
+            @staticmethod
+            def native_control_providers():
+                raise RuntimeError("compliance tree vanished mid-scan")
 
             @staticmethod
             def load_all():
@@ -331,9 +353,9 @@ class TestNativeLoadFailureIsInert(unittest.TestCase):
         cm._NATIVE_CACHE = None
         cm._load_native_module = lambda: Malformed()
         self.assertEqual(cm._native_mapping(), {"SOC 2 (TSC)": {"CC6": frozenset({"x"})}})
-        self.assertIsNone(cm._native_provider_scope("CMMC 2.0 Level 2"))
+        self.assertIsNone(cm._native_provider_scope("SOC 2 (TSC)", "CC6"))
 
-    def test_a_module_without_the_provider_scope_table_keeps_its_mapping(self):
+    def test_a_module_without_the_provider_scope_helper_keeps_its_mapping(self):
         """Version skew between the two sibling files costs the provider scope
         and nothing else — discarding the whole mapping would blank every
         natively-mapped control across all frameworks."""
@@ -347,7 +369,7 @@ class TestNativeLoadFailureIsInert(unittest.TestCase):
         cm._NATIVE_CACHE = None
         cm._load_native_module = lambda: OldModule()
         self.assertEqual(cm._native_mapping(), {"SOC 2 (TSC)": {"CC6": frozenset({"x"})}})
-        self.assertIsNone(cm._native_provider_scope("CMMC 2.0 Level 2"))
+        self.assertIsNone(cm._native_provider_scope("CMMC 2.0 Level 2", "AC"))
 
 
 class TestAbsenceIsInert(unittest.TestCase):


### PR DESCRIPTION
`load_framework()` reads the **installed Prowler package**, not the scan. Prowler ships each framework for some providers and not others, so a mapping is populated whenever Prowler is installed — including on a run that scanned none of those providers. Every natively-mapped control then matches zero findings and takes the `count == 0 → PASS` default. The shipped image makes it reachable: the Dockerfile strips `prowler/providers/{azure,gcp,...}` but never `prowler/compliance/**`.

This is the item #455 deliberately left out of scope. Measurement showed it was never NIST-only.

## Measured, not assumed

Provider coverage at the pinned Prowler 5.30.1:

| Framework | Providers Prowler ships it for |
|---|---|
| ISO 27001:2022 | aws, azure, gcp, kubernetes, m365, nhn |
| PCI-DSS v4.0.1 | aws, azure, gcp, kubernetes |
| SOC 2 (TSC) | aws, azure, gcp |
| **KISA ISMS-P** | **aws** |
| **NIST 800-53 Rev5** | **aws** |
| CMMC 2.0 Level 2 | aws |

Kubernetes-only scan, 62 real k8s check ids from Prowler's own `pci_4.0_kubernetes.json` + `iso27001_2022_kubernetes.json` as FAIL findings:

| Framework | Before | After |
|---|---|---|
| NIST 800-53 Rev5 | **10 pass / 0 fail** (all `prowler`) | 5 pass / 5 fail (all `keyword`) |
| SOC 2 (TSC) | **6 pass / 0 fail** (all `prowler`) | 3 pass / 3 fail (all `keyword`) |
| KISA ISMS-P | 20 pass / 7 fail (16 on `prowler`) | 9 pass / 18 fail |
| PCI-DSS v4.0.1 | 0 pass / 7 fail | unchanged |
| ISO 27001:2022 | 3 pass / 3 fail | unchanged |

NIST 800-53 and SOC 2 reported a perfect score on an estate whose evidence they could never read. **Five NIST, three SOC 2 and eleven KISA failures were hidden.** An AWS scan is unaffected in every framework.

## The gate is per control, not per framework

Caught in review. The loader **merges** every provider file into one check set per control, so "ISO ships for kubernetes" can be true while an individual control's checks are all AWS. A framework-level scope leaves that open — and it reaches the flagship provider:

| ISO control | Evidenced by |
|---|---|
| A.8.2 | aws, azure, gcp, kubernetes, m365, nhn |
| A.5.1 | aws, azure, gcp, kubernetes, m365 |
| A.8.5 | aws, azure, kubernetes, m365 |
| A.8.24 | aws, azure, gcp, kubernetes |
| A.8.9 | aws, azure, gcp, nhn |
| **A.8.8** | **m365 only** |
| A.8.28 | *(no native mapping — keywords)* |

On an **AWS** run, `A.8.8` reported `PASS` from Prowler's exact mapping while every check backing it belongs to m365. Verified before/after on the real files:

```text
A.8.8   before=PASS/prowler   after=PASS/keyword   <-- CHANGED
```

## Derived, not declared

Replaces the hand-written `FRAMEWORK_NATIVE_PROVIDERS` dict #455 added for CMMC alone. The table above is why that shape could not hold: it was already wrong for three more frameworks the moment it was written, and the answer differs per Prowler release.

The scope is now built **in the same pass, from the same parsed content** as the mapping it scopes — a provider is recorded for a control only once one of its requirements survived the merge. Deriving from filenames would let a file that exists but contributes nothing widen the scope past the evidence.

**Gating never invents an N/A.** A gated control returns to keywords; only `native_only` controls (CMMC's) report N/A. A GitHub-only run is out of scope for every registered framework — `compliance/github/` holds only `cis_1.0_github.json` and CIS is deliberately unregistered — so it keeps the keyword path, which is the case that path exists for.

## The dashboard now says which path it took

`match_source` was produced by `map_compliance` and rendered **nowhere**, so a control scored by Prowler's exact data and one scored by substring matching looked identical. They are not — the keyword path reproduces 41.5% of Prowler's own mapping where both have an opinion, and this change moves controls onto it. Each framework now renders an **Evidence source** line: `N exact · N keyword · N not assessed`.

## Test plan

- [x] `pytest scanner/tests/` — **2275 passed, 8 skipped**
- [x] `scanner/lib` **99.41%** at the CI gate (`--cov-precision=2 --cov-fail-under=99`) — `compliance-map.py`, `prowler_native_map.py`, `dashboard_html_compliance.py`, `prowler_compliance_summary.py` all **100%**
- [x] Shell: control liveness 14/14 and 20/20, `test_generate_html_dashboard` 36/36, `test_prowler_dashboard_summary` 24/24, provider-label 20/20 — all rc=0
- [x] `markdownlint` + `lychee` clean (0 errors, 0 redirects); `gitleaks protect --staged` clean
- [x] End-to-end against the real pinned Prowler 5.30.1 compliance files, not fixtures
- [x] **Eight mutations** each caught — including the two an independent `sec-reviewer` used to defeat the first draft: a scope that silently skips three frameworks (was `2258 passed` while re-hiding the KISA failures), and deriving the scope from file existence rather than contribution

New guards: `scanner/tests/test_native_provider_scope.py` runs against a tree holding **all six** frameworks at once (a single-framework fixture cannot catch a scope that skips frameworks), pins the 5.30.1 provider table, and reads the emitting side out of `integration.sh` rather than from `PROVIDER_LABELS` — that is a UI label table, and `nhn` is in it while the NHN block actually runs `_prowler_scan "openstack"`.

### Known, not changed here

- On a **mixed** run, a control whose native providers include the scanned one keeps its native mapping, so findings from an uncovered provider stay invisible to it. That needs per-finding matching, not per-control gating.
- The KISA glob's `[!k]` guard does not exclude the Korean file — `*` backtracks so `[!k]` lands on the `a` of `aws`. Measured impact: +1 control (`2.8.5`), no conflicting check sets.
- ClaudeSec never emits an `nhn` slug, so ISO's `nhn` scope row is unreachable here (pinned by a test so it is understood rather than assumed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)