### PR TITLE
fix(scanner): the diagram's OCSF loader still read an unread file as a clean scan

### DIFF
--- a/scanner/lib/diagram_data.py
+++ b/scanner/lib/diagram_data.py
@@ -55,18 +55,46 @@ def _parse_ocsf_json(content):
 
 
 def load_prowler_files(prowler_dir):
+    """`{provider: findings}` for every provider whose OCSF file was READ.
+
+    Second implementation of the invariant `dashboard_data_loader
+    ._load_single_prowler_file` carries, and it used to violate it. The keys are
+    this module's "these providers were scanned" claim: `aggregate_scan_data`
+    turns them into `prowler_providers` plus a `{"fail": n, "total": n}` summary,
+    so mapping an unread file to `[]` rendered it as `0/0` — a clean bill of
+    health for evidence that never decoded. Omit instead, exactly as #471 did on
+    the dashboard path and as `prowler_compliance_summary._read_findings` has
+    always done by adding the provider only after the parse succeeds.
+
+    `errors="replace"` is the recovery half. Without an explicit encoding
+    `open()` used the locale default, so under a C/POSIX locale any non-ASCII
+    byte in a cloud resource tag, owner or description cost the whole provider;
+    the replacement character can only corrupt the one string literal it lands
+    in, and `_parse_ocsf_json`'s `raw_decode` resync already tolerates that.
+
+    A file that reads but holds no record is the third case: an empty document
+    is a real, clean scan and keeps its provider, while garbage does not.
+    """
     providers = {}
     if not os.path.isdir(prowler_dir):
         return providers
     for fpath in sorted(glob.glob(os.path.join(prowler_dir, "prowler-*.ocsf.json"))):
         name = Path(fpath).stem.replace(".ocsf", "").replace("prowler-", "")
         try:
-            with open(fpath) as f:
+            with open(fpath, encoding="utf-8", errors="replace") as f:
                 content = f.read().strip()
-            items = _parse_ocsf_json(content)
-            providers[name] = items
         except Exception:
-            providers[name] = []
+            continue
+        items = _parse_ocsf_json(content)
+        if not items and content:
+            # Decided by asking whether the text is valid JSON at all, NOT by
+            # comparing it against a list of empty spellings — `"[ ]"` is legal,
+            # empty JSON and must not be misread as garbage (ADR-001 §5).
+            try:
+                json.loads(content)
+            except ValueError:
+                continue
+        providers[name] = items
     return providers
 
 

--- a/scanner/tests/test_ci_scanned_provider_invariant.py
+++ b/scanner/tests/test_ci_scanned_provider_invariant.py
@@ -1,6 +1,13 @@
 """Regression guard: `scanned_providers` may only ever name a provider whose
 Prowler evidence file actually decoded.
 
+TWO IMPLEMENTATIONS, TWO DOORS. `dashboard_data_loader.load_prowler_files` and
+`diagram_data.load_prowler_files` are independent copies of the same loader.
+#471 fixed only the first, so this guard covered only the first — and the
+diagram copy kept mapping an unread file to `[]` until 2026-08-25. Both are
+asserted here now; adding a third copy without a class in this file is the
+regression this paragraph exists to prevent.
+
 THE INVARIANT. `load_prowler_files`' keys are not a convenience — `dashboard-gen.py`
 passes them verbatim as `map_compliance(all_findings, scanned_providers=set(providers))`,
 where the #455 gate uses them to decide whether a control had evidence it could
@@ -55,6 +62,7 @@ by `test_sibling_file_failure_keeps_the_readable_findings` so the trade-off is
 pinned rather than assumed.
 """
 
+import glob
 import json
 import os
 import sys
@@ -62,11 +70,13 @@ import tempfile
 import unittest
 import warnings
 from pathlib import Path
+from unittest.mock import patch
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scanner" / "lib"))
 
 import dashboard_data_loader as loader  # noqa: E402
+import diagram_data  # noqa: E402
 
 
 def _finding(check="iam_user_mfa_enabled"):
@@ -319,6 +329,94 @@ class TestGuardFailsAgainstTheOldBehaviour(unittest.TestCase):
             self.assertEqual(got.get("aws"), [], "pre-fix behaviour not reproduced")
         finally:
             loader._load_single_prowler_file = original
+
+
+class TestDiagramDataCarriesTheSameInvariant(unittest.TestCase):
+    """The SECOND implementation. `diagram_data.load_prowler_files` is a separate
+    copy of the same loader and it violated the invariant for as long as the
+    dashboard one did — #471 fixed only `dashboard_data_loader`, so this file
+    guarded one of the two doors.
+
+    The claim here is narrower but the same shape: these keys become
+    `aggregate_scan_data`'s `prowler_providers`, and every key also gets a
+    `prowler_summary[prov] = {"fail": n, "total": n}` entry. Mapping an unread
+    file to `[]` therefore drew the provider on the architecture diagram as
+    `0 fail / 0 total` — scanned and clean — on evidence that never decoded.
+    There is no `match_source` to launder here, which is why this is the milder
+    half; it is still a claim the repository cannot support.
+    """
+
+    def test_module_is_importable(self):
+        """Canary — see `test_loader_is_importable`."""
+        self.assertTrue(hasattr(diagram_data, "load_prowler_files"))
+
+    def test_unreadable_file_is_not_claimed_as_scanned(self):
+        with tempfile.TemporaryDirectory() as d:
+            fpath = _write(d, "prowler-aws.ocsf.json", json.dumps([_finding()]))
+            real_open = open
+
+            def _raise_on_ocsf(path, *args, **kwargs):
+                if str(path) == str(fpath):
+                    raise OSError("permission denied")
+                return real_open(path, *args, **kwargs)
+
+            with patch("builtins.open", side_effect=_raise_on_ocsf):
+                got = diagram_data.load_prowler_files(d)
+        self.assertNotIn("aws", got)
+
+    def test_garbage_is_not_claimed_as_scanned(self):
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "prowler-aws.ocsf.json", "NOT JSON{{{")
+            got = diagram_data.load_prowler_files(d)
+        self.assertNotIn("aws", got)
+
+    def test_non_utf8_byte_recovers_every_finding(self):
+        """The recovery half. 50 findings, one 0x80 spliced in — delta must be 0,
+        not merely non-empty, or `errors="replace"` could silently drop records
+        and still pass."""
+        payload = bytearray(json.dumps([_finding() for _ in range(50)]).encode())
+        payload[200:200] = b"\x80"
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "prowler-aws.ocsf.json", bytes(payload))
+            got = diagram_data.load_prowler_files(d)
+        self.assertEqual(len(got.get("aws", [])), 50)
+
+    def test_empty_file_still_counts_as_scanned(self):
+        """DIRECTION check. Over-correcting here would stop drawing every clean
+        provider. `[ ]` is legal, empty JSON and must not read as garbage."""
+        for spelling in ("[]", "[ ]", "\n[]\n"):
+            with self.subTest(spelling=spelling):
+                with tempfile.TemporaryDirectory() as d:
+                    _write(d, "prowler-aws.ocsf.json", spelling)
+                    got = diagram_data.load_prowler_files(d)
+                self.assertIn("aws", got)
+                self.assertEqual(got["aws"], [])
+
+    def test_pre_fix_diagram_loader_reproduces_the_defect(self):
+        """Non-vacuity (ADR-001 §4) — verbatim shape of the code before this
+        change, proving the three assertions above actually fire."""
+        def _pre_fix(prowler_dir):
+            providers = {}
+            for fpath in sorted(
+                glob.glob(os.path.join(prowler_dir, "prowler-*.ocsf.json"))
+            ):
+                name = Path(fpath).stem.replace(".ocsf", "").replace("prowler-", "")
+                try:
+                    with open(fpath) as f:
+                        providers[name] = diagram_data._parse_ocsf_json(f.read().strip())
+                except Exception:
+                    providers[name] = []
+            return providers
+
+        with tempfile.TemporaryDirectory() as d:
+            _write(d, "prowler-aws.ocsf.json", "NOT JSON{{{")
+            got = _pre_fix(d)
+        self.assertEqual(
+            got.get("aws"),
+            [],
+            "the pre-fix diagram loader no longer reproduces the defect, so the "
+            "assertions in this class prove nothing — re-derive them",
+        )
 
 
 if __name__ == "__main__":

--- a/scanner/tests/test_diagram_gen_coverage.py
+++ b/scanner/tests/test_diagram_gen_coverage.py
@@ -2,7 +2,7 @@
 Targeted coverage tests for scanner/lib/diagram-gen.py.
 
 Covers the specific missing lines identified by --cov-report=term-missing:
-  73-74    — except Exception: providers[name] = [] in load_prowler_files
+  the except in load_prowler_files (unreadable file → provider dropped)
   159-182  — drawio_cell called with vertex=False (edge mode), source/target args
   292-293  — prowler_list non-empty branch in generate_scan_flow_diagram
   469      — targets = [] guard when report["targets"] is not a list
@@ -56,17 +56,24 @@ def _agg(**overrides):
 
 
 # ===========================================================================
-# Lines 73-74 — load_prowler_files: except Exception → providers[name] = []
+# load_prowler_files: except Exception → the provider is DROPPED, not emptied
 # ===========================================================================
 
 
 class TestLoadProwlerFilesExceptionFallback(unittest.TestCase):
     """
-    When a prowler OCSF file exists but open() raises, the except on
-    lines 73-74 must execute and set providers[name] to [].
+    When a prowler OCSF file exists but open() raises, the except must drop the
+    provider entirely.
+
+    This previously asserted `providers["aws"] == []`. That pinned the bug: the
+    keys are the "this provider was scanned" claim that `aggregate_scan_data`
+    turns into `prowler_providers` and a `{"fail": 0, "total": 0}` summary, so an
+    unreadable file was laundered into a clean bill of health. Same invariant
+    `dashboard_data_loader` carries since #471, and the reason `errors="replace"`
+    is now on the read.
     """
 
-    def test_oserror_on_open_sets_provider_to_empty_list(self):
+    def test_oserror_on_open_drops_the_provider(self):
         with tempfile.TemporaryDirectory() as d:
             fpath = os.path.join(d, "prowler-aws.ocsf.json")
             with open(fpath, "w") as f:
@@ -82,8 +89,7 @@ class TestLoadProwlerFilesExceptionFallback(unittest.TestCase):
             with patch("builtins.open", side_effect=_raise_on_ocsf):
                 providers = MOD.load_prowler_files(d)
 
-        self.assertIn("aws", providers)
-        self.assertEqual(providers["aws"], [])
+        self.assertNotIn("aws", providers)
 
 
 # ===========================================================================

--- a/scanner/tests/test_diagram_gen_pure_helpers.py
+++ b/scanner/tests/test_diagram_gen_pure_helpers.py
@@ -239,14 +239,16 @@ def test_load_prowler_files_provider_name_strips_prefix_and_suffix(tmp_path):
     assert list(providers.keys()) == ["gcp"]
 
 
-def test_load_prowler_files_unreadable_file_becomes_empty(tmp_path):
-    # Write invalid content — _parse_ocsf_json returns [] and the
-    # provider entry should become [].
+def test_load_prowler_files_garbage_file_is_not_claimed_as_scanned(tmp_path):
+    # Was `assert providers.get("bad") == []`, which pinned the false-PASS: the
+    # keys are the "this provider was scanned" claim, so an entry that never
+    # decoded rendered as `{"fail": 0, "total": 0}` — a clean bill of health for
+    # evidence that does not exist. Garbage must drop the provider instead.
     (tmp_path / "prowler-bad.ocsf.json").write_text(
         "xxx not json xxx", encoding="utf-8"
     )
     providers = MOD.load_prowler_files(str(tmp_path))
-    assert providers.get("bad") == []
+    assert "bad" not in providers
 
 
 # ===========================================================================


### PR DESCRIPTION
Follow-up to #471, which closed only one of two doors.

## The gap

`dashboard_data_loader.load_prowler_files` and `diagram_data.load_prowler_files` are **independent copies of the same loader**. #471 fixed the first. The second still had the original shape:

```python
try:
    with open(fpath) as f:                     # no encoding
        content = f.read().strip()
    items = _parse_ocsf_json(content)
    providers[name] = items
except Exception:
    providers[name] = []                       # unread file -> "scanned, clean"
```

Those keys are a scanned-provider claim here too: `aggregate_scan_data` turns them into `prowler_providers` **and** `prowler_summary[prov] = {"fail": 0, "total": 0}`, so a file that never decoded was drawn on the architecture diagram as scanned and clean.

This is milder than #471 — there is no `match_source` provenance label to launder, and it does not flip a compliance control. But the **trigger was more likely**: `open()` with no `encoding=` uses the locale default, so under a C/POSIX locale any non-ASCII byte in a cloud resource tag, owner or description cost the entire provider.

## Verification — the guard was run against the pre-fix loader

```console
$ git checkout scanner/lib/diagram_data.py    # revert the fix
$ python3 -m pytest scanner/tests/test_ci_scanned_provider_invariant.py -q
>       self.assertNotIn("aws", got)
E       AssertionError: 'aws' unexpectedly found in {'aws': []}

FAILED ...::test_garbage_is_not_claimed_as_scanned
FAILED ...::test_non_utf8_byte_recovers_every_finding
FAILED ...::test_unreadable_file_is_not_claimed_as_scanned
3 failed, 15 passed

$ # restore
18 passed
```

All three defect axes fire. Note `test_non_utf8_byte_recovers_every_finding` failing pre-fix: on a UTF-8 locale one `0x80` byte was already enough.

## The fix — mirrors #471 exactly

- `errors="replace"` on the read. Recovery is exact, not approximate: 50 of 50 findings with `0x80` spliced in, delta `+0`.
- An unreadable file **drops** the provider instead of mapping it to `[]`.
- A file that reads but parses to no record is separated **by the grammar** (`json.loads`), not by enumerating empty spellings — `"[ ]"` is legal, empty JSON and stays claimed as assessed-and-clean (ADR-001 §5).

## Tests that were pinning the bug

Two existing tests asserted the old behaviour and are updated, with the rationale inline rather than silently flipped:

- `test_diagram_gen_pure_helpers.py` — `..._unreadable_file_becomes_empty` → `..._garbage_file_is_not_claimed_as_scanned`
- `test_diagram_gen_coverage.py` — `..._sets_provider_to_empty_list` → `..._drops_the_provider`

`test_ci_scanned_provider_invariant.py` gains `TestDiagramDataCarriesTheSameInvariant` with its own non-vacuity shim, plus a docstring paragraph stating that a third copy of this loader may not be added without a class in that file. That is what let #471 fix one door and leave the other open.

## Evidence

```console
$ CLAUDESEC_DASHBOARD_OFFLINE=1 python3 -m pytest scanner/ -q
2476 passed, 11 skipped, 1 warning in 11.91s

$ ... --cov=scanner/lib --cov-precision=2 --cov-fail-under=99
scanner/lib/diagram_data.py     91    0  100.00%
TOTAL                         3707   22   99.41%
Required test coverage of 99% reached.

$ ruff check --select E9,F <changed files>
All checks passed!
```

## Not in scope (reported, not changed)

- `scripts/build-dashboard.py:224` uses `Path.read_text()` with no encoding and `except Exception: pass`. A decode failure there silently drops that file's findings, under-reporting failures. No per-provider scanned claim, so it is a different (smaller) blast radius — separate change.
- `diagram_data.py:79` (`load_scan_history`) also opens without an encoding. Same class, outside this loader.
- `diagram_data.load_prowler_files` does not apply `_normalize_provider`, so `k8s`/`eks` do not merge into `kubernetes` the way they do on the dashboard path. Pre-existing drift, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)