### PR TITLE
fix(docker): strip six providers prowler 5.39.1 added, restoring the size headroom

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,6 +78,12 @@ RUN pip install --no-cache-dir --no-compile --break-system-packages --prefix=/in
        "${SITE}"/googleapis* \
        "${SITE}"/cloudflare* \
        "${SITE}"/alibabacloud* \
+       "${SITE}"/huaweicloud* \
+       "${SITE}"/scaleway* \
+       "${SITE}"/stackit* \
+       "${SITE}"/linode* \
+       "${SITE}"/e2enetworks* \
+       "${SITE}"/vercel* \
        "${SITE}"/openstacksdk* \
        "${SITE}"/openstack* \
        "${SITE}"/plotly* \
@@ -97,11 +103,17 @@ RUN pip install --no-cache-dir --no-compile --break-system-packages --prefix=/in
        "${SITE}"/prowler/providers/openstack \
        "${SITE}"/prowler/providers/oraclecloud \
        "${SITE}"/prowler/providers/image \
+       "${SITE}"/prowler/providers/huaweicloud \
+       "${SITE}"/prowler/providers/scaleway \
+       "${SITE}"/prowler/providers/stackit \
+       "${SITE}"/prowler/providers/linode \
+       "${SITE}"/prowler/providers/e2enetworks \
+       "${SITE}"/prowler/providers/vercel \
        2>/dev/null || true \
     # Patch prowler to skip removed provider imports (guard: skip if entrypoint moved)
     && MAIN="${SITE}/prowler/__main__.py" \
     && if [ -f "$MAIN" ]; then \
-         for p in alibabacloud azure gcp googleworkspace llm m365 mongodbatlas nhn cloudflare openstack oraclecloud image; do \
+         for p in alibabacloud azure gcp googleworkspace llm m365 mongodbatlas nhn cloudflare openstack oraclecloud image huaweicloud scaleway stackit linode e2enetworks vercel; do \
            sed -i "s|^from prowler\.providers\.${p}|# removed: ${p} #|" "$MAIN"; \
          done; \
        else \


### PR DESCRIPTION
# Pull Request

## Summary

The prowler 5.30.1 → 5.39.1 bump I merged in #473 passed the 600 MB image-size gate at **599 MB**. One megabyte.

I did not notice, because the size evidence in that PR body — "176 MB" — came from `docker image inspect` on Docker Desktop, which reports something **~3.5× smaller** than the CI runner measures. That number was wrong, and the gate was effectively already breached for whatever changed next. #479 (an alpine 3.20 → 3.23 bump) then measured **614 MB** in CI, and that is how this surfaced.

## Where the growth went

Measured inside the image with `du`, so the method is comparable across machines:

```text
prowler 5.30.1   site-packages 274 MB   /  580 MB
prowler 5.39.1   site-packages 364 MB   /  669 MB      (+90 MB)
```

5.39.1 ships **six providers 5.30.1 did not**, and the Dockerfile's strip list — twelve providers long — predates all of them:

| provider | SDK | provider dir |
|---|---|---|
| `huaweicloud` | **61 MB** (22 packages) | 1 MB |
| `scaleway` | 11 MB | 1 MB |
| `stackit` | 8 MB | 1 MB |
| `linode` | 2 MB | 1 MB |
| `e2enetworks` | 0 MB | 1 MB |
| `vercel` | 0 MB | 1 MB |

None of the six appears in `_prowler_providers` in `scanner/checks/prowler/integration.sh`, so the scanner never offered them and nothing can regress by their absence. They are stripped exactly like the existing twelve — SDK globs, provider directories, **and** the `__main__.py` import patch. All three: omitting the import patch would leave prowler importing a package that is no longer there.

## Result

site-packages **364 → 304 MB**, a 60 MB recovery.

Not the full 88 MB the per-provider figures sum to — those overlap in shared transitive deps — which is why the number quoted here is the one **measured after** the change rather than predicted before it. Remaining provider set is exactly what the scanner uses: `aws common github iac kubernetes okta`.

## Validation

| Check | Result |
|---|---|
| `prowler --version` in the built image | `Prowler 5.39.1` — **runs**, not just installs |
| `prowler.providers.aws` import | importable |
| `test_prowler_provider_build_parity.sh` | 41 passed, 0 failed |
| in-container `claudesec scan -c code` | 24 checks, clean exit |
| `unittest discover -p test_ci_*.py` | 945 OK |
| `pytest scanner/tests/` | 2470 passed |

**I cannot verify the CI-measured megabyte count locally — that is the whole lesson of this PR.** `dashboard-regression-check` here is the real evidence. Expected ≈539 MB against the 600 MB gate.

- [x] `./scripts/lint-shell.sh` equivalent — no shell changed
- [ ] `gh pr checks <PR_NUMBER>`

Refs #473, #479

## Checks Snapshot

To be pasted from `.github/comment-templates/pr-checks-snapshot.md` once checks report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)