### PR TITLE
fix(ci): the guard against running Chrome under kcov never once fired

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -449,6 +449,12 @@ jobs:
         run: bash scanner/tests/test_run_with_timeout_fallbacks.sh
       - name: Run bash unit tests (save_scan_history OCSF compliance)
         run: bash scanner/tests/test_save_scan_history_ocsf.sh
+      # Executes the kcov-skip guard in the two browser smokes, both directions.
+      # The guard it pins replaced one that never fired (TracerPid vs kcov's real
+      # xtrace instrumentation), which is why those smokes drove headless Chrome
+      # under kcov for 7-30s a run and reddened PR #465.
+      - name: Run bash unit tests (kcov-skip guard)
+        run: bash scanner/tests/test_kcov_skip_guard.sh
       # --- end of the #437 follow-up registration -------------------------------
       # Produce the grade-A baseline report the next step asserts against.
       # Without this, test_scan_report_baseline.py skips itself — which is what

--- a/scanner/tests/test_asset_dashboard_control_liveness.sh
+++ b/scanner/tests/test_asset_dashboard_control_liveness.sh
@@ -36,17 +36,30 @@ FIXTURE="$SCRIPT_DIR/fixtures/asset-dashboard-data.json"
 HARNESS="$SCRIPT_DIR/dashboard-control-liveness.mjs"
 ASSERTIONS="$SCRIPT_DIR/asset-dashboard-assertions.js"
 
-# The CI kcov job globs scanner/tests/test_*.sh and runs each DIRECTLY under kcov's
-# ptrace tracer. Driving headless Chrome under ptrace is unreliable (and pointless —
-# this harness measures no SUT bash coverage). Skip when traced so the kcov glob runs
-# us as an instant no-op; the dedicated dashboard-control smoke workflow runs us
-# untraced. macOS/local (no /proc) => treated as untraced.
-if [[ -r /proc/self/status ]]; then
-  tracer_pid="$(awk '/^TracerPid:/{print $2}' /proc/self/status 2>/dev/null || echo 0)"
-  if [[ "${tracer_pid:-0}" != "0" ]]; then
-    echo "SKIP: running under a tracer (kcov/ptrace) — browser smoke runs only in the dedicated workflow."
-    exit 0
-  fi
+# The CI kcov job globs scanner/tests/test_*.sh and runs each one under kcov.
+# Driving headless Chrome there is unreliable and pointless — this harness
+# measures no SUT bash coverage, since it never sources one of the five files in
+# kcov's include-pattern. Skip under kcov so the glob runs us as an instant
+# no-op; the dedicated dashboard-control smoke workflow runs us for real.
+#
+# DETECTED BY ENV VAR, NOT BY TracerPid. The original check read
+# `/proc/self/status` for a non-zero `TracerPid` and NEVER ONCE FIRED, because
+# kcov 42 instruments bash through XTRACE, not ptrace. Measured under the exact
+# CI invocation (`timeout 30 kcov --include-pattern=… <script>`):
+#
+#     TracerPid                 0        <- for the script itself, too
+#     KCOV_BASH_COMMAND         /bin/bash
+#     KCOV_BASH_XTRACEFD        262144
+#     PS4                       kcov@${BASH_SOURCE}@${LINENO}@
+#     SHELLOPTS                 …:xtrace
+#
+# So both browser smokes ran fully under kcov for as long as the guard existed —
+# 7s, 9s, 13s, 21s and 30s across five observed runs, one of them a red build on
+# PR #465 that blocked a merge for a change touching none of this. The env var is
+# set by kcov itself, needs no /proc, and works on macOS.
+if [[ -n "${KCOV_BASH_XTRACEFD:-}" || -n "${KCOV_BASH_COMMAND:-}" ]]; then
+  echo "SKIP: running under kcov (xtrace instrumentation) — browser smoke runs only in the dedicated workflow."
+  exit 0
 fi
 
 for f in "$TEMPLATE" "$FIXTURE" "$HARNESS" "$ASSERTIONS"; do

--- a/scanner/tests/test_dashboard_control_liveness.sh
+++ b/scanner/tests/test_dashboard_control_liveness.sh
@@ -27,17 +27,30 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 GEN="$REPO_ROOT/scanner/lib/dashboard-gen.py"
 HARNESS="$SCRIPT_DIR/dashboard-control-liveness.mjs"
 
-# The CI kcov job globs scanner/tests/test_*.sh and runs each DIRECTLY under
-# kcov's ptrace tracer. Driving headless Chrome under ptrace is unreliable (and
-# pointless — this harness measures no SUT bash coverage). Skip when traced so
-# the kcov glob runs us as an instant no-op; the dedicated dashboard-control
-# smoke workflow runs us untraced. macOS/local (no /proc) => treated as untraced.
-if [[ -r /proc/self/status ]]; then
-  tracer_pid="$(awk '/^TracerPid:/{print $2}' /proc/self/status 2>/dev/null || echo 0)"
-  if [[ "${tracer_pid:-0}" != "0" ]]; then
-    echo "SKIP: running under a tracer (kcov/ptrace) — browser smoke runs only in the dedicated workflow."
-    exit 0
-  fi
+# The CI kcov job globs scanner/tests/test_*.sh and runs each one under kcov.
+# Driving headless Chrome there is unreliable and pointless — this harness
+# measures no SUT bash coverage, since it never sources one of the five files in
+# kcov's include-pattern. Skip under kcov so the glob runs us as an instant
+# no-op; the dedicated dashboard-control smoke workflow runs us for real.
+#
+# DETECTED BY ENV VAR, NOT BY TracerPid. The original check read
+# `/proc/self/status` for a non-zero `TracerPid` and NEVER ONCE FIRED, because
+# kcov 42 instruments bash through XTRACE, not ptrace. Measured under the exact
+# CI invocation (`timeout 30 kcov --include-pattern=… <script>`):
+#
+#     TracerPid                 0        <- for the script itself, too
+#     KCOV_BASH_COMMAND         /bin/bash
+#     KCOV_BASH_XTRACEFD        262144
+#     PS4                       kcov@${BASH_SOURCE}@${LINENO}@
+#     SHELLOPTS                 …:xtrace
+#
+# So both browser smokes ran fully under kcov for as long as the guard existed —
+# 7s, 9s, 13s, 21s and 30s across five observed runs, one of them a red build on
+# PR #465 that blocked a merge for a change touching none of this. The env var is
+# set by kcov itself, needs no /proc, and works on macOS.
+if [[ -n "${KCOV_BASH_XTRACEFD:-}" || -n "${KCOV_BASH_COMMAND:-}" ]]; then
+  echo "SKIP: running under kcov (xtrace instrumentation) — browser smoke runs only in the dedicated workflow."
+  exit 0
 fi
 
 # ── graceful local skip when tooling is missing ──────────────────────────────

--- a/scanner/tests/test_kcov_skip_guard.sh
+++ b/scanner/tests/test_kcov_skip_guard.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Executes the kcov-skip guard in the two browser-smoke tests, both directions.
+#
+# WHY THIS EXISTS: the guard it pins replaced one that never worked. The original
+# read `/proc/self/status` for a non-zero `TracerPid`, on the premise that kcov
+# shows up as a ptrace tracer. It does not — kcov 42 instruments bash through
+# XTRACE. Measured under the exact CI invocation
+# (`timeout 30 kcov --include-pattern=… <script>`), `TracerPid` is 0 for the
+# script itself, while kcov announces itself in the environment:
+#
+#     KCOV_BASH_COMMAND=/bin/bash
+#     KCOV_BASH_XTRACEFD=262144
+#     PS4=kcov@${BASH_SOURCE}@${LINENO}@
+#
+# So both smokes drove headless Chrome under kcov for as long as the guard
+# existed — 7s, 9s, 13s, 21s and 30s across five observed runs, one of them a red
+# build on PR #465 that blocked a merge for a change touching none of this.
+#
+# A guard whose premise is wrong reads exactly like a guard that is working, so
+# this test EXECUTES it rather than grepping for it, and pins BOTH directions:
+# under-firing costs a flaky required check, and OVER-firing would make the
+# dedicated dashboard-control-smoke workflow skip too — silently dropping the
+# only coverage those 34 controls have.
+#
+# Run: bash scanner/tests/test_kcov_skip_guard.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+SUBJECTS=(
+  "test_dashboard_control_liveness.sh"
+  "test_asset_dashboard_control_liveness.sh"
+)
+
+KCOV_SKIP_MARKER="running under kcov"
+
+BASH_BIN="$(command -v bash)"
+
+# A PATH that resolves everything the subjects need BEFORE their own node check
+# (measured: `dirname` and `python3`) but deliberately NOT `node`. Starving PATH
+# entirely was the first draft and it broke the scripts at their `dirname` call,
+# long before the branch under test — a harness failure that read as a guard
+# failure. Chrome is unreachable via CHROME_BIN below; the node check fires first
+# in both subjects, so that is the skip we expect.
+shim_dir="$(mktemp -d)"
+trap 'rm -rf "$shim_dir"' EXIT
+for tool in dirname python3; do
+  tool_path="$(command -v "$tool" 2>/dev/null)" || {
+    echo "  FAIL: harness needs $tool on PATH to build the shim"
+    exit 1
+  }
+  ln -s "$tool_path" "$shim_dir/$tool"
+done
+
+pass() { echo "  PASS: $1"; ((TEST_PASSED++)); }
+fail() {
+  echo "  FAIL: $1"
+  [[ -n "${2:-}" ]] && echo "    $2"
+  ((TEST_FAILED++))
+}
+
+echo "=== kcov-skip guard ==="
+
+for name in "${SUBJECTS[@]}"; do
+  target="$SCRIPT_DIR/$name"
+  if [[ ! -s "$target" ]]; then
+    fail "$name exists" "not found or empty: $target"
+    continue
+  fi
+
+  # ── direction 1: under kcov it must skip, instantly and successfully ────────
+  # `KCOV_BASH_XTRACEFD` is what kcov exports; setting it is the whole simulation.
+  out="$(KCOV_BASH_XTRACEFD=262144 bash "$target" 2>&1)"
+  rc=$?
+  if [[ $rc -ne 0 ]]; then
+    fail "$name: exits 0 under kcov" "rc=$rc, output: $out"
+  elif [[ "$out" != *"$KCOV_SKIP_MARKER"* ]]; then
+    fail "$name: announces the kcov skip" \
+      "expected a line containing '$KCOV_SKIP_MARKER', got: $out"
+  else
+    pass "$name: skips under KCOV_BASH_XTRACEFD (rc=0)"
+  fi
+
+  # The other variable kcov exports must work on its own, so dropping either
+  # spelling upstream cannot silently disable the guard.
+  out="$(KCOV_BASH_COMMAND=/bin/bash bash "$target" 2>&1)"
+  rc=$?
+  if [[ $rc -eq 0 && "$out" == *"$KCOV_SKIP_MARKER"* ]]; then
+    pass "$name: skips under KCOV_BASH_COMMAND (rc=0)"
+  else
+    fail "$name: skips under KCOV_BASH_COMMAND" "rc=$rc, output: $out"
+  fi
+
+  # ── direction 2: NOT under kcov it must not claim to be ─────────────────────
+  # Deliberately starved of node and Chrome so the script takes one of its own
+  # tooling skips instead of launching a browser: this asserts WHICH skip fires,
+  # never that the smoke can run here. An over-firing kcov guard would make the
+  # dedicated workflow a no-op, and nothing else would notice.
+  # `bash` is invoked by ABSOLUTE path because the starved `PATH` cannot resolve
+  # it — the first draft set `PATH=/nonexistent` and `env` failed with rc=127
+  # before the script ever started, which looked like a guard failure.
+  out="$(env -u KCOV_BASH_XTRACEFD -u KCOV_BASH_COMMAND \
+    PATH="$shim_dir" CHROME_BIN=/nonexistent-for-this-test \
+    "$BASH_BIN" "$target" 2>&1)"
+  rc=$?
+  if [[ "$out" == *"$KCOV_SKIP_MARKER"* ]]; then
+    fail "$name: does NOT claim kcov when unset" \
+      "the kcov skip fired with both variables unset — it would also fire in the dedicated workflow, silently dropping the browser coverage. Output: $out"
+  elif [[ $rc -ne 0 ]]; then
+    fail "$name: exits 0 when tooling is absent" "rc=$rc, output: $out"
+  else
+    pass "$name: takes a tooling skip, not the kcov skip, when kcov is absent"
+  fi
+
+  # ── the dead mechanism must not come back ──────────────────────────────────
+  # `TracerPid` may still be NAMED in the explanatory comment — that history is
+  # worth keeping — but it must not be read into a variable the control flow uses.
+  if grep -nE '^[^#]*TracerPid' "$target" >/dev/null 2>&1; then
+    fail "$name: no live TracerPid read" \
+      "TracerPid appears outside a comment; kcov 42 does not ptrace, so such a check cannot fire: $(grep -nE '^[^#]*TracerPid' "$target")"
+  else
+    pass "$name: TracerPid appears only in comments, if at all"
+  fi
+done
+
+echo "=== Results: $TEST_PASSED passed, $TEST_FAILED failed ==="
+exit "$TEST_FAILED"


### PR DESCRIPTION
fix(ci): the guard against running Chrome under kcov never once fired

PR #465 went red on `scanner-shell-coverage` for a change touching none of the
relevant files: `test_asset_dashboard_control_liveness` exited 1 after 21s. A
rerun passed, so it looked like a flake to accept. It is not — it is a dead
guard, and the flake was the guard's absence showing.

Both browser-smoke tests already carry a check meant to make them instant
no-ops under the kcov glob, on the premise that kcov shows up as a ptrace
tracer:

    if [[ -r /proc/self/status ]]; then
      tracer_pid="$(awk '/^TracerPid:/{print $2}' /proc/self/status …)"

kcov 42 does not ptrace bash. It instruments through XTRACE. Measured under the
EXACT CI invocation (`timeout 30 kcov --include-pattern=… <script>`, script via
its shebang) in a container with the same kcov 42 the job caches:

    TracerPid              0          <- for the script's own process, too
    KCOV_BASH_COMMAND      /bin/bash
    KCOV_BASH_XTRACEFD     262144
    PS4                    kcov@${BASH_SOURCE}@${LINENO}@
    SHELLOPTS              …:xtrace

So the check could never fire, and both smokes have driven headless Chrome
under kcov for as long as it existed. Five consecutive runs on `main`:

    test_asset_dashboard_control_liveness   7s   9s   13s   21s   30s
    test_dashboard_control_liveness         1s   1s    1s    1s    1s

The 1s figure is NOT the guard working — I checked the log, and that test also
runs its full browser smoke; it is simply smaller (14 controls vs 20, on a
smaller template). Neither ever skipped. The 30s one sat exactly on the per-test
cap.

## What changed

Detection now reads `KCOV_BASH_XTRACEFD` / `KCOV_BASH_COMMAND` — set by kcov
itself, needs no `/proc`, and works on macOS. Verified in both directions
against real kcov in a container:

    under CI-exact kcov     SKIP: running under kcov (xtrace instrumentation), rc=0, instant
    without kcov            guard does NOT fire (falls through to the node check)

Neither test contributes anything to the coverage this job measures: they never
source one of the five files in `--include-pattern`
(`checks.sh`, `checks_credentials.sh`, `kubectl.sh`, `output.sh`,
`output_prowler.sh`) — they drive `dashboard-gen.py` and a node harness. So
skipping them under kcov is coverage-neutral by construction, which is what
their own comments claimed all along.

This is deliberately NOT fixed by excluding them from the kcov glob in
`lint.yml`. The scripts already own this decision; the decision was just broken.

## The new test

`test_kcov_skip_guard.sh` EXECUTES the guard rather than grepping for it,
because a guard whose premise is wrong reads exactly like one that works. It
pins both directions: under-firing costs a flaky required check, and OVER-firing
would make the dedicated `dashboard-control-smoke` workflow a no-op — silently
dropping the only coverage those 34 controls have. It also rejects a live
`TracerPid` read so the dead mechanism cannot come back.

Non-vacuity proved by reverting ONE script to the original check:

    5 passed, 3 failed
      - announces the kcov skip          (it did not)
      - skips under KCOV_BASH_COMMAND    (it did not)
      - no live TracerPid read           (it had one)

and the reverted script launched Chrome and ran the whole smoke inside the
harness output — the CI behaviour, reproduced locally. Restored: 8 passed.

Two harness bugs of my own, both caught before they could mislead: starving
`PATH` entirely broke the subjects at their `dirname` call (rc=127) long before
the branch under test, and invoking `bash` through the starved PATH failed to
resolve `bash` itself. The negative direction now uses an absolute `bash` and a
shim PATH carrying exactly the two externals the subjects need before their own
node check.

Registered in `scanner-unit-tests`; the reachability guard from #465 caught the
omission first (`2 failed, 59 passed` until it was listed).

## Verification

    pytest scanner/ -q                              2426 passed, 11 skipped
    test_ci_*.py under unittest                     Ran 903 tests, OK
    bash scanner/tests/test_kcov_skip_guard.sh       8 passed, 0 failed
    shellcheck (3 touched scripts)                   rc=0
    actionlint .github/workflows/lint.yml            rc=0
    markdownlint "**/*.md"                           rc=0

Expected CI effect: both liveness tests drop to ~0s in `scanner-shell-coverage`,
with no change to `percent_covered`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)