### PR TITLE
fix(scanner): the users handler type-checked the list but not what was in it [stacked on #475]

### DIFF
--- a/scanner/lib/zscaler-api.py
+++ b/scanner/lib/zscaler-api.py
@@ -131,8 +131,30 @@ def collect_posture(base: str, session: "requests.Session") -> dict:
         result["service_status"] = "UNKNOWN"
 
     # 2. Users — count only, never expose emails/names
+    #
+    # `isinstance(data, list)` checked the CONTAINER and not its elements, so a
+    # 200 body of `[1, 2]` or `["okta"]` reached `u.get("groups")` and raised
+    # `AttributeError: 'int' object has no attribute 'get'`, taking down the whole
+    # posture collection. Measured before this guard:
+    #   [{"groups": [...], ...}] -> counted      [1, 2] -> CRASH
+    #   ["okta"] -> CRASH                        [None] -> CRASH
+    # Same shape as the `{"saas": ["okta"]}` case in the dashboard asset loader:
+    # a type check one level too shallow.
+    #
+    # A list with a non-dict element is routed to `_unreachable(code)` rather
+    # than filtered down to the dict elements. Filtering would keep `total` and
+    # call it a success while silently under-counting, which trades a crash for a
+    # quiet wrong number — and `_unreachable(200)` already means exactly this
+    # ("reason": "unexpected_payload"), so no new state is invented.
+    #
+    # This endpoint is the only one that needs the element check: groups,
+    # departments and nss_feeds take `len(data)` and never dereference an element.
     code, data = _safe_get(session, base, "/api/v1/users")
-    if code == 200 and isinstance(data, list):
+    if (
+        code == 200
+        and isinstance(data, list)
+        and all(isinstance(u, dict) for u in data)
+    ):
         total = len(data)
         no_group = sum(1 for u in data if not u.get("groups"))
         no_dept = sum(1 for u in data if not u.get("department"))

--- a/scanner/tests/test_zscaler_api_fail_closed.py
+++ b/scanner/tests/test_zscaler_api_fail_closed.py
@@ -293,26 +293,53 @@ def test_service_status_is_unknown_when_the_dict_carries_no_status():
     assert posture["service_status"] == "UNKNOWN"
 
 
-def test_known_gap_list_body_still_crashes_the_users_handler():
-    """NEW pin, replacing the one this change consumed.
-
-    `isinstance(data, list)` in the users handler checks the container and not
-    its elements, so a 200 whose body is `[1, 2]` reaches `u.get("groups")` and
-    raises. Same shape as the `{"saas": ["okta"]}` case fixed in the dashboard
-    asset loader. Out of scope here — this change is the `service_status` crash —
-    and pinned so it cannot rot: the assertion FAILS the moment it is fixed, which
-    is exactly how this defect got picked up.
+def test_users_list_with_non_dict_elements_is_unexpected_payload():
+    """The pin that stood here asserted this still crashed, and failed the moment
+    it was fixed — the second time in this file that a self-destructing pin has
+    routed the next change to the right place. `[1, 2]` used to raise
+    `AttributeError: 'int' object has no attribute 'get'` out of the users
+    handler, because `isinstance(data, list)` checked the container and not its
+    elements.
     """
     mod = _load()
-    session = _session_returning(200, lambda url: [1, 2])
-    try:
-        mod.collect_posture(_FAKE_BASE, session)
-    except AttributeError as exc:
-        assert "get" in str(exc)
-    else:
-        raise AssertionError(
-            "list-element crash in the users handler appears fixed — update this pin"
-        )
+    for body in ([1, 2], ["okta"], [None], [{"groups": []}, "mixed"]):
+        session = _session_returning(200, lambda url, b=body: b)
+        posture = mod.collect_posture(_FAKE_BASE, session)
+        assert posture["users"]["accessible"] is False, body
+        assert posture["users"]["reason"] == "unexpected_payload", body
+
+
+def test_users_list_of_dicts_still_counts():
+    """Positive control. The assertion above means nothing unless a well-formed
+    list is still counted — routing everything to `unexpected_payload` would
+    satisfy it and destroy the feature."""
+    mod = _load()
+    session = _session_returning(200, _healthy_payload)
+    posture = mod.collect_posture(_FAKE_BASE, session)
+    assert posture["users"]["accessible"] is True
+    assert posture["users"]["total"] == 1
+
+
+def test_users_empty_list_is_a_real_empty_result():
+    """`all()` over an empty list is True, which is what we want here: an empty
+    user list is a legitimate answer, not a malformed payload."""
+    mod = _load()
+    session = _session_returning(200, lambda url: [])
+    posture = mod.collect_posture(_FAKE_BASE, session)
+    assert posture["users"]["accessible"] is True
+    assert posture["users"]["total"] == 0
+
+
+def test_endpoints_that_only_count_are_unaffected():
+    """groups/departments/nss_feeds take `len(data)` and never dereference an
+    element, so they need no element guard — pinned so a future 'consistency'
+    refactor does not add one and change their behaviour by accident."""
+    mod = _load()
+    session = _session_returning(200, lambda url: [1, 2, 3])
+    posture = mod.collect_posture(_FAKE_BASE, session)
+    for key in ("groups", "departments", "nss_feeds"):
+        assert posture[key]["accessible"] is True, key
+        assert posture[key]["total"] == 3, key
 
 
 def test_service_status_is_unknown_on_a_transport_failure():
@@ -392,8 +419,17 @@ class ZscalerApiFailClosedTestCase(unittest.TestCase):
     def test_service_status_transport_failure(self):
         test_service_status_is_unknown_on_a_transport_failure()
 
-    def test_users_handler_list_element_gap(self):
-        test_known_gap_list_body_still_crashes_the_users_handler()
+    def test_users_non_dict_elements(self):
+        test_users_list_with_non_dict_elements_is_unexpected_payload()
+
+    def test_users_list_of_dicts(self):
+        test_users_list_of_dicts_still_counts()
+
+    def test_users_empty_list(self):
+        test_users_empty_list_is_a_real_empty_result()
+
+    def test_count_only_endpoints_unaffected(self):
+        test_endpoints_that_only_count_are_unaffected()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Pull Request

> **⚠️ STACKED ON #475**, which is itself stacked on #472. Base is `fix/zscaler-service-status-non-dict`.
>
> The repo has `delete_branch_on_merge=true` at the **repository** level, so a merge deletes the head branch **regardless of the `--delete-branch` flag** and auto-closes anything based on it. Merge this chain bottom-up (#472 → #475 → this), rebasing each successor onto `main` as its base lands.

## Summary

`if code == 200 and isinstance(data, list)` checked the **container** and not its elements, so a 200 body of `[1, 2]` reached `u.get("groups")` and raised `AttributeError: 'int' object has no attribute 'get'` out of `collect_posture` — the same total loss of SAAS-ZIA-* findings the `service_status` crash caused, through a different door.

Measured before this guard:

```text
[{"groups": [...], "department": "d"}] -> counted
[1, 2]  -> CRASH        ["okta"] -> CRASH        [None] -> CRASH
```

Same shape as the `{"saas": ["okta"]}` case in the dashboard asset loader: a type check one level too shallow.

## Why route to `_unreachable`, not filter

A list containing a non-dict goes to `_unreachable(code)` rather than being filtered down to its dict elements. **Filtering would keep `total` and call it a success while silently under-counting** — trading a crash for a quiet wrong number, which is the worse of the two. `_unreachable(200)` already means exactly this (`"reason": "unexpected_payload"`), so no new state is invented and the consumer's existing handling applies unchanged.

## Scope checked, not assumed

This is the **only** endpoint needing the element guard. `groups`, `departments` and `nss_feeds` take `len(data)` and never dereference an element — pinned by `test_endpoints_that_only_count_are_unaffected` so a future "consistency" refactor does not add a guard there and change their behaviour by accident.

## The pin did its job again

`test_known_gap_list_body_still_crashes_the_users_handler` asserted the crash still happened and **failed the moment it was fixed** — the second time in this file a self-destructing pin has routed the next change to the right place, after the one that produced #475.

Four tests replace it, including **two positive controls**:

- a well-formed list must still be counted — routing everything to `unexpected_payload` would satisfy the negative assertion and destroy the feature;
- an **empty** list must stay a real result (`all()` over an empty list is True, which is the behaviour wanted here).

## Validation

| Check | Result |
|---|---|
| `pytest test_zscaler_api_fail_closed.py` | **44 passed** |
| `unittest test_zscaler_api_fail_closed` | **22 tests, OK** (dual-runner) |
| `pytest --cov=scanner/lib --cov-fail-under=99` | **2523 passed**, 99.41% |
| `unittest discover -p test_ci_*.py` | 933 OK |
| `test_check_saas_zscaler.sh` | 17 passed, 0 failed |
| `ruff check .` | All checks passed |

Post-fix, all six shapes:

```text
list of dicts   -> accessible=True  total=1     empty list      -> accessible=True  total=0
list of ints    -> accessible=False unexpected_payload
list of strings -> accessible=False unexpected_payload
list with None  -> accessible=False unexpected_payload
mixed           -> accessible=False unexpected_payload
```

- [x] `./scripts/lint-shell.sh` equivalent — no shell changed
- [ ] `gh pr checks <PR_NUMBER>`

## Checks Snapshot

To be pasted from `.github/comment-templates/pr-checks-snapshot.md` once checks report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)