### PR TITLE
fix(ci): the auto-arm allowlist advertised a path it could not take

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -68,13 +68,36 @@ jobs:
       #
       # ELIGIBLE (auto-arm) only when ALL hold:
       #   - update-type is semver-patch or semver-minor
-      #   - ecosystem is pip, docker, or github-actions
+      #   - ecosystem is pip or docker
       #   - no hard-excluded path pattern matches
       #
-      # NOTE: bot approval is intentionally absent. Branch protection requires
-      # a code-owner review (* @Twodragon0) which GITHUB_TOKEN cannot satisfy.
-      # Auto-merge fires ONLY after the human code-owner approves AND required
-      # checks (Lint, Security Scan Gate) pass AND the branch is up-to-date.
+      # `github-actions` USED TO BE LISTED HERE AND WAS UNREACHABLE, twice over.
+      # First observed live on PR #460 (a `codeql-action` patch bump), the first
+      # real Dependabot PR this workflow ever evaluated:
+      #
+      #   1. Every github-actions bump edits a `uses:` line under `.github/` by
+      #      definition, and the `.github/**` hard-exclude below is evaluated
+      #      BEFORE the ecosystem check. #460's log: "PR touches a hard-excluded
+      #      path ... Requires human code-owner review", then exit 0.
+      #   2. The allowlist arm read `github-actions` with a HYPHEN, while the
+      #      metadata action emits an UNDERSCORE — #460's log again:
+      #      `outputs.package-ecosystem: github_actions`. So even with the path
+      #      exclude removed, the arm could not have matched.
+      #
+      # Removing the entry rather than repairing it: an actions bump changes what
+      # CI itself runs, so human review is the deliberate policy (OWASP CICD-SEC-3
+      # — a repointable ref is a supply-chain exposure). Keeping a dead arm that
+      # advertises auto-merge for actions patches is worse than not offering it.
+      # If that policy ever changes, the `.github/**` exclude must be narrowed in
+      # the same commit, and the ecosystem spelled `github_actions`.
+      #
+      # NOTE: bot approval is intentionally absent, and auto-merge is armed
+      # SERVER-SIDE so branch protection remains the only gate. Required checks
+      # (Lint, Security Scan Gate) must pass and the branch must be up-to-date
+      # (strict mode). Approval is NOT part of that gate: re-verified 2026-08-21,
+      # `require_code_owner_reviews=false`, `required_approving_review_count=0`,
+      # no repo rulesets. An earlier version of this note asserted a code-owner
+      # requirement; that was true when written and is not true now.
       - name: Evaluate eligibility and arm auto-merge
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -126,18 +149,25 @@ jobs:
           esac
 
           # ── Eligible ecosystems ───────────────────────────────────────────
+          # `github_actions` is deliberately absent — see the note above. It is
+          # already unreachable via the `.github/**` hard-exclude, so this is a
+          # second, independent refusal rather than the only one.
           case "$ECOSYSTEM" in
-            pip|docker|github-actions) ;;
+            pip|docker) ;;
             *)
-              echo "Ecosystem '$ECOSYSTEM' is not in the auto-arm allowlist (pip, docker, github-actions) — skipping."
+              echo "Ecosystem '$ECOSYSTEM' is not in the auto-arm allowlist (pip, docker) — skipping."
               exit 0
               ;;
           esac
 
           # ── Arm auto-merge ────────────────────────────────────────────────
-          # This only ARMS GitHub's server-side auto-merge feature. The actual
-          # merge will not execute until the human code-owner (@Twodragon0)
-          # approves the PR AND all required status checks pass AND the branch
-          # is up-to-date with main (strict mode).
+          # This only ARMS GitHub's server-side auto-merge feature. The merge
+          # will not execute until all required status checks pass AND the
+          # branch is up-to-date with main (strict mode). It does NOT wait for a
+          # review: `require_code_owner_reviews` and
+          # `required_approving_review_count` are both off as of 2026-08-21, so
+          # branch protection is the whole gate. That is exactly why the
+          # hard-excludes above, not an approval step, are what keep sensitive
+          # paths on human review.
           echo "PR is eligible ($UPDATE_TYPE / $ECOSYSTEM). Arming auto-merge (squash)."
           gh pr merge --auto --squash "$PR_URL"

--- a/scanner/tests/test_ci_dependabot_automerge.py
+++ b/scanner/tests/test_ci_dependabot_automerge.py
@@ -23,7 +23,7 @@ Control / CICD-SEC-4 Poisoned Pipeline Execution; NIST SSDF PW.4/PO.3):
   3. **Update-type allowlist** — only `version-update:semver-patch` /
      `semver-minor` may auto-arm; `semver-major` is hard-excluded. Broadening
      this would auto-merge breaking bumps.
-  4. **Ecosystem allowlist** — only `pip|docker|github-actions`. Adding e.g.
+  4. **Ecosystem allowlist** — only `pip|docker`. Adding e.g.
      `npm` here is a policy change that must be reviewed, not slipped in.
   5. **No bypass** — the arm must stay `gh pr merge --auto` (server-side, still
      gated by branch protection + the human code-owner review). `--admin` must
@@ -81,8 +81,10 @@ REQUIRED_TOKENS = {
     "eligible_update_types": (
         "version-update:semver-patch|version-update:semver-minor)"
     ),
-    # 4. Ecosystem allowlist
-    "eligible_ecosystems": "pip|docker|github-actions)",
+    # 4. Ecosystem allowlist. `github-actions` was REMOVED, not narrowed — it
+    #    was unreachable twice over (see
+    #    `test_actions_ecosystem_stays_out_of_the_allowlist`).
+    "eligible_ecosystems": "pip|docker)",
     # 5. The arm must be server-side auto-merge (gated by branch protection)
     "arm_is_auto_merge": "gh pr merge --auto",
     # Sanity: this is the pull_request_target workflow we think it is
@@ -205,9 +207,61 @@ class TestDependabotAutoMergeGuard(unittest.TestCase):
         )
         self.assertIn(
             REQUIRED_TOKENS["eligible_ecosystems"], self.scan,
-            "Ecosystem allowlist changed from pip|docker|github-actions — a policy "
+            "Ecosystem allowlist changed from pip|docker — a policy "
             "change that must be reviewed, not slipped in.",
         )
+
+    def test_actions_ecosystem_stays_out_of_the_allowlist(self):
+        """An allowlist must not advertise a path the policy forbids.
+
+        `github-actions` sat in this allowlist while being unreachable for TWO
+        independent reasons, and the first live Dependabot PR this workflow ever
+        evaluated (#460, a `codeql-action` patch bump) demonstrated both:
+
+        1. every github-actions bump edits a `uses:` line under `.github/` by
+           definition, and the `.github/**` hard-exclude is evaluated BEFORE the
+           ecosystem check — #460 exited there;
+        2. the arm was spelled with a HYPHEN while the metadata action emits an
+           UNDERSCORE (`outputs.package-ecosystem: github_actions` in #460's
+           log), so it could not have matched even without the path exclude.
+
+        DIRECTION, stated as it actually behaves rather than as the first draft
+        of this docstring claimed. Both spellings are rejected while the
+        `.github/**` exclude is present, and if that exclude is REMOVED this test
+        does not silently permit the ecosystem — it fails too, on its own opening
+        assertion, because it cannot judge an allowlist whose ordering premise is
+        gone. Measured: narrowing the exclude and adding `github_actions` trips
+        FOUR guards at once (this one, `test_hard_exclude_paths_present`,
+        `test_all_invariants_hold`, `test_real_workflow_clean`). So re-enabling
+        actions auto-arm is deliberately a multi-guard change, not a one-line
+        edit — which is the right cost for a policy that decides whether CI's own
+        definition can merge itself.
+
+        What this is NOT is a claim that actions bumps must never auto-merge. It
+        is a consistency rule: the allowlist must not advertise a capability the
+        evaluation order forbids. A dead arm reads as a capability the repo has,
+        and reason 2 above means nobody would have noticed it was dead even if
+        reason 1 were fixed alone.
+        """
+        active = _active_scan(self.text)
+        github_excluded = REQUIRED_TOKENS["exclude_github"] in active
+        self.assertTrue(
+            github_excluded,
+            "the `.github/**` hard-exclude is gone; that is a separate "
+            "regression and `test_hard_exclude_paths_present` owns it. This test "
+            "cannot judge the allowlist without it.",
+        )
+        for spelling in ("github-actions", "github_actions"):
+            with self.subTest(spelling=spelling):
+                self.assertNotIn(
+                    f"{spelling})",
+                    active,
+                    f"`{spelling}` appears as a case arm while `.github/**` is "
+                    "hard-excluded ahead of the ecosystem check, so it can never "
+                    "match. Either narrow the hard-exclude in this same change, "
+                    "or leave the ecosystem out. Note the emitted value uses an "
+                    "UNDERSCORE: a hyphenated arm is dead even on its own.",
+                )
 
     def test_no_bypass_tokens(self):
         for key, tok in FORBIDDEN_TOKENS.items():
@@ -241,7 +295,7 @@ class TestDependabotAutoMergeGuardMutation(unittest.TestCase):
             "  scripts/*|scripts)",
             'if [ "$UPDATE_TYPE" = "version-update:semver-major" ]; then',
             "  version-update:semver-patch|version-update:semver-minor) ;;",
-            "  pip|docker|github-actions) ;;",
+            "  pip|docker) ;;",
             'gh pr merge --auto --squash "$PR_URL"',
         ]
     )
@@ -338,8 +392,8 @@ class TestDependabotAutoMergeGuardMutation(unittest.TestCase):
 
     def test_broadening_ecosystems_is_detected(self):
         mutant = self._GOOD.replace(
-            "  pip|docker|github-actions) ;;",
-            "  pip|docker|github-actions|npm) ;;",
+            "  pip|docker) ;;",
+            "  pip|docker|npm) ;;",
         )
         self.assertTrue(
             any("eligible_ecosystems" in p for p in _violations(mutant)),


### PR DESCRIPTION
fix(ci): the auto-arm allowlist advertised a path it could not take

PR #460 (a `codeql-action` patch bump) was the FIRST live Dependabot PR
`dependabot-auto-merge.yml` ever evaluated. It worked exactly as coded — and in
doing so proved that one of its allowlist entries was dead, twice over.

    outputs.update-type: version-update:semver-patch
    outputs.package-ecosystem: github_actions
    CHANGED_PATHS: .github/workflows/dast-full-scan.yml
    PR touches a hard-excluded path (Dockerfile / .github / scanner / hooks /
      scripts). Requires human code-owner review.

1. Every `github-actions` bump edits a `uses:` line under `.github/` BY
   DEFINITION, and the `.github/**` hard-exclude is evaluated BEFORE the
   ecosystem check. So no actions PR can reach the allowlist at all.
2. The allowlist arm read `github-actions` with a HYPHEN. The metadata action
   emits an UNDERSCORE — `github_actions`, quoted above from #460's own log. So
   even with the path exclude removed, the arm could not have matched.

Either reason alone makes the entry unreachable; together they mean nobody would
have noticed it was dead even after fixing one. `autoMergeRequest: null` on #460
confirms nothing was armed.

Removing the entry rather than repairing it: an actions bump changes what CI
itself runs, so human review is the deliberate policy (OWASP CICD-SEC-3 — a
repointable ref is a supply-chain exposure; `tj-actions/changed-files`, 2025).
Advertising auto-merge for actions patches while the policy forbids it is worse
than not offering it — someone reading the allowlist would reasonably expect
safe patches to flow through, and plan around a capability that does not exist.

## Also corrected: two stale comments that asserted a gate we no longer have

The workflow's own notes claimed "Branch protection requires a code-owner review
(* @Twodragon0) which GITHUB_TOKEN cannot satisfy" and that the armed merge
"will not execute until the human code-owner (@Twodragon0) approves". Re-verified
against the live API on 2026-08-21:

    require_code_owner_reviews          false
    required_approving_review_count     0
    repo rulesets                       []

`.github/CODEOWNERS` still exists but nothing enforces it. Those notes were true
when written; they are not true now, and they matter because they describe
approval as the thing keeping sensitive paths on human review. It is not — the
hard-excludes are. The comments now say so, and both are dated so the next
reader knows what was measured and when.

## The new invariant

`test_actions_ecosystem_stays_out_of_the_allowlist` pins the CONSISTENCY rule:
the allowlist must not name an ecosystem the evaluation order forbids. Both
spellings are rejected, so re-adding it under either name trips the guard.

Verified in three directions:

    re-add `github-actions` (hyphen), exclude intact    1 failed  (correct)
    re-add `github_actions` (underscore), same          1 failed  (correct)
    re-add AND narrow the .github exclude              4 guards fail

That third case is worth stating precisely, because the first draft of the
docstring claimed it would be GREEN. It is not: this test refuses to judge an
allowlist whose ordering premise is gone and fails on its own opening assertion,
while `test_hard_exclude_paths_present`, `test_all_invariants_hold` and
`test_real_workflow_clean` fail alongside it. Re-enabling actions auto-arm is
therefore deliberately a multi-guard change, which is the right cost for a
policy deciding whether CI's own definition can merge itself. The docstring now
describes the measured behaviour instead of the intended behaviour.

The four synthetic fixtures in the guard's own mutation suite carried the old
allowlist and were updated with it, so `test_broadening_ecosystems_is_detected`
still tests a broadening (`pip|docker` -> `pip|docker|npm`) rather than a no-op.

## Verification

    test_ci_dependabot_automerge.py            19 passed
    pytest scanner/ -q                         2427 passed, 11 skipped
    test_ci_*.py under unittest                Ran 904 tests, OK
    actionlint dependabot-auto-merge.yml       rc=0

## Not verified

Whether `pip` or `docker` auto-arm actually works end to end. The `github_actions`
underscore shows the allowlist was written against assumed vocabulary rather than
observed output, and no live pip/docker Dependabot PR has been observed reaching
the arm — #353 (nginx digest) and #354 (actions group) were both merged by hand.
Those two entries are left as they are rather than "fixed" on a guess; the next
pip or docker bump is the experiment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)