### PR TITLE
test(scanner): the temp-file leak check was reading other runs' residue

### DIFF
--- a/scanner/tests/test_output_dashboard_gen_stderr.sh
+++ b/scanner/tests/test_output_dashboard_gen_stderr.sh
@@ -73,6 +73,13 @@ assert_eq() {
 tmpdir="$(mktemp -d)"
 trap 'rm -rf "$tmpdir"' EXIT
 
+# Point TMPDIR at this run's own directory so the `mktemp` inside
+# `generate_html_dashboard` lands somewhere only this run can touch. Without it,
+# Case 6's leak check reads the shared /tmp and reports on other runs' residue —
+# see the note there. Exported (not just set) because the function runs in this
+# shell and shells out to python3.
+export TMPDIR="$tmpdir"
+
 SCAN_DIR="$tmpdir"
 source "$LIB_DIR_REAL/output.sh" 2>/dev/null || true
 should_report() { return 0; }
@@ -216,7 +223,19 @@ assert_eq "legacy fallback produced the file" "true" \
 echo ""
 echo "=== the stderr temp file is cleaned up ==="
 
-leftover="$(find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'claudesec-dashgen.*' 2>/dev/null | wc -l | tr -d ' ')"
+# Scoped to THIS test's own directory, not the shared `$TMPDIR`.
+#
+# The first version scanned `${TMPDIR:-/tmp}` wholesale, which made the result
+# depend on state no run of this file controls. Measured: after an unrelated
+# earlier run of the PRE-FIX code (which creates these files and never removes
+# them — the very leak this asserts against), four strays sat in `$TMPDIR` and
+# this assertion reported `expected '0', got '4'` on a tree whose behaviour was
+# correct. It passed in CI, where the runner is fresh, and failed locally. A
+# check that reads another run's residue is not measuring this one.
+#
+# `TMPDIR` is exported for the whole file above, so `mktemp` inside `output.sh`
+# lands here and the scan is exact.
+leftover="$(find "$tmpdir" -maxdepth 1 -name 'claudesec-dashgen.*' 2>/dev/null | wc -l | tr -d ' ')"
 assert_eq "no claudesec-dashgen.* temp files remain" "0" "$leftover"
 
 # ==============================================================================


### PR DESCRIPTION
# Pull Request

## Summary

Case 6 of `test_output_dashboard_gen_stderr.sh` scanned `${TMPDIR:-/tmp}` wholesale for `claudesec-dashgen.*`, so its verdict depended on state no run of this file controls.

My own mutation experiment against the pre-fix `output.sh` — which creates those files and never removes them, **the very leak this asserts against** — left four strays behind, and the assertion then reported `expected '0', got '4'` on a tree whose behaviour was correct.

It **passed in CI**, where the runner is fresh, and **failed locally**. That combination is the tell: a check reading another run's residue is not measuring this one, and it would eventually fire on a colleague's machine for no reason they could act on. It landed in the same change as the fix it guards, so it is mine to correct.

`TMPDIR` is now exported to this run's own directory, so the `mktemp` inside `generate_html_dashboard` lands somewhere only this run can touch and the scan is exact rather than approximate.

## Verified in both directions

A hermetic check that no longer detects anything would be the worse outcome, so both halves are measured:

```text
clean run                                  -> 18 passed, 0 failed
three strays planted in the shared $TMPDIR -> 18 passed, 0 failed   (immune now)
cleanup calls removed from output.sh       -> 17 passed, 1 failed   (still catches a real leak)
```

## Validation

| Check | Result |
|---|---|
| `test_output_dashboard_gen_stderr.sh` | 18 passed, 0 failed |
| `test_output_coverage.sh` | 71 passed, 0 failed (unchanged) |
| `test_generate_html_dashboard.sh` | 36 passed, 0 failed (unchanged) |
| `shellcheck -x -S error` | clean |

- [x] `./scripts/lint-shell.sh` equivalent — `shellcheck -x -S error`, clean
- [ ] `gh pr checks <PR_NUMBER>`

## Checks Snapshot

To be pasted from `.github/comment-templates/pr-checks-snapshot.md` once checks report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)