### PR TITLE
fix(compliance): five keywords were scoring a sibling control's checks

### DIFF
--- a/docs/guides/compliance-mapping.md
+++ b/docs/guides/compliance-mapping.md
@@ -113,7 +113,7 @@ twice: it published `sso` and `vulnerability` after #447/#452 narrowed them to
 | CC1 Control environment | **N/A** (governance) | 30 | `security_policy`, `governance` |
 | CC2 Communication and information | **N/A** (governance) | 23 | `awareness`, `training` |
 | CC3 Risk assessment | PASS/FAIL | 55 | `vulnerab`, `dependency`, `dependabot`, `scan`, `cve` |
-| CC4 Monitoring activities | PASS/FAIL | 28 | `audit`, `monitoring`, `scan`, `guardduty`, `securityhub`, `config_recorder` |
+| CC4 Monitoring activities | PASS/FAIL | 28 | `monitoring`, `scan`, `guardduty`, `securityhub`, `config_recorder` |
 | CC5 Control activities | PASS/FAIL | 29 | `configuration`, `misconfigur`, `hardening`, `benchmark` |
 | CC6 Logical and physical access controls | PASS/FAIL | 136 | `mfa`, `two_factor`, `_sso`, `authentication`, `rbac`, `encrypt`, `secret`, `public_access`, `publicly`, `0.0.0.0`, `security_group`, `securitygroup`, `ingress`, `unrestricted` |
 | CC7 System operations | PASS/FAIL | 113 | `logging`, `incident`, `detection`, `alert`, `anomaly`, `cloudtrail`, `flow_log`, `log_file_validation` |

--- a/scanner/lib/compliance-map.py
+++ b/scanner/lib/compliance-map.py
@@ -146,7 +146,10 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "사용자 식별 (User identification)",
             "desc": "개인별 고유한 사용자 계정 부여",
             "action": "공용 계정 금지; 개인별 고유 ID 부여; 특수권한 계정 별도 관리.",
-            "checks": ["authentication", "identity", "shared_account", "root"],
+            # `authentication` pruned: 0 of this control's mapped checks — 2.5.2 is
+            # 사용자 식별, and 5 of the checks the token pulls in belong to 2.5.3
+            # (사용자 인증), which owns it.
+            "checks": ["identity", "shared_account", "root"],
             "status": "",
         },
         {
@@ -154,7 +157,10 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "사용자 인증 (User authentication)",
             "desc": "안전한 인증 수단 사용 (MFA, SSO 등)",
             "action": "MFA 적용; SSO 통합; 비밀번호 복잡도 및 주기적 변경.",
-            "checks": ["mfa", "two_factor", "_sso", "authentication", "password"],
+            # `password` pruned: 0 of this control's 33 mapped checks, and 13 of
+            # the checks it drags in belong to 2.5.4 (비밀번호 관리), which owns
+            # that vocabulary.
+            "checks": ["mfa", "two_factor", "_sso", "authentication"],
             "status": "",
         },
         {
@@ -360,7 +366,11 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "사고 예방 및 대응체계 구축 (Incident response)",
             "desc": "침해사고 예방, 탐지, 대응, 복구 체계 수립",
             "action": "SIEM/모니터링; 대응 플레이북; 24시간 내 신고(정보통신망법 2024 개정); 사후 분석.",
-            "checks": ["monitoring", "logging", "alert", "audit", "incident"],
+            # `logging` and `audit` pruned on measurement: neither matches ANY of
+            # this control's 2 Prowler-mapped checks, while between them they
+            # drag in 81 checks Prowler assigns elsewhere in the framework —
+            # 33 of those to 2.9.4, which IS the logging control.
+            "checks": ["monitoring", "alert", "incident"],
             "status": "",
         },
         {
@@ -817,7 +827,10 @@ COMPLIANCE_CONTROL_MAP = {
             "name": "Monitoring activities",
             "desc": "Ongoing and separate evaluations confirm controls are present and operating",
             "action": "Run continuous control scans; internal audit and evidence review; track deficiency remediation to closure.",
-            "checks": ["audit", "monitoring", "scan", "guardduty", "securityhub", "config_recorder"],
+            # `audit` pruned: 0 of CC4's 28 mapped checks, and 5 of the checks it
+            # drags in are CC7's. Same shape as the CC4 + `alert` rejection
+            # already pinned in test_ci_compliance_keyword_guard.py.
+            "checks": ["monitoring", "scan", "guardduty", "securityhub", "config_recorder"],
             "status": "",
         },
         {

--- a/scanner/tests/test_audit_points_scan_coverage.py
+++ b/scanner/tests/test_audit_points_scan_coverage.py
@@ -198,12 +198,20 @@ class TestMainEntrypoint(unittest.TestCase):
 
     def test_main_runs_as_subprocess(self):
         script = Path(__file__).resolve().parents[1] / "lib" / "audit-points-scan.py"
+        # CLAUDESEC_DASHBOARD_OFFLINE=1 is REQUIRED, not tidiness. The script
+        # importlib-loads a sibling that reaches `dashboard_api_client`, so
+        # without it this makes live GitHub API calls: measured 22.4s wall for
+        # 0.16s of CPU (0% CPU — pure network wait), which blows the 15s timeout
+        # and fails on any host that can reach the network. With it, 0.13s.
+        # Same class as the #190 kcov hang, and the same repo rule.
+        env = {**os.environ, "CLAUDESEC_DASHBOARD_OFFLINE": "1"}
         with tempfile.TemporaryDirectory() as d:
             result = subprocess.run(
                 [sys.executable, str(script), d],
                 capture_output=True,
                 text=True,
                 timeout=15,
+                env=env,
             )
         # Must exit 0 and emit a JSON line on stdout
         self.assertEqual(result.returncode, 0)

--- a/scanner/tests/test_ci_compliance_keyword_guard.py
+++ b/scanner/tests/test_ci_compliance_keyword_guard.py
@@ -187,6 +187,37 @@ REMOVED_TOKENS = [
     ("PCI-DSS v4.0.1", "Req 8", "sso"),
     ("NIST 800-53 Rev5", "IA-2", "sso"),
     ("CIS Benchmarks", "CIS-K8s-ArgoCD", "sso"),
+    # 2026-08-19, THIRD class — tokens that STEAL A SIBLING CONTROL'S checks.
+    #
+    # Found by Phase 0 of docs/plans/compliance-status-model.md, and only
+    # findable once the KISA/ISO control ids were realigned (#459) — before
+    # that, "which control does Prowler assign this check to" was itself wrong.
+    # The measurement here is stronger than raw corpus noise: it counts the
+    # checks a token drags in that Prowler assigns to a DIFFERENT control OF
+    # THE SAME FRAMEWORK, which is misattribution with ground truth rather than
+    # an unattributable hit. Each of these covers ZERO of its own control's
+    # Prowler-mapped checks. Measured at 5.30.1:
+    #
+    #   2.11.1 + logging  0/2   covered; 69 misattributed, 30 of them to 2.9.4
+    #                           — the actual 로그 및 접속기록 관리 control
+    #   2.11.1 + audit    0/2   covered; 12 misattributed, 3 to 2.9.4
+    #   2.5.3  + password 0/33  covered; 28 misattributed, 13 to 2.5.4
+    #                           (비밀번호 관리), which owns that vocabulary
+    #   2.5.2  + auth…    0/1   covered; 22 misattributed, 5 to 2.5.3
+    #                           (사용자 인증) — 2.5.2 is 사용자 식별
+    #   CC4    + audit    0/28  covered; 7 misattributed, 5 to CC7. Same shape
+    #                           as the CC4 + `alert` rejection pinned below.
+    #
+    # Nine further candidates (`restrict`, `alert` on 2.11.1/Req 10/CA-7/SI-4,
+    # `identity`, `authentication` on IA-2/CC6) were measured and KEPT: their
+    # noise is checks Prowler assigns to no control at all, which is far weaker
+    # evidence of harm, and check-id matching cannot see the finding-text path
+    # those tokens plausibly serve.
+    ("KISA ISMS-P", "2.11.1", "logging"),
+    ("KISA ISMS-P", "2.11.1", "audit"),
+    ("KISA ISMS-P", "2.5.3", "password"),
+    ("KISA ISMS-P", "2.5.2", "authentication"),
+    ("SOC 2 (TSC)", "CC4", "audit"),
     # 2026-08-14, SECOND class — over-broad WHOLE WORDS. These are correctly
     # spelled, correctly meaning English words that are simply too common in
     # Prowler's risk narratives. The collision detector below CANNOT catch them:


### PR DESCRIPTION
Completes **Phase 0** of [`docs/plans/compliance-status-model.md`](../blob/main/docs/plans/compliance-status-model.md). #459 fixed the control *labels*; this prunes the keyword tokens measurement can now condemn — which it could not before, because *"which control does Prowler assign this check to"* was itself wrong until the realignment landed.

## The criterion, made evaluable

The plan's stated gate — *"recovers zero while lighting more than a stated number of unrelated corpus checks"* — **prunes 136 of 240 tokens when applied literally**, gutting every list and breaching the ≥2 floor. Raw corpus noise is the wrong denominator: a hit Prowler assigns to *no* control is weak evidence of harm, and check-id matching cannot see the finding-text path a token may serve.

Replaced with **misattribution against ground truth**: of the checks a token drags in, how many does Prowler assign to a **different control of the same framework**? That is measurable, and it converges:

```text
240 tokens on 51 natively-mapped controls
→ 136 cover zero of their own control's checks
→  21 of those are also noisy (>20 unrelated catalog hits)
→  14 contribute nothing on the GitHub path either
→   5 survive the misattribution test
```

## The five, measured at Prowler 5.30.1

| Control | Token | Covers | Misattributed | …to |
|---|---|---|---|---|
| KISA 2.11.1 (사고대응) | `logging` | 0/2 | **69** | 30 → **2.9.4**, the actual 로그 및 접속기록 관리 control |
| KISA 2.11.1 | `audit` | 0/2 | 12 | 3 → 2.9.4 |
| KISA 2.5.3 (인증) | `password` | 0/33 | 28 | 13 → **2.5.4 비밀번호 관리** |
| KISA 2.5.2 (식별) | `authentication` | 0/1 | 22 | 5 → **2.5.3 사용자 인증** |
| SOC 2 CC4 (모니터링) | `audit` | 0/28 | 7 | 5 → **CC7** |

Coverage is **unchanged** on all four controls; only noise drops. Every list stays at 3+ tokens, above the ≥2 floor. CC4 + `audit` is the same shape as the CC4 + `alert` rejection already pinned in `test_ci_compliance_keyword_guard.py`.

## Measured and *kept* — recorded so the next pass doesn't re-litigate

Nine further candidates — `restrict` (Req 7, AC-6), `alert` (2.11.1, Req 10, CA-7, SI-4), `identity` (IA-2), `authentication` (IA-2, CC6) — score **zero** misattribution: their noise is checks Prowler assigns to no control of that framework. Far weaker evidence, and `alert` on CA-7/SI-4 is intent-correct for continuous/system monitoring even where Prowler's check ids don't contain the word.

> The doc-table guard added in #457 caught the CC4 edit and forced the guide back in step — working as designed.

## Incidental, pre-existing

`test_audit_points_scan_coverage.py::test_main_runs_as_subprocess` failed on this machine **before any change in this branch** (verified by stashing). The script `importlib`-loads a sibling that reaches `dashboard_api_client`, so without `CLAUDESEC_DASHBOARD_OFFLINE` it makes live GitHub API calls: **22.4s wall for 0.16s of CPU** — 0% CPU, pure network wait — against a 15s timeout. With the guard, **0.13s**. Same class as the #190 kcov hang and the same documented repo rule.

## Test plan

- [x] `pytest scanner/tests/` — **2305 passed, 11 skipped** (was 1 failed before the incidental fix)
- [x] `scanner/lib` **99.41%** at the CI gate (floor 99)
- [x] `markdownlint` + `lychee` clean; `gitleaks protect --staged` clean
- [x] Shell: control liveness 14/14, `test_generate_html_dashboard` 36/36
- [x] All figures measured against the real pinned Prowler 5.30.1 files and the 1401-id catalog from the 5.30.1 tag

**Phase 0 is now complete**, which is the plan's stated prerequisite for Phase 1 (per-finding evidence routing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)