### PR TITLE
fix(scanner): a JSON string from /api/v1/status took down the whole ZIA scan [stacked on #472]

### DIFF
--- a/scanner/lib/zscaler-api.py
+++ b/scanner/lib/zscaler-api.py
@@ -102,8 +102,33 @@ def collect_posture(base: str, session: "requests.Session") -> dict:
     result: dict = {}
 
     # 1. Service status
+    #
+    # `if data else` tested TRUTHINESS where it needed to test TYPE. A 200 whose
+    # body is a JSON string or list is truthy, so `.get` raised
+    # `AttributeError: 'str' object has no attribute 'get'` and took down the
+    # whole posture collection — `scanner/checks/saas/zscaler.sh` then produced
+    # no SAAS-ZIA-* findings at all, with its `2>/dev/null` hiding why.
+    # Reproduced against the real function before the fix:
+    #   {"status": "ok"} -> 'ok'      "a string" -> CRASH      [1, 2] -> CRASH
+    # An `isinstance` guard is also the idiom the rest of this function already
+    # uses (`if code == 200 and isinstance(data, list)` for every list endpoint).
+    #
+    # UNEXPECTED_PAYLOAD is kept distinct from UNKNOWN so the two are
+    # distinguishable downstream: the consumer passes only on `== "ACTIVE"` and
+    # echoes the value in its warning otherwise, so a reachable-but-malformed API
+    # no longer reads the same as one that reported nothing.
     code, data = _safe_get(session, base, "/api/v1/status")
-    result["service_status"] = data.get("status") if data else "UNKNOWN"
+    if isinstance(data, dict):
+        result["service_status"] = str(data.get("status") or "UNKNOWN")
+    elif code == 200:
+        result["service_status"] = "UNEXPECTED_PAYLOAD"
+    else:
+        # Non-200 and transport failures both land here and both report UNKNOWN.
+        # Left as-is deliberately: it predates this fix, it warns either way
+        # rather than passing, and separating them changes a value that is not
+        # part of the crash being fixed. `_unreachable()` below already draws
+        # that distinction for the endpoints where it decides accessibility.
+        result["service_status"] = "UNKNOWN"
 
     # 2. Users — count only, never expose emails/names
     code, data = _safe_get(session, base, "/api/v1/users")

--- a/scanner/tests/test_zscaler_api_fail_closed.py
+++ b/scanner/tests/test_zscaler_api_fail_closed.py
@@ -227,24 +227,109 @@ def test_policy_access_stays_fail_closed_on_transport_failure():
 
 
 # ---------------------------------------------------------------------------
-# Known-unfixed, pinned here so it is not mistaken for this change's doing:
-# `service_status` still calls `.get()` on whatever /api/v1/status returned,
-# so an HTTP 200 that yields a JSON string/list raises AttributeError out of
-# collect_posture(). Out of scope for the accessible-flag fix.
+# `service_status` on a non-dict 200 body. This was pinned as a KNOWN GAP by the
+# accessible-flag change ("still calls .get() on whatever /api/v1/status
+# returned"), with a self-destructing assertion that failed the moment the crash
+# was fixed — which is what brought us back here. The pin worked; these are its
+# replacements, asserting the fixed behaviour in both directions.
 # ---------------------------------------------------------------------------
 
 
-def test_known_gap_service_status_raises_on_non_dict_200_payload():
+def _malformed_status_only(body):
+    """Only `/api/v1/status` is malformed; every other endpoint stays healthy.
+
+    Scoped per-URL on purpose. The first draft returned the malformed body for
+    EVERY endpoint, which made the list case fail — not because `service_status`
+    was still broken, but because a list body then reaches the users handler,
+    whose `isinstance(data, list)` guard checks the CONTAINER and not its
+    elements, so `1.get("groups")` raises. That is a separate defect, pinned
+    below; mixing it in here would have made this test report on the wrong bug.
+    """
+
+    def _payload(url):
+        return body if url.endswith("/api/v1/status") else _healthy_payload(url)
+
+    return _payload
+
+
+def test_service_status_survives_a_string_200_payload():
+    """The exact input the old pin used. It raised AttributeError before."""
     mod = _load()
-    session = _session_returning(200, lambda url: "a string")
+    session = _session_returning(200, _malformed_status_only("a string"))
+    posture = mod.collect_posture(_FAKE_BASE, session)
+    assert posture["service_status"] == "UNEXPECTED_PAYLOAD"
+
+
+def test_service_status_survives_a_list_200_payload():
+    mod = _load()
+    session = _session_returning(200, _malformed_status_only([1, 2]))
+    posture = mod.collect_posture(_FAKE_BASE, session)
+    assert posture["service_status"] == "UNEXPECTED_PAYLOAD"
+
+
+def test_service_status_survives_a_null_200_body():
+    """A 200 whose body is JSON `null`. This used to read as "UNKNOWN" via the
+    truthiness test; it is genuinely an unexpected payload, and saying so is the
+    point of separating the two values."""
+    mod = _load()
+    session = _session_returning(200, _malformed_status_only(None))
+    posture = mod.collect_posture(_FAKE_BASE, session)
+    assert posture["service_status"] == "UNEXPECTED_PAYLOAD"
+
+
+def test_service_status_reports_the_real_status_for_a_dict_payload():
+    """Positive control. The assertions above mean nothing unless the normal path
+    still reports the API's own value."""
+    mod = _load()
+    session = _session_returning(200, _healthy_payload)
+    posture = mod.collect_posture(_FAKE_BASE, session)
+    assert posture["service_status"] == "ACTIVE"
+
+
+def test_service_status_is_unknown_when_the_dict_carries_no_status():
+    mod = _load()
+    session = _session_returning(200, _malformed_status_only({}))
+    posture = mod.collect_posture(_FAKE_BASE, session)
+    assert posture["service_status"] == "UNKNOWN"
+
+
+def test_known_gap_list_body_still_crashes_the_users_handler():
+    """NEW pin, replacing the one this change consumed.
+
+    `isinstance(data, list)` in the users handler checks the container and not
+    its elements, so a 200 whose body is `[1, 2]` reaches `u.get("groups")` and
+    raises. Same shape as the `{"saas": ["okta"]}` case fixed in the dashboard
+    asset loader. Out of scope here — this change is the `service_status` crash —
+    and pinned so it cannot rot: the assertion FAILS the moment it is fixed, which
+    is exactly how this defect got picked up.
+    """
+    mod = _load()
+    session = _session_returning(200, lambda url: [1, 2])
     try:
         mod.collect_posture(_FAKE_BASE, session)
     except AttributeError as exc:
         assert "get" in str(exc)
     else:
         raise AssertionError(
-            "service_status non-dict crash appears fixed — update this pin"
+            "list-element crash in the users handler appears fixed — update this pin"
         )
+
+
+def test_service_status_is_unknown_on_a_transport_failure():
+    """Documented residual: a transport failure and a status-less 200 both report
+    UNKNOWN. Pinned so the conflation stays a recorded decision rather than an
+    accident — see the comment at the call site."""
+    mod = _load()
+
+    class _Boom:
+        def get(self, *_a, **_k):
+            raise OSError("dns failure")
+
+        def delete(self, *_a, **_k):
+            return None
+
+    posture = mod.collect_posture(_FAKE_BASE, _Boom())
+    assert posture["service_status"] == "UNKNOWN"
 
 
 # ---------------------------------------------------------------------------
@@ -289,8 +374,26 @@ class ZscalerApiFailClosedTestCase(unittest.TestCase):
     def test_policy_access_fail_closed(self):
         test_policy_access_stays_fail_closed_on_transport_failure()
 
-    def test_service_status_known_gap(self):
-        test_known_gap_service_status_raises_on_non_dict_200_payload()
+    def test_service_status_string_payload(self):
+        test_service_status_survives_a_string_200_payload()
+
+    def test_service_status_list_payload(self):
+        test_service_status_survives_a_list_200_payload()
+
+    def test_service_status_null_body(self):
+        test_service_status_survives_a_null_200_body()
+
+    def test_service_status_dict_payload(self):
+        test_service_status_reports_the_real_status_for_a_dict_payload()
+
+    def test_service_status_no_status_key(self):
+        test_service_status_is_unknown_when_the_dict_carries_no_status()
+
+    def test_service_status_transport_failure(self):
+        test_service_status_is_unknown_on_a_transport_failure()
+
+    def test_users_handler_list_element_gap(self):
+        test_known_gap_list_body_still_crashes_the_users_handler()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

> **⚠️ STACKED ON #472** — base is `fix/auth-parse-crash-and-zscaler-fail-open`, not `main`. That branch is where the pin this PR closes lives, and it renumbers the same file.
>
> **RETARGET THIS PR TO `main` BEFORE #472 MERGES.** Merging #472 with `--delete-branch` (the repo posture) deletes the base ref and GitHub **auto-closes** this PR; a closed PR base cannot be changed and it cannot be reopened once the ref is gone. Recovery is a rebase plus a brand-new PR, losing this thread.

## Summary

`result["service_status"] = data.get("status") if data else "UNKNOWN"` tested **truthiness** where it needed to test **type**. A 200 whose body is a JSON string or list is truthy, so `.get` raised `AttributeError` out of `collect_posture` — and `scanner/checks/saas/zscaler.sh` then produced **no SAAS-ZIA-* findings at all**, with its own `2>/dev/null` hiding why.

Reproduced against the real function before the fix:

```text
{"status": "ok"} -> 'ok'        "a string" -> CRASH        [1, 2] -> CRASH
```

Fixed with an `isinstance(data, dict)` guard — also the idiom the rest of `collect_posture` already uses (`if code == 200 and isinstance(data, list)` at every list endpoint).

`UNEXPECTED_PAYLOAD` is kept distinct from `UNKNOWN`. That is safe: the consumer passes only on `== "ACTIVE"` and echoes the value in its warning otherwise, so a reachable-but-malformed API no longer reads the same as one reporting nothing. A 200 body of JSON `null` moves from `UNKNOWN` to `UNEXPECTED_PAYLOAD` for the same reason, pinned by its own test rather than left as a silent side effect.

Non-200 and transport failures both still report `UNKNOWN` — left alone deliberately (predates this fix, warns either way rather than passing, and separating them changes a value outside the crash), and pinned so the conflation stays a recorded decision.

## The pin #472 left behind did its job

#472 recorded this as `test_known_gap_service_status_raises_on_non_dict_200_payload`, asserting the crash still happened and **failing the moment it was fixed**. That self-destructing assertion is what brought us back here. Five tests replace it, both directions plus a positive control on the normal path.

## My first draft of those tests was wrong, and the way it was wrong matters

It returned the malformed body for **every** endpoint, so the list case failed — not because `service_status` was still broken, but because a list body then reaches the users handler, whose `isinstance(data, list)` guard checks the **container** and not its elements. `1.get("groups")` raises. **The crash had moved, not gone.**

Tests are now scoped per-URL via `_malformed_status_only`, so they report on the bug they name. That element-level crash is a separate defect (same shape as the `{"saas": ["okta"]}` case in the dashboard asset loader), out of scope here, and it gets the same treatment #472 gave this one: `test_known_gap_list_body_still_crashes_the_users_handler` fails the moment it is fixed, so the pin cannot rot.

## Validation

| Check | Result |
|---|---|
| `pytest test_zscaler_api_fail_closed.py` | **38 passed** |
| `unittest test_zscaler_api_fail_closed` | **19 tests, OK** (dual-runner) |
| `pytest --cov=scanner/lib --cov-fail-under=99` | **2517 passed**, 11 skipped, 99.41% |
| `unittest discover -p test_ci_*.py` | 933 OK |
| `test_check_saas_zscaler.sh` | 17 passed, 0 failed |
| `ruff check .` | All checks passed |

Post-fix repro, all five shapes:

```text
dict ACTIVE -> 'ACTIVE'   dict empty -> 'UNKNOWN'   string -> 'UNEXPECTED_PAYLOAD'
list (status only) -> 'UNEXPECTED_PAYLOAD'   transport failure -> 'UNKNOWN'
```

- [x] `./scripts/lint-shell.sh` equivalent — no shell changed
- [ ] `gh pr checks <PR_NUMBER>`

## Checks Snapshot

To be pasted from `.github/comment-templates/pr-checks-snapshot.md` once checks report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)