### PR TITLE
refactor(scanner): single-source the diagram's three OCSF/history loaders

### DIFF
--- a/scanner/lib/dashboard_data_loader.py
+++ b/scanner/lib/dashboard_data_loader.py
@@ -192,6 +192,18 @@ def load_prowler_files(prowler_dir: str) -> dict[str, list[dict[str, Any]]]:
 
 
 def load_scan_history(history_dir: str) -> list[dict[str, Any]]:
+    """Every readable `scan-*.json` in `history_dir`; unreadable ones are skipped.
+
+    `ValueError`, not `json.JSONDecodeError`. `UnicodeDecodeError` is a SIBLING
+    `ValueError` subclass, not a `JSONDecodeError`, so the narrower form let one
+    non-UTF-8 byte in a history file abort the whole dashboard build instead of
+    dropping that entry — the same defect `_load_saas_sso_stats` carried:
+
+        >>> issubclass(UnicodeDecodeError, ValueError)
+        True
+        >>> issubclass(UnicodeDecodeError, json.JSONDecodeError)
+        False
+    """
     entries: list[dict[str, Any]] = []
     if not os.path.isdir(history_dir):
         return entries
@@ -199,7 +211,7 @@ def load_scan_history(history_dir: str) -> list[dict[str, Any]]:
         try:
             with open(fpath, encoding="utf-8") as f:
                 entries.append(json.load(f))
-        except (OSError, json.JSONDecodeError):
+        except (OSError, ValueError):
             continue
     return entries
 

--- a/scanner/lib/diagram_data.py
+++ b/scanner/lib/diagram_data.py
@@ -6,13 +6,19 @@ Leaf module for the diagram generator: it loads scan-report.json, Prowler OCSF
 provider files, and scan history, then aggregates them into the label dict the
 draw.io / SVG builders consume. No draw.io/SVG concerns live here.
 
-`load_scan_results` is single-sourced from `dashboard_data_loader` (with
-try/except hardening) so the two implementations can't drift.
+Every loader here is single-sourced from `dashboard_data_loader` so the two
+implementations can't drift. `load_scan_results` always was; `_parse_ocsf_json`,
+`load_prowler_files` and `load_scan_history` were byte-near copies until
+2026-08-25, and the copies cost two bugs. #471 fixed the OCSF false-PASS in
+`dashboard_data_loader` only, leaving the copy here to be found and fixed
+separately by #484; the copy also never applied `_normalize_provider`, so the
+diagram labelled a cluster `k8s` where the dashboard called it `kubernetes`.
+Pinned by `scanner/tests/test_ci_diagram_gen_canonical_sync.py`, which asserts
+object identity rather than matching source text.
 """
 import json
 import os
 import sys
-import glob
 from pathlib import Path
 
 # Sibling-module imports: ensure this file's dir (scanner/lib) is importable
@@ -21,7 +27,12 @@ from pathlib import Path
 # diagram-gen.py and the dashboard_* modules.
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from dashboard_data_loader import load_scan_results  # noqa: E402,F401
+from dashboard_data_loader import (  # noqa: E402,F401
+    _parse_ocsf_json,
+    load_prowler_files,
+    load_scan_history,
+    load_scan_results,
+)
 
 # Scanner categories — order must mirror the `CLAUDESEC_ALL_CATEGORIES` array in
 # scanner/claudesec (the authoritative scan order). CATEGORIES[:8]/[:7] slices
@@ -31,84 +42,6 @@ CATEGORIES = [
     "infra", "ai", "network", "cloud", "access-control",
     "cicd", "code", "macos", "windows", "saas", "prowler",
 ]
-
-
-def _parse_ocsf_json(content):
-    items = []
-    decoder = json.JSONDecoder()
-    idx = 0
-    while idx < len(content):
-        while idx < len(content) and content[idx] in " \t\n\r":
-            idx += 1
-        if idx >= len(content):
-            break
-        try:
-            obj, end = decoder.raw_decode(content, idx)
-            if isinstance(obj, list):
-                items.extend(o for o in obj if isinstance(o, dict))
-            elif isinstance(obj, dict):
-                items.append(obj)
-            idx = end
-        except json.JSONDecodeError:
-            idx += 1
-    return items
-
-
-def load_prowler_files(prowler_dir):
-    """`{provider: findings}` for every provider whose OCSF file was READ.
-
-    Second implementation of the invariant `dashboard_data_loader
-    ._load_single_prowler_file` carries, and it used to violate it. The keys are
-    this module's "these providers were scanned" claim: `aggregate_scan_data`
-    turns them into `prowler_providers` plus a `{"fail": n, "total": n}` summary,
-    so mapping an unread file to `[]` rendered it as `0/0` — a clean bill of
-    health for evidence that never decoded. Omit instead, exactly as #471 did on
-    the dashboard path and as `prowler_compliance_summary._read_findings` has
-    always done by adding the provider only after the parse succeeds.
-
-    `errors="replace"` is the recovery half. Without an explicit encoding
-    `open()` used the locale default, so under a C/POSIX locale any non-ASCII
-    byte in a cloud resource tag, owner or description cost the whole provider;
-    the replacement character can only corrupt the one string literal it lands
-    in, and `_parse_ocsf_json`'s `raw_decode` resync already tolerates that.
-
-    A file that reads but holds no record is the third case: an empty document
-    is a real, clean scan and keeps its provider, while garbage does not.
-    """
-    providers = {}
-    if not os.path.isdir(prowler_dir):
-        return providers
-    for fpath in sorted(glob.glob(os.path.join(prowler_dir, "prowler-*.ocsf.json"))):
-        name = Path(fpath).stem.replace(".ocsf", "").replace("prowler-", "")
-        try:
-            with open(fpath, encoding="utf-8", errors="replace") as f:
-                content = f.read().strip()
-        except Exception:
-            continue
-        items = _parse_ocsf_json(content)
-        if not items and content:
-            # Decided by asking whether the text is valid JSON at all, NOT by
-            # comparing it against a list of empty spellings — `"[ ]"` is legal,
-            # empty JSON and must not be misread as garbage (ADR-001 §5).
-            try:
-                json.loads(content)
-            except ValueError:
-                continue
-        providers[name] = items
-    return providers
-
-
-def load_scan_history(history_dir):
-    entries = []
-    if not os.path.isdir(history_dir):
-        return entries
-    for fpath in sorted(glob.glob(os.path.join(history_dir, "scan-*.json"))):
-        try:
-            with open(fpath) as f:
-                entries.append(json.load(f))
-        except Exception:
-            pass
-    return entries
 
 
 def aggregate_scan_data(scan_dir):

--- a/scanner/tests/test_ci_diagram_gen_canonical_sync.py
+++ b/scanner/tests/test_ci_diagram_gen_canonical_sync.py
@@ -185,5 +185,64 @@ class TestDiagramGenCanonicalSync(unittest.TestCase):
         self.assertNotEqual(bash_cats, list(reversed(bash_cats)))
 
 
+class TestDiagramDataLoadersAreSingleSourced(unittest.TestCase):
+    """`diagram_data` must not carry its own copy of any `dashboard_data_loader`
+    loader.
+
+    WHY IDENTITY, NOT A SOURCE GREP. This is the same drift class as the inline
+    `ARCH_DOMAINS` above, but it had already cost two bugs before anyone looked
+    for it: `diagram_data` held byte-near copies of `_parse_ocsf_json`,
+    `load_prowler_files` and `load_scan_history`, so
+
+      * #471 fixed the OCSF false-PASS in `dashboard_data_loader` and the copy
+        here kept it, needing a whole second PR (#484); and
+      * the copy never called `_normalize_provider`, so the diagram labelled a
+        cluster `k8s` where the dashboard called the same cluster `kubernetes`.
+
+    A source pin on the import line would pass against a re-added local `def`
+    that shadows it. `is` cannot be satisfied by a copy — which is exactly the
+    ADR-001 §5 / #404 lesson that executing beats matching text.
+    """
+
+    LOADERS = ("_parse_ocsf_json", "load_prowler_files", "load_scan_history",
+               "load_scan_results")
+
+    @classmethod
+    def setUpClass(cls):
+        sys.path.insert(0, str(LIB_DIR))
+        import dashboard_data_loader
+        import diagram_data
+        cls.canonical = dashboard_data_loader
+        cls.diagram = diagram_data
+
+    def test_each_loader_is_the_same_object_as_canonical(self):
+        for name in self.LOADERS:
+            with self.subTest(loader=name):
+                self.assertIs(
+                    getattr(self.diagram, name),
+                    getattr(self.canonical, name),
+                    f"diagram_data.{name} is not dashboard_data_loader.{name} — "
+                    "a local copy was re-added and will drift",
+                )
+
+    def test_diagram_gen_reexports_resolve_to_canonical(self):
+        """The tests and builders reach these through `diagram-gen.py`'s
+        re-export, so pin that hop too — re-exporting a shadowed copy would
+        satisfy the check above and still ship the copy."""
+        mod = _load_diagram_gen()
+        for name in ("_parse_ocsf_json", "load_prowler_files"):
+            with self.subTest(loader=name):
+                self.assertIs(getattr(mod, name), getattr(self.canonical, name))
+
+    def test_identity_check_is_not_vacuous(self):
+        """A distinct function with identical behaviour must FAIL the check, or
+        the assertions above would pass against any copy."""
+        def _copy(content):
+            return self.canonical._parse_ocsf_json(content)
+
+        self.assertEqual(_copy("[]"), self.canonical._parse_ocsf_json("[]"))
+        self.assertIsNot(_copy, self.canonical._parse_ocsf_json)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scanner/tests/test_dashboard_data_loader_pure.py
+++ b/scanner/tests/test_dashboard_data_loader_pure.py
@@ -221,6 +221,25 @@ class TestLoadScanHistory(unittest.TestCase):
             result = loader.load_scan_history(d)
         self.assertEqual(len(result), 1)
 
+    def test_non_utf8_byte_skips_the_entry_instead_of_raising(self):
+        """`test_invalid_json_entries_skipped` above covers only JSONDecodeError,
+        which is why this went unnoticed: the handler caught
+        `json.JSONDecodeError`, and `UnicodeDecodeError` is a SIBLING
+        `ValueError` subclass — not a `JSONDecodeError`. One bad byte in a
+        history file therefore aborted the whole dashboard build:
+
+            UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in
+            position 7: invalid start byte
+        """
+        self.assertTrue(issubclass(UnicodeDecodeError, ValueError))
+        self.assertFalse(issubclass(UnicodeDecodeError, json.JSONDecodeError))
+        with tempfile.TemporaryDirectory() as d:
+            with open(os.path.join(d, "scan-1.json"), "wb") as f:
+                f.write(b'{"score": "\x80"}')
+            _write_json(os.path.join(d, "scan-2.json"), {"score": 80})
+            result = loader.load_scan_history(d)
+        self.assertEqual(result, [{"score": 80}])
+
 
 # ===========================================================================
 # 7. load_audit_points_detected


### PR DESCRIPTION
Closes the drift class that produced #484, and fixes a live crash it exposed.

## The duplication

`diagram_data.py` already imported `load_scan_results` from `dashboard_data_loader` and said so in its docstring — but carried its own byte-near copies of `_parse_ocsf_json`, `load_prowler_files` and `load_scan_history`. Those copies had already cost two bugs:

- **#471** fixed the OCSF false-PASS in `dashboard_data_loader`. The copy here kept it and needed a whole second PR (**#484**).
- The copy never applied `_normalize_provider`, so the diagram labelled a cluster `k8s` where the dashboard called the same cluster `kubernetes`. `dashboard_providers.PROVIDER_LABELS` only knows the canonical `kubernetes` key.

## Measured deltas

Every one is in the diagram's favour:

| input | before | after |
|---|---|---|
| `prowler-k8s.ocsf.json` | `['k8s']` | `['kubernetes']` |
| `aws.ocsf.json` (no `prowler-` prefix) | dropped | `['aws']` |
| `prowler-eks` + `prowler-k8s` | overwritten | `{'kubernetes': 3}` |
| history with one `0x80` byte | **crash** | `[{'ok': 1}]` |
| unreadable OCSF evidence | silent | `warnings.warn` |

Consumers (`diagram-gen.py:97`, `diagram_svg.py:53`) only `", ".join(...)` the slugs — no name-based branching — so the relabel is display-only.

## The live crash this exposed

`dashboard_data_loader.load_scan_history` caught `(OSError, json.JSONDecodeError)`. `UnicodeDecodeError` is a **sibling** `ValueError` subclass, not a `JSONDecodeError`:

```pycon
>>> issubclass(UnicodeDecodeError, ValueError)
True
>>> issubclass(UnicodeDecodeError, json.JSONDecodeError)
False
```

So one bad byte in a history file aborted the whole dashboard build rather than dropping that entry. Reproduced on `main`:

```console
PRE-FIX RAISED: UnicodeDecodeError - 'utf-8' codec can't decode byte 0x80 in position 7: invalid start byte
```

This is the same defect `_load_saas_sso_stats` carried (and #472 is fixing there). Widened to `ValueError`, a strict superset of `json.JSONDecodeError`. It was a prerequisite for the unification — single-sourcing onto a function that crashes where the copy degraded would have been a regression.

## Guards — identity, not source text

`test_ci_diagram_gen_canonical_sync.py` gains `TestDiagramDataLoadersAreSingleSourced`:

- object **identity** for all four loaders (`assertIs`), plus `diagram-gen.py`'s re-export hop, because re-exporting a shadowed copy would satisfy a module-level check alone;
- a non-vacuity test proving a behaviourally identical copy **fails** `assertIs`.

A source pin on the import line would pass against a re-added local `def` that shadows it — the ADR-001 §5 / #404 lesson that executing beats matching text.

`test_dashboard_data_loader_pure.py` gains the non-UTF-8 history case. The existing `test_invalid_json_entries_skipped` only covered `JSONDecodeError`, which is exactly why this went unnoticed.

## Evidence

Both guards were run against the pre-change tree:

```console
FAILED ...TestDiagramDataLoadersAreSingleSourced::test_each_loader_is_the_same_object_as_canonical
  AssertionError: <function _parse_ocsf_json at 0x107b55300> is not <function _parse_ocsf_json at 0x107ab71a0>
FAILED ...TestDiagramDataLoadersAreSingleSourced::test_diagram_gen_reexports_resolve_to_canonical
FAILED ...TestLoadScanHistory::test_non_utf8_byte_skips_the_entry_instead_of_raising
  UnicodeDecodeError: 'utf-8' codec can't decode byte 0x80 in position 11
3 failed, 96 passed        # after the change: 99 passed
```

```console
$ CLAUDESEC_DASHBOARD_OFFLINE=1 python3 -m pytest scanner/tests/ --cov=scanner/lib --cov-precision=2 --cov-fail-under=99 -q
scanner/lib/diagram_data.py               41    0  100.00%   (was 91 statements)
scanner/lib/dashboard_data_loader.py     407    1   99.75%
TOTAL                                   3657   22   99.40%
Required test coverage of 99% reached.
2480 passed, 11 skipped

$ ruff check .          # repo ruff.toml, as CI runs it
All checks passed!
```

## Not in scope

`scripts/build-dashboard.py:224` (`Path.read_text()` with no encoding + `except Exception: pass`) is the remaining reader in this class — separate change.

Also found while here, **reported not fixed**: 17 `except ... json.JSONDecodeError` sites remain across `scanner/lib/` (`audit-points-scan.py`, `dashboard_auth.py`, `dashboard_data_loader.py`, `diagram_data.py`). Each has the same `UnicodeDecodeError` gap, but widening them needs a per-site audit of what else in the `try` could raise a legitimate `ValueError` — not a mechanical sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)