### PR TITLE
chore(deps): bump codeql-action to v4.37.8 at all four pinned sites

### DIFF
--- a/.github/workflows/dast-full-scan.yml
+++ b/.github/workflows/dast-full-scan.yml
@@ -185,7 +185,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always() && hashFiles('zap_scan.sarif') != ''
-        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
         with:
           sarif_file: zap_scan.sarif
           category: "DAST"

--- a/templates/codeql.yml
+++ b/templates/codeql.yml
@@ -42,15 +42,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
         with:
           languages: ${{ matrix.language }}
           queries: +security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
 
       - name: Perform Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd  # v4.37.7
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28  # v4.37.8
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Supersedes #478.

## Why #478 cannot merge on its own

Dependabot only bumped the single site it tracks — `.github/workflows/dast-full-scan.yml:188` — and left the three pins in `templates/codeql.yml` on v4.37.7. `scanner/tests/test_ci_template_pin_policy.py` requires all four SHA-pinned `github/codeql-action` sites to move together, so #478 is red:

```
CI config guards   fail   13s
Lint               fail    3s
```

This is the same drift class recorded for #460 and is the reason the Dependabot auto-arm workflow hard-excludes `.github/**`.

## What this does

Bumps all four sites from `ff2f1c62…` (v4.37.7) to `db488dde…` (v4.37.8):

- `.github/workflows/dast-full-scan.yml:188` — `upload-sarif`
- `templates/codeql.yml:45` — `init`
- `templates/codeql.yml:51` — `autobuild`
- `templates/codeql.yml:54` — `analyze`

## Verification

SHA resolved against upstream rather than trusted from the Dependabot diff — the annotated tag dereferences to the pinned commit:

```console
$ gh api repos/github/codeql-action/git/ref/tags/v4.37.8 -q .object.sha
37f2634a92ba38a0926ef79a0748ac8ae7d95ab2
$ gh api repos/github/codeql-action/git/tags/37f2634a92ba38a0926ef79a0748ac8ae7d95ab2 -q ".object.type + \" -> \" + .object.sha"
commit -> db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28
```

Guard passes locally:

```console
$ python3 -m pytest scanner/tests/test_ci_template_pin_policy.py -q
17 passed in 0.04s
```

No `v4.37.7` / `ff2f1c62` references remain under `.github/` or `templates/`.

## Follow-up

Close #478 as superseded once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)