### PR TITLE
fix(scanner): every read in build-dashboard.py inherited the runner's locale

### DIFF
--- a/scanner/tests/test_build_dashboard_units.py
+++ b/scanner/tests/test_build_dashboard_units.py
@@ -298,5 +298,62 @@ class TestOpenpyxlAbsenceHandling(unittest.TestCase):
         http_client.request.assert_called_once()
 
 
+class TestReadsDeclareTheirEncoding(unittest.TestCase):
+    """`Path.read_text()` with no `encoding=` uses `locale.getpreferredencoding`.
+
+    That makes what the script can parse depend on the runner's `LANG`: under a
+    C/POSIX locale the default is ASCII, so any non-ASCII byte anywhere in a
+    cache, inventory or Prowler artifact raises `UnicodeDecodeError`. In the
+    OCSF reader that exception landed in `except Exception: pass` and silently
+    dropped the file's findings, which UNDER-REPORTS failures — the same class
+    as #471/#484, minus the per-provider "was scanned" claim.
+
+    Source-level on purpose: the 16 call sites are spread across cache, git,
+    inventory and template paths that a unit test cannot all reach, so the
+    cheap invariant is "no read declares no encoding".
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.src = Path(_SCRIPT).read_text(encoding="utf-8")
+
+    @staticmethod
+    def _bare_read_text_lines(src):
+        """Line numbers of `.read_text()` calls with no arguments. Returns line
+        numbers rather than the source, so a failure names the sites instead of
+        dumping 100 KB of script into the assertion message."""
+        return [
+            i for i, line in enumerate(src.splitlines(), 1)
+            if ".read_text()" in line
+        ]
+
+    def test_no_read_text_without_an_encoding(self):
+        self.assertEqual(
+            self._bare_read_text_lines(self.src),
+            [],
+            'every Path.read_text() in build-dashboard.py must pass '
+            'encoding="utf-8" — a bare call inherits the runner locale',
+        )
+
+    def test_detector_is_not_vacuous(self):
+        """Sanity: the detector must name the line of a shape it forbids."""
+        self.assertEqual(
+            self._bare_read_text_lines("import os\nx = p.read_text()\ny = 1\n"),
+            [2],
+        )
+
+    def test_ocsf_reader_tolerates_a_bad_byte(self):
+        """The findings reader specifically needs errors="replace": dropping a
+        provider's file here lowers the reported failure count."""
+        needle = 'f.read_text(encoding="utf-8", errors="replace")'
+        self.assertEqual(
+            self.src.count(needle),
+            2,
+            f'both reads in the OCSF loop must use {needle} (the first parse '
+            "and the NDJSON re-read); found "
+            f"{self.src.count(needle)}",
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/build-dashboard.py
+++ b/scripts/build-dashboard.py
@@ -66,7 +66,7 @@ def load_env() -> dict[str, str]:
     ]
     for p in candidates:
         if p and p.exists():
-            for line in p.read_text().splitlines():
+            for line in p.read_text(encoding="utf-8").splitlines():
                 if "=" in line and not line.startswith("#"):
                     k, v = line.split("=", 1)
                     env[k.strip()] = v.strip()
@@ -221,12 +221,18 @@ def collect_prowler():
     findings = []
     for f in pdir.glob("*.ocsf.json"):
         try:
-            data = json.loads(f.read_text())
+            # errors="replace" for the same reason as #471/#484: one non-UTF-8
+            # byte in a cloud resource tag, owner or description used to fall
+            # through to `except Exception: pass` below and silently drop that
+            # file's findings, which UNDER-REPORTS failures. The replacement
+            # character can only corrupt the one string literal it lands in, and
+            # the raw_decode resync below already tolerates that.
+            data = json.loads(f.read_text(encoding="utf-8", errors="replace"))
             findings.extend(data if isinstance(data, list) else [data])
         except json.JSONDecodeError:
             # Handle NDJSON or multi-object files (e.g., prowler-iac.ocsf.json)
             decoder = json.JSONDecoder()
-            raw = f.read_text().strip()
+            raw = f.read_text(encoding="utf-8", errors="replace").strip()
             pos = 0
             while pos < len(raw):
                 try:
@@ -425,7 +431,7 @@ def load_cached_notion_audits(cache_path: Path) -> list[NotionAudit]:
     if not cache_path.exists():
         return []
     try:
-        audits = json.loads(cache_path.read_text())
+        audits = json.loads(cache_path.read_text(encoding="utf-8"))
     except Exception:
         return []
 
@@ -726,7 +732,7 @@ def collect_jamf_pcs():
     inventory_path = ASSETS_DIR / "jamf-full-inventory.json"
     if not pcs and inventory_path.exists():
         try:
-            inv = json.loads(inventory_path.read_text())
+            inv = json.loads(inventory_path.read_text(encoding="utf-8"))
             pcs = [item for item in inv if item.get("type") == "computer"]
             print(f"    Jamf PC: {len(pcs)}대 (CSV 인벤토리)")
             return pcs
@@ -737,7 +743,7 @@ def collect_jamf_pcs():
     cache_path = ASSETS_DIR / "jamf-computers.json"
     if not pcs and cache_path.exists():
         try:
-            pcs = json.loads(cache_path.read_text())
+            pcs = json.loads(cache_path.read_text(encoding="utf-8"))
             print(f"    Jamf PC: {len(pcs)}대 (캐시)")
             return pcs
         except Exception:
@@ -755,7 +761,7 @@ def collect_intune_pcs():
     cache_path = ASSETS_DIR / "intune-computers.json"
     if cache_path.exists():
         try:
-            pcs = json.loads(cache_path.read_text())
+            pcs = json.loads(cache_path.read_text(encoding="utf-8"))
             print(f"  Intune PC: {len(pcs)}대")
             return pcs
         except Exception:
@@ -769,7 +775,7 @@ def collect_policies():
     cache_path = ASSETS_DIR / "policies.json"
     if cache_path.exists():
         try:
-            policies = json.loads(cache_path.read_text())
+            policies = json.loads(cache_path.read_text(encoding="utf-8"))
             total_articles = sum(p.get("total_articles", 0) for p in policies)
             print(f"  규정/지침: {len(policies)}개 ({total_articles}개 조항)")
             return policies
@@ -1126,7 +1132,7 @@ def collect_sheets():
     s1_path = ASSETS_DIR / "sentinelone-agents.json"
     s1_agents: list[dict[str, object]] = []
     if s1_path.exists():
-        loaded_agents = json.loads(s1_path.read_text())
+        loaded_agents = json.loads(s1_path.read_text(encoding="utf-8"))
         if isinstance(loaded_agents, list):
             s1_agents = [item for item in loaded_agents if isinstance(item, dict)]
         print(f"    SentinelOne: {len(s1_agents)}대")
@@ -1134,14 +1140,14 @@ def collect_sheets():
     s1_threats_path = ASSETS_DIR / "sentinelone-threats.json"
     s1_threats: list[dict[str, object]] = []
     if s1_threats_path.exists():
-        loaded_threats = json.loads(s1_threats_path.read_text())
+        loaded_threats = json.loads(s1_threats_path.read_text(encoding="utf-8"))
         if isinstance(loaded_threats, list):
             s1_threats = [item for item in loaded_threats if isinstance(item, dict)]
 
     ep_xv_path = ASSETS_DIR / "endpoint-crossverify.json"
     ep_crossverify: dict[str, object] = {}
     if ep_xv_path.exists():
-        loaded_crossverify = json.loads(ep_xv_path.read_text())
+        loaded_crossverify = json.loads(ep_xv_path.read_text(encoding="utf-8"))
         if isinstance(loaded_crossverify, dict):
             ep_crossverify = loaded_crossverify
 
@@ -1285,7 +1291,7 @@ def load_aws_live_data():
             if not fpath.exists():
                 continue
             try:
-                data = json.loads(fpath.read_text())
+                data = json.loads(fpath.read_text(encoding="utf-8"))
                 if isinstance(data, list):
                     for item in data:
                         item["_profile"] = profile
@@ -1312,7 +1318,7 @@ def collect_scan_history():
     history = []
     for f in sorted(hist_dir.glob("scan-*.json")):
         try:
-            data = json.loads(f.read_text())
+            data = json.loads(f.read_text(encoding="utf-8"))
             history.append(data)
         except Exception:
             pass
@@ -1353,7 +1359,7 @@ def main():
     mobile_inv = ASSETS_DIR / "jamf-full-inventory.json"
     if mobile_inv.exists():
         try:
-            all_inv = json.loads(mobile_inv.read_text())
+            all_inv = json.loads(mobile_inv.read_text(encoding="utf-8"))
             jamf_mobiles = [item for item in all_inv if item.get("type") == "mobile"]
         except Exception:
             pass
@@ -1373,7 +1379,7 @@ def main():
     scan = {}
     scan_path = ROOT / "scan-report.json"
     if scan_path.exists():
-        scan = json.loads(scan_path.read_text())
+        scan = json.loads(scan_path.read_text(encoding="utf-8"))
         # Normalize: scanner outputs "results", dashboard expects "findings"
         if "results" in scan and "findings" not in scan:
             scan["findings"] = scan.pop("results")
@@ -1484,7 +1490,7 @@ def main():
 
     # HTML에 데이터 주입
     tmpl_path = ROOT / "claudesec-asset-dashboard.html"
-    html = tmpl_path.read_text()
+    html = tmpl_path.read_text(encoding="utf-8")
 
     json_str = json.dumps(dashboard_data, ensure_ascii=False, default=str)
     # Escape sequences that break out of <script> context (XSS prevention)


### PR DESCRIPTION
The last reader in the #471 / #484 class. Independent of #485 — different file, no overlap.

## The defect

All **16** `Path.read_text()` calls in `scripts/build-dashboard.py` passed no `encoding=`. `Path.read_text()` then uses `locale.getpreferredencoding(False)`, so what the script can parse depends on the runner's `LANG` — under a C/POSIX locale the default is ASCII, and any non-ASCII byte in a cache, inventory, git output or Prowler artifact raises `UnicodeDecodeError`.

In the OCSF findings reader that exception landed in `except Exception: pass`, silently dropping the file. That **under-reports failures** — the dashboard shows fewer FAILs than the scan found.

## Measured

Three real FAILs, one `0x80` spliced in:

```
BEFORE (no errors=)      FAILs reported: 0
AFTER  (errors=replace)  FAILs reported: 2
```

`2`, not `3`, because the byte was spliced into a **key name** and `raw_decode`'s resync has to skip that whole object. When it lands in a string **value** — a resource tag, owner or description, which is the realistic case — nothing is lost, as measured in #471 (50/50, delta 0). Either way, `0 -> 2` is the difference between a silent under-report and a near-complete one.

## Scope of the change

- All 16 reads: `read_text()` → `read_text(encoding="utf-8")`. This just declares the encoding the script already assumed.
- **Only** the two reads in the OCSF loop also get `errors="replace"`. For a cache or inventory, degrading to empty is correct behaviour; for a findings file it lowers the reported count. Same reasoning as #471/#484.

## Guard

`test_build_dashboard_units.py` gains `TestReadsDeclareTheirEncoding`. The detector returns **line numbers**, not the source, so a failure names the sites instead of dumping 100 KB into the assertion message (the first draft did exactly that):

```console
AssertionError: Lists differ: [69, 224, 229, 428, 729, 740, 758, 772, 1129,
1137, 1144, 1288, 1315, 1356, 1376, 1487] != []

AssertionError: 0 != 2 : both reads in the OCSF loop must use
f.read_text(encoding="utf-8", errors="replace") (the first parse and the
NDJSON re-read); found 0
```

Both fire against the pre-change script (`2 failed, 22 passed`) and pass after (`24 passed`), plus a non-vacuity test asserting the detector names the line of a shape it forbids.

Source-level on purpose: the 16 sites span cache, git, inventory and template paths a unit test cannot all reach, so the cheap invariant is "no read declares no encoding". `scripts/` is in the `scanner` diff bucket, so `scanner-unit-tests` runs on any change to this file.

## Evidence

```console
$ CLAUDESEC_DASHBOARD_OFFLINE=1 python3 -m pytest scanner/ -q
2479 passed, 11 skipped, 1 warning in 21.57s

$ ruff check .          # repo ruff.toml, as CI runs it
All checks passed!
```

Coverage is unaffected — `--cov=scanner/lib` does not include `scripts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)