### PR TITLE
fix(hooks): the pre-commit secret gate greped the wrong bytes [HUMAN REVIEW REQUIRED]

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -455,6 +455,8 @@ jobs:
         run: bash scanner/tests/test_prowler_provider_build_parity.sh
       - name: Run bash unit tests (security-lint PreToolUse hook)
         run: bash scanner/tests/test_hook_security_lint.sh
+      - name: Run bash unit tests (secret/pii pre-commit hooks, staged-blob contract)
+        run: bash scanner/tests/test_hook_staged_scan.sh
       - name: Run bash unit tests (cloud/aws checks)
         run: bash scanner/tests/test_check_cloud_aws.sh
       - name: Run bash unit tests (infra/kubernetes checks)

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -59,10 +59,15 @@ Two consequences of scanning the staged blob rather than the path:
 In staged mode both hooks **fail closed**: if the object store cannot produce a
 staged blob, if `$TMPDIR` is unwritable, or if the hook is somehow run outside a
 repository, they block the commit and say so rather than passing something they
-could not read. An absent object is never lazily fetched over the network
-(`GIT_NO_LAZY_FETCH=1`), so behaviour is the same offline and a hanging remote
-cannot hang your commit; in a partial clone, run `git fetch` to hydrate the
-object.
+could not read.
+
+Objects are probed locally first, so the common path — everything you just
+staged — never touches the network. Only an object that is genuinely absent
+(partial clone, sparse checkout) is fetched from the promisor remote, bounded by
+`timeout` where the system provides it. If that fetch fails, the hook blocks and
+prints the object id: note that **`git fetch` does not hydrate a filtered blob**
+— the clone filter still applies — so the way to materialise it is
+`git cat-file -e <oid>`, or `git commit --no-verify` if you accept the risk.
 
 ## Creating Custom Hooks
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -11,6 +11,7 @@ description: Security hooks for Claude Code integration
 |------|---------|---------|
 | `security-lint.sh` | PreToolUse (Write/Edit) | Catches hardcoded secrets, personal absolute paths, injection patterns, insecure code |
 | `secret-check.sh` | Pre-commit | Prevents committing files containing secrets |
+| `pii-check.sh` | Pre-commit | Prevents committing personal paths, account IDs, real emails, internal IPs |
 
 ## Installation
 
@@ -39,6 +40,14 @@ Add to your project's `.claude/settings.json`:
 cp secret-check.sh .git/hooks/pre-commit
 chmod +x .git/hooks/pre-commit
 ```
+
+With no arguments (the shape above), `secret-check.sh` and `pii-check.sh` scan
+the **staged blob** of each staged file — what `git commit` is about to write —
+not the working-tree copy. That distinction is load-bearing in both directions:
+a secret staged and then edited out of the working tree still blocks the commit,
+and a secret that exists only in an unstaged edit does not. Given file arguments
+instead, both scan those paths as-is, which is what CI and the `pre-commit`
+framework want (they hand the hook a clean tree).
 
 ## Creating Custom Hooks
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -49,6 +49,21 @@ and a secret that exists only in an unstaged edit does not. Given file arguments
 instead, both scan those paths as-is, which is what CI and the `pre-commit`
 framework want (they hand the hook a clean tree).
 
+Two consequences of scanning the staged blob rather than the path:
+
+- A staged **symlink** is scanned as its own content, which is the *target path
+  text* — not the target's bytes. That is deliberate: committing a link does not
+  commit what it points at.
+- A staged **submodule** (gitlink) has no blob and is skipped.
+
+In staged mode both hooks **fail closed**: if the object store cannot produce a
+staged blob, if `$TMPDIR` is unwritable, or if the hook is somehow run outside a
+repository, they block the commit and say so rather than passing something they
+could not read. An absent object is never lazily fetched over the network
+(`GIT_NO_LAZY_FETCH=1`), so behaviour is the same offline and a hanging remote
+cannot hang your commit; in a partial clone, run `git fetch` to hydrate the
+object.
+
 ## Creating Custom Hooks
 
 PreToolUse hooks are commands that:

--- a/hooks/pii-check.sh
+++ b/hooks/pii-check.sh
@@ -14,6 +14,13 @@ NC='\033[0m'
 SKIP_PATTERNS="(\.lock$|\.svg$|\.png$|\.jpg$|\.woff$|/node_modules/|/\.git/)"
 FOUND=0
 
+# True when the PATH is one we never scan. Split out of scan_file so staged mode
+# can decide BEFORE extracting a blob — otherwise a skipped 200MB .png is copied
+# into $TMPDIR only to be discarded.
+should_skip() {
+  echo "$1" | grep -qE "$SKIP_PATTERNS"
+}
+
 scan_file() {
   local file="$1"
   # Content to grep. Defaults to the path itself (argument / CI / pre-commit-
@@ -21,7 +28,7 @@ scan_file() {
   # passes the extracted blob.
   local content="${2:-$1}"
 
-  if echo "$file" | grep -qE "$SKIP_PATTERNS"; then
+  if should_skip "$file"; then
     return
   fi
 
@@ -90,9 +97,15 @@ else
   # (160000) or absent/unmerged entry (000000) has no blob and is skipped by mode.
   # Process substitution keeps FOUND in the parent shell.
   #
-  # Fails CLOSED on a missing temp file or an unreadable blob. This script has no
-  # `set -e`, so an unwritable TMPDIR previously turned the whole gate off while
-  # still exiting 0 — the failure had to become explicit rather than inherited.
+  # Fails CLOSED on no repository, a missing temp file, or an unreadable blob.
+  # This script has no `set -e`, so an unwritable TMPDIR previously turned the
+  # whole gate off while still exiting 0 — the failure had to become explicit
+  # rather than inherited. The mktemp guard is defence in depth: with `$_blob`
+  # empty the redirect fails and the unreadable-blob branch blocks too.
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo -e "${RED}[PII]${NC} not inside a git repository — refusing to pass an unscanned commit" >&2
+    exit 1
+  fi
   _blob=$(mktemp "${TMPDIR:-/tmp}/claudesec-pii-check.XXXXXX") || {
     echo -e "${RED}[PII]${NC} cannot create a temp file — refusing to pass an unscanned commit" >&2
     exit 1
@@ -105,11 +118,25 @@ else
     case "$_status" in
       R* | C*) IFS= read -r -d '' file || break ;;
     esac
+    # A gitlink (submodule) and an absent/unmerged entry have no blob. Skipping
+    # them BY MODE is load-bearing: without it every submodule commit hits the
+    # unreadable-blob branch below and is FALSELY BLOCKED.
     case "$_dstmode" in
       160000 | 000000) continue ;;
     esac
-    if ! git cat-file blob "$_dstsha" >"$_blob" 2>/dev/null; then
+    # Skip decided on the PATH before extracting, so a skipped large binary is
+    # never copied into $TMPDIR at all.
+    if should_skip "$file"; then
+      continue
+    fi
+    # GIT_NO_LAZY_FETCH: in a partial clone an absent blob would otherwise make
+    # `cat-file` fetch over the NETWORK, with no timeout, from inside a
+    # pre-commit hook. Fail fast and block instead (offline-deterministic, per
+    # the repo's own network-guard rule).
+    if ! GIT_NO_LAZY_FETCH=1 git cat-file blob "$_dstsha" >"$_blob" 2>/dev/null; then
       echo -e "${RED}[PII]${NC} cannot read the staged blob for: $file (not scanned)"
+      echo "  The object is missing locally (partial clone, or a damaged object store)."
+      echo "  Run 'git fetch' to hydrate it, or 'git commit --no-verify' if you accept the risk."
       FOUND=$((FOUND + 1))
       continue
     fi

--- a/hooks/pii-check.sh
+++ b/hooks/pii-check.sh
@@ -16,36 +16,40 @@ FOUND=0
 
 scan_file() {
   local file="$1"
+  # Content to grep. Defaults to the path itself (argument / CI / pre-commit-
+  # framework mode, where the working tree IS what gets checked); staged mode
+  # passes the extracted blob.
+  local content="${2:-$1}"
 
   if echo "$file" | grep -qE "$SKIP_PATTERNS"; then
     return
   fi
 
   # Hardcoded macOS/Linux user paths (exposes usernames)
-  if grep -qE "/Users/[a-zA-Z][a-zA-Z0-9_-]+/" "$file" 2>/dev/null; then
+  if grep -qE "/Users/[a-zA-Z][a-zA-Z0-9_-]+/" "$content" 2>/dev/null; then
     echo -e "${RED}[PII]${NC} Hardcoded user path in: $file"
-    grep -nE "/Users/[a-zA-Z][a-zA-Z0-9_-]+/" "$file" 2>/dev/null | head -3
+    grep -nE "/Users/[a-zA-Z][a-zA-Z0-9_-]+/" "$content" 2>/dev/null | head -3
     FOUND=$((FOUND + 1))
   fi
 
   # AWS Account IDs (12-digit in context)
-  if grep -qE "(account|aws)[_\"':-].*[0-9]{12}" "$file" 2>/dev/null; then
+  if grep -qE "(account|aws)[_\"':-].*[0-9]{12}" "$content" 2>/dev/null; then
     echo -e "${RED}[PII]${NC} Possible AWS account ID in: $file"
     FOUND=$((FOUND + 1))
   fi
 
   # Google Sheet / Notion IDs hardcoded (not placeholders)
-  if grep -qE "(SHEET_ID|NOTION_DB_ID|NOTION_TOKEN)\s*=\s*['\"]?[A-Za-z0-9_-]{25,}" "$file" 2>/dev/null; then
+  if grep -qE "(SHEET_ID|NOTION_DB_ID|NOTION_TOKEN)\s*=\s*['\"]?[A-Za-z0-9_-]{25,}" "$content" 2>/dev/null; then
     echo -e "${RED}[PII]${NC} Possible service ID hardcoded in: $file"
     FOUND=$((FOUND + 1))
   fi
 
   # Internal email addresses (not example.com or placeholder)
-  if grep -qE "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(io|co|com|net|org)" "$file" 2>/dev/null; then
+  if grep -qE "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(io|co|com|net|org)" "$content" 2>/dev/null; then
     # Exclude common safe patterns
-    if ! grep -qE "@(example\.com|anthropic\.com|users\.noreply\.github\.com|your-domain\.com)" "$file" 2>/dev/null; then
+    if ! grep -qE "@(example\.com|anthropic\.com|users\.noreply\.github\.com|your-domain\.com)" "$content" 2>/dev/null; then
       local real_emails
-      real_emails=$(grep -oE "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(io|co|com|net|org)" "$file" 2>/dev/null | grep -vE "@(example|anthropic|noreply|your-domain|openssh|libssh|openbsd)" | head -3)
+      real_emails=$(grep -oE "[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.(io|co|com|net|org)" "$content" 2>/dev/null | grep -vE "@(example|anthropic|noreply|your-domain|openssh|libssh|openbsd)" | head -3)
       if [ -n "$real_emails" ]; then
         echo -e "${YELLOW}[PII]${NC} Possible real email in: $file"
         echo "  $real_emails"
@@ -55,7 +59,7 @@ scan_file() {
   fi
 
   # Internal IP addresses (private ranges with specific octets, not documentation)
-  if grep -qE "10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}" "$file" 2>/dev/null; then
+  if grep -qE "10\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}" "$content" 2>/dev/null; then
     if echo "$file" | grep -qvE "(\.md|\.txt)$"; then
       echo -e "${YELLOW}[PII]${NC} Internal IP address in: $file"
       FOUND=$((FOUND + 1))
@@ -69,10 +73,20 @@ if [ $# -gt 0 ]; then
     [ -f "$file" ] && scan_file "$file"
   done
 else
-  # Process substitution to keep FOUND in parent shell
+  # Staged mode. Grep the STAGED BLOB, not the path: the working-tree copy is not
+  # what `git commit` is about to write. Reading the path let PII that was staged
+  # and then edited out of the working tree commit with the hook exiting 0, and
+  # blocked a commit whose staged content was clean when the PII existed only in
+  # an unstaged edit. Wrong in both directions.
+  #
+  # --diff-filter=ACMR drops deletions, which have no blob to read.
+  # Process substitution keeps FOUND in the parent shell.
+  _blob=$(mktemp "${TMPDIR:-/tmp}/claudesec-pii-check.XXXXXX")
+  trap 'rm -f "$_blob"' EXIT
   while IFS= read -r -d '' file; do
-    [ -f "$file" ] && scan_file "$file"
-  done < <(git diff --cached --name-only -z 2>/dev/null)
+    git show ":$file" >"$_blob" 2>/dev/null || continue
+    scan_file "$file" "$_blob"
+  done < <(git diff --cached --name-only --diff-filter=ACMR -z 2>/dev/null)
 fi
 
 if [ $FOUND -gt 0 ]; then

--- a/hooks/pii-check.sh
+++ b/hooks/pii-check.sh
@@ -79,14 +79,42 @@ else
   # blocked a commit whose staged content was clean when the PII existed only in
   # an unstaged edit. Wrong in both directions.
   #
-  # --diff-filter=ACMR drops deletions, which have no blob to read.
+  # The blob is addressed by OID, from `--raw`, and NOT by a `:<path>` pathspec —
+  # `:<path>` is parsed as `:<stage>:<path>` for a path like `0:notes.txt`, which
+  # either skips the file or scans an unrelated `notes.txt` instead. `T` (type
+  # change) must stay in the set, so the filter EXCLUDES deletions
+  # (`--diff-filter=d`, lowercase) rather than listing `ACMR`. See the long
+  # comment in secret-check.sh for the three fail-opens this shape closes.
+  #
+  # Renames/copies carry TWO paths; the second is the destination. A gitlink
+  # (160000) or absent/unmerged entry (000000) has no blob and is skipped by mode.
   # Process substitution keeps FOUND in the parent shell.
-  _blob=$(mktemp "${TMPDIR:-/tmp}/claudesec-pii-check.XXXXXX")
+  #
+  # Fails CLOSED on a missing temp file or an unreadable blob. This script has no
+  # `set -e`, so an unwritable TMPDIR previously turned the whole gate off while
+  # still exiting 0 — the failure had to become explicit rather than inherited.
+  _blob=$(mktemp "${TMPDIR:-/tmp}/claudesec-pii-check.XXXXXX") || {
+    echo -e "${RED}[PII]${NC} cannot create a temp file — refusing to pass an unscanned commit" >&2
+    exit 1
+  }
   trap 'rm -f "$_blob"' EXIT
-  while IFS= read -r -d '' file; do
-    git show ":$file" >"$_blob" 2>/dev/null || continue
+  while IFS= read -r -d '' _meta; do
+    IFS= read -r -d '' file || break
+    # :<srcmode> <dstmode> <srcsha> <dstsha> <status>
+    read -r _ _dstmode _ _dstsha _status <<<"${_meta#:}"
+    case "$_status" in
+      R* | C*) IFS= read -r -d '' file || break ;;
+    esac
+    case "$_dstmode" in
+      160000 | 000000) continue ;;
+    esac
+    if ! git cat-file blob "$_dstsha" >"$_blob" 2>/dev/null; then
+      echo -e "${RED}[PII]${NC} cannot read the staged blob for: $file (not scanned)"
+      FOUND=$((FOUND + 1))
+      continue
+    fi
     scan_file "$file" "$_blob"
-  done < <(git diff --cached --name-only --diff-filter=ACMR -z 2>/dev/null)
+  done < <(git diff --cached --raw -z --no-abbrev --diff-filter=d 2>/dev/null)
 fi
 
 if [ $FOUND -gt 0 ]; then

--- a/hooks/pii-check.sh
+++ b/hooks/pii-check.sh
@@ -30,8 +30,10 @@ FOUND=0
 # git 2.36, so on those the absent-object read is unbounded, exactly as it was
 # before this guard. The claim is "the common path never dials out", not "nothing
 # ever can".
-# Return codes are load-bearing: 0 read it, 1 absent-and-unfetchable,
-# 2 PRESENT but unreadable. The two failures need different advice — measured on
+# Return contract — the codes are load-bearing and each maps to DIFFERENT advice:
+#   0  READ_OK           blob is in "$_blob"
+#   1  READ_ABSENT       not local, and could not be fetched
+#   2  READ_UNDECODABLE  present locally, but git cannot output it The two failures need different advice — measured on
 # a loose object overwritten with non-zlib bytes, `cat-file -e` returns 0 while
 # `cat-file blob` returns 128 with 0 bytes written, so telling that user to run
 # `cat-file -e` (the advice for the absent case) sends them to a command that
@@ -43,13 +45,24 @@ read_staged_blob() {
     GIT_NO_LAZY_FETCH=1 git cat-file blob "$oid" >"$_blob" 2>/dev/null || return 2
     return 0
   fi
+  local rc=0
   if command -v timeout >/dev/null 2>&1; then
-    timeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+    timeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null || rc=$?
   elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+    gtimeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null || rc=$?
   else
-    git cat-file blob "$oid" >"$_blob" 2>/dev/null
+    git cat-file blob "$oid" >"$_blob" 2>/dev/null || rc=$?
   fi
+  [ "$rc" -eq 0 ] && return 0
+  # The fetch may have LANDED and the decode still failed. Re-probe: if the
+  # object is local now, this is a decode problem and deserves the damaged-store
+  # advice, not "missing locally, run cat-file -e" — which would succeed and fix
+  # nothing. Inspection-only: no fixture serves a corrupt object over a promisor,
+  # so this branch is UNPINNED.
+  if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
+    return 2
+  fi
+  return 1
 }
 
 # True when the PATH is one we never scan. Split out of scan_file so staged mode

--- a/hooks/pii-check.sh
+++ b/hooks/pii-check.sh
@@ -30,11 +30,18 @@ FOUND=0
 # git 2.36, so on those the absent-object read is unbounded, exactly as it was
 # before this guard. The claim is "the common path never dials out", not "nothing
 # ever can".
+# Return codes are load-bearing: 0 read it, 1 absent-and-unfetchable,
+# 2 PRESENT but unreadable. The two failures need different advice — measured on
+# a loose object overwritten with non-zlib bytes, `cat-file -e` returns 0 while
+# `cat-file blob` returns 128 with 0 bytes written, so telling that user to run
+# `cat-file -e` (the advice for the absent case) sends them to a command that
+# succeeds and changes nothing. That is the same dead-end shape as the earlier
+# `git fetch` advice, one path over.
 read_staged_blob() {
   local oid="$1"
   if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
-    GIT_NO_LAZY_FETCH=1 git cat-file blob "$oid" >"$_blob" 2>/dev/null
-    return
+    GIT_NO_LAZY_FETCH=1 git cat-file blob "$oid" >"$_blob" 2>/dev/null || return 2
+    return 0
   fi
   if command -v timeout >/dev/null 2>&1; then
     timeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
@@ -160,7 +167,18 @@ else
     if should_skip "$file"; then
       continue
     fi
-    if ! read_staged_blob "$_dstsha"; then
+    # `|| _read_rc=$?` not a bare call: under `set -e` a function returning 2
+    # aborts the script before the message is printed (measured — secret-check
+    # exited 2 silently while pii-check, which has no `set -e`, was fine).
+    _read_rc=0
+    read_staged_blob "$_dstsha" || _read_rc=$?
+    if [ "$_read_rc" -eq 2 ]; then
+      echo -e "${RED}[PII]${NC} cannot read the staged blob for: $file (not scanned)"
+      echo "  The object EXISTS but could not be decoded — a damaged object store."
+      echo "  Run 'git fsck' to locate it (or 'git commit --no-verify' to accept the risk)."
+      FOUND=$((FOUND + 1))
+      continue
+    elif [ "$_read_rc" -ne 0 ]; then
       echo -e "${RED}[PII]${NC} cannot read the staged blob for: $file (not scanned)"
       echo "  The object is missing locally and could not be fetched."
       echo "  'git fetch' does NOT hydrate it — the clone filter still applies."

--- a/hooks/pii-check.sh
+++ b/hooks/pii-check.sh
@@ -33,12 +33,14 @@ FOUND=0
 # Return contract — the codes are load-bearing and each maps to DIFFERENT advice:
 #   0  READ_OK           blob is in "$_blob"
 #   1  READ_ABSENT       not local, and could not be fetched
-#   2  READ_UNDECODABLE  present locally, but git cannot output it The two failures need different advice — measured on
-# a loose object overwritten with non-zlib bytes, `cat-file -e` returns 0 while
-# `cat-file blob` returns 128 with 0 bytes written, so telling that user to run
-# `cat-file -e` (the advice for the absent case) sends them to a command that
-# succeeds and changes nothing. That is the same dead-end shape as the earlier
-# `git fetch` advice, one path over.
+#   2  READ_UNDECODABLE  present locally, but git cannot output it
+#
+# The two failures need DIFFERENT advice — measured on a loose object overwritten
+# with non-zlib bytes, `cat-file -e` returns 0 while `cat-file blob` returns 128
+# with 0 bytes written, so telling that user to run `cat-file -e` (the advice for
+# the absent case) sends them to a command that succeeds and changes nothing.
+# That is the same dead-end shape as the earlier `git fetch` advice, one path
+# over.
 read_staged_blob() {
   local oid="$1"
   if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
@@ -57,8 +59,9 @@ read_staged_blob() {
   # The fetch may have LANDED and the decode still failed. Re-probe: if the
   # object is local now, this is a decode problem and deserves the damaged-store
   # advice, not "missing locally, run cat-file -e" — which would succeed and fix
-  # nothing. Inspection-only: no fixture serves a corrupt object over a promisor,
-  # so this branch is UNPINNED.
+  # nothing. PINNED via a `--filter=tree:0` clone plus an absent TREE oid staged
+  # at mode 100644: the fetch lands the object and the read then fails on TYPE,
+  # which drives this branch with no corruption and no network.
   if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
     return 2
   fi

--- a/hooks/pii-check.sh
+++ b/hooks/pii-check.sh
@@ -14,6 +14,37 @@ NC='\033[0m'
 SKIP_PATTERNS="(\.lock$|\.svg$|\.png$|\.jpg$|\.woff$|/node_modules/|/\.git/)"
 FOUND=0
 
+# Write the staged blob for OID $1 into $_blob. Non-zero when it cannot.
+#
+# Two-step on purpose. `GIT_NO_LAZY_FETCH=1` alone was WRONG: in a partial clone
+# or a sparse checkout an out-of-cone blob is legitimately non-local with nothing
+# corrupted, and hard-refusing it FALSE-BLOCKS a clean commit — the "gate nobody
+# can get past" shape, whose only exit is `--no-verify`, i.e. the gate off.
+# Fetching unconditionally was also wrong: a promisor fetch has no timeout, so a
+# hanging remote hangs the commit.
+#
+# So: probe locally first, and only an object that is genuinely absent is allowed
+# to go to the promisor — bounded by `timeout` where that exists. The common path
+# (every object you just staged) is provably network-free. NOTE the honest limit:
+# macOS ships neither `timeout` nor `gtimeout`, and `GIT_NO_LAZY_FETCH` predates
+# git 2.36, so on those the absent-object read is unbounded, exactly as it was
+# before this guard. The claim is "the common path never dials out", not "nothing
+# ever can".
+read_staged_blob() {
+  local oid="$1"
+  if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
+    GIT_NO_LAZY_FETCH=1 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+    return
+  fi
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+  else
+    git cat-file blob "$oid" >"$_blob" 2>/dev/null
+  fi
+}
+
 # True when the PATH is one we never scan. Split out of scan_file so staged mode
 # can decide BEFORE extracting a blob — otherwise a skipped 200MB .png is copied
 # into $TMPDIR only to be discarded.
@@ -129,14 +160,11 @@ else
     if should_skip "$file"; then
       continue
     fi
-    # GIT_NO_LAZY_FETCH: in a partial clone an absent blob would otherwise make
-    # `cat-file` fetch over the NETWORK, with no timeout, from inside a
-    # pre-commit hook. Fail fast and block instead (offline-deterministic, per
-    # the repo's own network-guard rule).
-    if ! GIT_NO_LAZY_FETCH=1 git cat-file blob "$_dstsha" >"$_blob" 2>/dev/null; then
+    if ! read_staged_blob "$_dstsha"; then
       echo -e "${RED}[PII]${NC} cannot read the staged blob for: $file (not scanned)"
-      echo "  The object is missing locally (partial clone, or a damaged object store)."
-      echo "  Run 'git fetch' to hydrate it, or 'git commit --no-verify' if you accept the risk."
+      echo "  The object is missing locally and could not be fetched."
+      echo "  'git fetch' does NOT hydrate it — the clone filter still applies."
+      echo "  Run: git cat-file -e $_dstsha   (or 'git commit --no-verify' to accept the risk)"
       FOUND=$((FOUND + 1))
       continue
     fi

--- a/hooks/secret-check.sh
+++ b/hooks/secret-check.sh
@@ -30,11 +30,18 @@ FOUND=0
 # git 2.36, so on those the absent-object read is unbounded, exactly as it was
 # before this guard. The claim is "the common path never dials out", not "nothing
 # ever can".
+# Return codes are load-bearing: 0 read it, 1 absent-and-unfetchable,
+# 2 PRESENT but unreadable. The two failures need different advice — measured on
+# a loose object overwritten with non-zlib bytes, `cat-file -e` returns 0 while
+# `cat-file blob` returns 128 with 0 bytes written, so telling that user to run
+# `cat-file -e` (the advice for the absent case) sends them to a command that
+# succeeds and changes nothing. That is the same dead-end shape as the earlier
+# `git fetch` advice, one path over.
 read_staged_blob() {
   local oid="$1"
   if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
-    GIT_NO_LAZY_FETCH=1 git cat-file blob "$oid" >"$_blob" 2>/dev/null
-    return
+    GIT_NO_LAZY_FETCH=1 git cat-file blob "$oid" >"$_blob" 2>/dev/null || return 2
+    return 0
   fi
   if command -v timeout >/dev/null 2>&1; then
     timeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
@@ -155,7 +162,18 @@ else
     if should_skip "$file"; then
       continue
     fi
-    if ! read_staged_blob "$_dstsha"; then
+    # `|| _read_rc=$?` not a bare call: under `set -e` a function returning 2
+    # aborts the script before the message is printed (measured — secret-check
+    # exited 2 silently while pii-check, which has no `set -e`, was fine).
+    _read_rc=0
+    read_staged_blob "$_dstsha" || _read_rc=$?
+    if [ "$_read_rc" -eq 2 ]; then
+      echo -e "${RED}[SECRET]${NC} cannot read the staged blob for: $file (not scanned)"
+      echo "  The object EXISTS but could not be decoded — a damaged object store."
+      echo "  Run 'git fsck' to locate it (or 'git commit --no-verify' to accept the risk)."
+      FOUND=$((FOUND + 1))
+      continue
+    elif [ "$_read_rc" -ne 0 ]; then
       echo -e "${RED}[SECRET]${NC} cannot read the staged blob for: $file (not scanned)"
       echo "  The object is missing locally and could not be fetched."
       echo "  'git fetch' does NOT hydrate it — the clone filter still applies."

--- a/hooks/secret-check.sh
+++ b/hooks/secret-check.sh
@@ -63,14 +63,52 @@ else
   # only in an unstaged edit. Wrong in both directions, and the false-negative
   # direction is a secret in a commit (OWASP A07 / CWE-798).
   #
-  # --diff-filter=ACMR drops deletions, which have no blob to read.
-  # Process substitution keeps FOUND in the parent shell.
-  _blob=$(mktemp "${TMPDIR:-/tmp}/claudesec-secret-check.XXXXXX")
+  # The blob is addressed by OID, from `--raw`, and NOT by a `:<path>` pathspec.
+  # A first version used `git show ":$file"` with `--diff-filter=ACMR`, and
+  # adversarial review found that both halves of that opened NEW fail-open paths:
+  #
+  #   * `:<path>` is parsed as `:<stage>:<path>` when the path starts with a
+  #     digit 0-3 and a colon. A staged `0:notes.txt` was therefore either
+  #     SKIPPED (`fatal: path 'notes.txt' does not exist`) or, with an unrelated
+  #     `notes.txt` also staged, scanned as THAT FILE's content — the gate read
+  #     clean on a decoy. `git cat-file blob ":$f"` is identically affected, so
+  #     this is not a show-vs-cat-file choice; only an OID avoids the parse.
+  #   * `ACMR` omits `T`, a TYPE CHANGE. Replacing a symlinked config with a real
+  #     file carrying a secret was never scanned, and the exclusion bought
+  #     nothing — a `T` entry has a perfectly readable blob.
+  #
+  # `--diff-filter=d` (lowercase: EXCLUDE) drops only deletions, so `T` stays in.
+  # Renames and copies carry TWO paths; the second is the destination, which is
+  # the one entering the commit. A gitlink (160000) or an absent/unmerged entry
+  # (000000) has no blob and is skipped by mode, explicitly rather than by a
+  # failed read. Process substitution keeps FOUND in the parent shell.
+  #
+  # Every remaining failure FAILS CLOSED: no temp file and no readable blob both
+  # mean "this commit was not scanned", which for a secret gate must block, not
+  # pass. An unwritable TMPDIR silently turning the gate off was the third
+  # fail-open found in review.
+  _blob=$(mktemp "${TMPDIR:-/tmp}/claudesec-secret-check.XXXXXX") || {
+    echo -e "${RED}[SECRET]${NC} cannot create a temp file — refusing to pass an unscanned commit" >&2
+    exit 1
+  }
   trap 'rm -f "$_blob"' EXIT
-  while IFS= read -r -d '' file; do
-    git show ":$file" >"$_blob" 2>/dev/null || continue
+  while IFS= read -r -d '' _meta; do
+    IFS= read -r -d '' file || break
+    # :<srcmode> <dstmode> <srcsha> <dstsha> <status>
+    read -r _ _dstmode _ _dstsha _status <<<"${_meta#:}"
+    case "$_status" in
+      R* | C*) IFS= read -r -d '' file || break ;;
+    esac
+    case "$_dstmode" in
+      160000 | 000000) continue ;;
+    esac
+    if ! git cat-file blob "$_dstsha" >"$_blob" 2>/dev/null; then
+      echo -e "${RED}[SECRET]${NC} cannot read the staged blob for: $file (not scanned)"
+      FOUND=$((FOUND + 1))
+      continue
+    fi
     scan_file "$file" "$_blob"
-  done < <(git diff --cached --name-only --diff-filter=ACMR -z 2>/dev/null)
+  done < <(git diff --cached --raw -z --no-abbrev --diff-filter=d 2>/dev/null)
 fi
 
 if [ $FOUND -gt 0 ]; then

--- a/hooks/secret-check.sh
+++ b/hooks/secret-check.sh
@@ -16,6 +16,9 @@ FOUND=0
 
 scan_file() {
   local file="$1"
+  # Content to grep. Defaults to the path itself (argument / CI mode, where the
+  # working tree IS what gets checked); staged mode passes the extracted blob.
+  local content="${2:-$1}"
 
   # Skip binary and irrelevant files
   if echo "$file" | grep -qE "$SKIP_PATTERNS"; then
@@ -23,25 +26,25 @@ scan_file() {
   fi
 
   # AWS keys
-  if grep -qE "(AKIA|ASIA)[A-Z0-9]{16}" "$file" 2>/dev/null; then
+  if grep -qE "(AKIA|ASIA)[A-Z0-9]{16}" "$content" 2>/dev/null; then
     echo -e "${RED}[SECRET]${NC} AWS key in: $file"
     FOUND=$((FOUND + 1))
   fi
 
   # Generic secrets in env-like assignments
-  if grep -qE "^[A-Z_]*(SECRET|TOKEN|PASSWORD|API_KEY|PRIVATE_KEY)[A-Z_]*\s*=\s*['\"]?[A-Za-z0-9/+=]{8,}" "$file" 2>/dev/null; then
+  if grep -qE "^[A-Z_]*(SECRET|TOKEN|PASSWORD|API_KEY|PRIVATE_KEY)[A-Z_]*\s*=\s*['\"]?[A-Za-z0-9/+=]{8,}" "$content" 2>/dev/null; then
     echo -e "${RED}[SECRET]${NC} Possible secret assignment in: $file"
     FOUND=$((FOUND + 1))
   fi
 
   # Private keys
-  if grep -q "BEGIN.*PRIVATE KEY" "$file" 2>/dev/null; then
+  if grep -q "BEGIN.*PRIVATE KEY" "$content" 2>/dev/null; then
     echo -e "${RED}[SECRET]${NC} Private key in: $file"
     FOUND=$((FOUND + 1))
   fi
 
   # Connection strings with passwords
-  if grep -qE "(mongodb|postgres|mysql|redis)://[^:]+:[^@]+@" "$file" 2>/dev/null; then
+  if grep -qE "(mongodb|postgres|mysql|redis)://[^:]+:[^@]+@" "$content" 2>/dev/null; then
     echo -e "${RED}[SECRET]${NC} Connection string with credentials in: $file"
     FOUND=$((FOUND + 1))
   fi
@@ -53,10 +56,21 @@ if [ $# -gt 0 ]; then
     [ -f "$file" ] && scan_file "$file"
   done
 else
-  # Scan staged files (process substitution to keep FOUND in parent shell)
+  # Staged mode. Grep the STAGED BLOB, not the path: the working-tree copy is not
+  # what `git commit` is about to write. Reading the path let a secret that was
+  # staged and then edited out of the working tree commit with the hook exiting 0,
+  # and blocked a commit whose staged content was clean when the secret existed
+  # only in an unstaged edit. Wrong in both directions, and the false-negative
+  # direction is a secret in a commit (OWASP A07 / CWE-798).
+  #
+  # --diff-filter=ACMR drops deletions, which have no blob to read.
+  # Process substitution keeps FOUND in the parent shell.
+  _blob=$(mktemp "${TMPDIR:-/tmp}/claudesec-secret-check.XXXXXX")
+  trap 'rm -f "$_blob"' EXIT
   while IFS= read -r -d '' file; do
-    [ -f "$file" ] && scan_file "$file"
-  done < <(git diff --cached --name-only -z 2>/dev/null)
+    git show ":$file" >"$_blob" 2>/dev/null || continue
+    scan_file "$file" "$_blob"
+  done < <(git diff --cached --name-only --diff-filter=ACMR -z 2>/dev/null)
 fi
 
 if [ $FOUND -gt 0 ]; then

--- a/hooks/secret-check.sh
+++ b/hooks/secret-check.sh
@@ -14,6 +14,13 @@ SKIP_PATTERNS="(\.lock$|\.svg$|\.png$|\.jpg$|\.woff$|/node_modules/|/\.git/)"
 
 FOUND=0
 
+# True when the PATH is one we never scan. Split out of scan_file so staged mode
+# can decide BEFORE extracting a blob — otherwise a skipped 200MB .png is copied
+# into $TMPDIR only to be discarded.
+should_skip() {
+  echo "$1" | grep -qE "$SKIP_PATTERNS"
+}
+
 scan_file() {
   local file="$1"
   # Content to grep. Defaults to the path itself (argument / CI mode, where the
@@ -21,7 +28,7 @@ scan_file() {
   local content="${2:-$1}"
 
   # Skip binary and irrelevant files
-  if echo "$file" | grep -qE "$SKIP_PATTERNS"; then
+  if should_skip "$file"; then
     return
   fi
 
@@ -83,10 +90,17 @@ else
   # (000000) has no blob and is skipped by mode, explicitly rather than by a
   # failed read. Process substitution keeps FOUND in the parent shell.
   #
-  # Every remaining failure FAILS CLOSED: no temp file and no readable blob both
-  # mean "this commit was not scanned", which for a secret gate must block, not
-  # pass. An unwritable TMPDIR silently turning the gate off was the third
-  # fail-open found in review.
+  # Every remaining failure FAILS CLOSED: no repository, no temp file and no
+  # readable blob all mean "this commit was not scanned", which for a secret gate
+  # must block, not pass. An unwritable TMPDIR silently turning the gate off was
+  # the third fail-open found in review. NOTE: the mktemp guard below is defence
+  # in depth, not the only thing standing there — with `$_blob` empty the
+  # redirect fails and the unreadable-blob branch also blocks. It is kept for the
+  # clearer message.
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo -e "${RED}[SECRET]${NC} not inside a git repository — refusing to pass an unscanned commit" >&2
+    exit 1
+  fi
   _blob=$(mktemp "${TMPDIR:-/tmp}/claudesec-secret-check.XXXXXX") || {
     echo -e "${RED}[SECRET]${NC} cannot create a temp file — refusing to pass an unscanned commit" >&2
     exit 1
@@ -99,11 +113,26 @@ else
     case "$_status" in
       R* | C*) IFS= read -r -d '' file || break ;;
     esac
+    # A gitlink (submodule) and an absent/unmerged entry have no blob. Skipping
+    # them BY MODE is load-bearing: without it every submodule commit hits the
+    # unreadable-blob branch below and is FALSELY BLOCKED.
     case "$_dstmode" in
       160000 | 000000) continue ;;
     esac
-    if ! git cat-file blob "$_dstsha" >"$_blob" 2>/dev/null; then
+    # Skip decided on the PATH before extracting, so a skipped large binary is
+    # never copied into $TMPDIR at all.
+    if should_skip "$file"; then
+      continue
+    fi
+    # GIT_NO_LAZY_FETCH: in a partial clone an absent blob would otherwise make
+    # `cat-file` fetch over the NETWORK, with no timeout, from inside a
+    # pre-commit hook — a hanging remote would hang the commit, and the repo's
+    # own coding-style rule says network paths must be guarded so behaviour is
+    # offline-deterministic. Fail fast and block instead.
+    if ! GIT_NO_LAZY_FETCH=1 git cat-file blob "$_dstsha" >"$_blob" 2>/dev/null; then
       echo -e "${RED}[SECRET]${NC} cannot read the staged blob for: $file (not scanned)"
+      echo "  The object is missing locally (partial clone, or a damaged object store)."
+      echo "  Run 'git fetch' to hydrate it, or 'git commit --no-verify' if you accept the risk."
       FOUND=$((FOUND + 1))
       continue
     fi

--- a/hooks/secret-check.sh
+++ b/hooks/secret-check.sh
@@ -30,8 +30,10 @@ FOUND=0
 # git 2.36, so on those the absent-object read is unbounded, exactly as it was
 # before this guard. The claim is "the common path never dials out", not "nothing
 # ever can".
-# Return codes are load-bearing: 0 read it, 1 absent-and-unfetchable,
-# 2 PRESENT but unreadable. The two failures need different advice — measured on
+# Return contract — the codes are load-bearing and each maps to DIFFERENT advice:
+#   0  READ_OK           blob is in "$_blob"
+#   1  READ_ABSENT       not local, and could not be fetched
+#   2  READ_UNDECODABLE  present locally, but git cannot output it The two failures need different advice — measured on
 # a loose object overwritten with non-zlib bytes, `cat-file -e` returns 0 while
 # `cat-file blob` returns 128 with 0 bytes written, so telling that user to run
 # `cat-file -e` (the advice for the absent case) sends them to a command that
@@ -43,13 +45,24 @@ read_staged_blob() {
     GIT_NO_LAZY_FETCH=1 git cat-file blob "$oid" >"$_blob" 2>/dev/null || return 2
     return 0
   fi
+  local rc=0
   if command -v timeout >/dev/null 2>&1; then
-    timeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+    timeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null || rc=$?
   elif command -v gtimeout >/dev/null 2>&1; then
-    gtimeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+    gtimeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null || rc=$?
   else
-    git cat-file blob "$oid" >"$_blob" 2>/dev/null
+    git cat-file blob "$oid" >"$_blob" 2>/dev/null || rc=$?
   fi
+  [ "$rc" -eq 0 ] && return 0
+  # The fetch may have LANDED and the decode still failed. Re-probe: if the
+  # object is local now, this is a decode problem and deserves the damaged-store
+  # advice, not "missing locally, run cat-file -e" — which would succeed and fix
+  # nothing. Inspection-only: no fixture serves a corrupt object over a promisor,
+  # so this branch is UNPINNED.
+  if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
+    return 2
+  fi
+  return 1
 }
 
 # True when the PATH is one we never scan. Split out of scan_file so staged mode

--- a/hooks/secret-check.sh
+++ b/hooks/secret-check.sh
@@ -33,12 +33,14 @@ FOUND=0
 # Return contract — the codes are load-bearing and each maps to DIFFERENT advice:
 #   0  READ_OK           blob is in "$_blob"
 #   1  READ_ABSENT       not local, and could not be fetched
-#   2  READ_UNDECODABLE  present locally, but git cannot output it The two failures need different advice — measured on
-# a loose object overwritten with non-zlib bytes, `cat-file -e` returns 0 while
-# `cat-file blob` returns 128 with 0 bytes written, so telling that user to run
-# `cat-file -e` (the advice for the absent case) sends them to a command that
-# succeeds and changes nothing. That is the same dead-end shape as the earlier
-# `git fetch` advice, one path over.
+#   2  READ_UNDECODABLE  present locally, but git cannot output it
+#
+# The two failures need DIFFERENT advice — measured on a loose object overwritten
+# with non-zlib bytes, `cat-file -e` returns 0 while `cat-file blob` returns 128
+# with 0 bytes written, so telling that user to run `cat-file -e` (the advice for
+# the absent case) sends them to a command that succeeds and changes nothing.
+# That is the same dead-end shape as the earlier `git fetch` advice, one path
+# over.
 read_staged_blob() {
   local oid="$1"
   if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
@@ -57,8 +59,9 @@ read_staged_blob() {
   # The fetch may have LANDED and the decode still failed. Re-probe: if the
   # object is local now, this is a decode problem and deserves the damaged-store
   # advice, not "missing locally, run cat-file -e" — which would succeed and fix
-  # nothing. Inspection-only: no fixture serves a corrupt object over a promisor,
-  # so this branch is UNPINNED.
+  # nothing. PINNED via a `--filter=tree:0` clone plus an absent TREE oid staged
+  # at mode 100644: the fetch lands the object and the read then fails on TYPE,
+  # which drives this branch with no corruption and no network.
   if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
     return 2
   fi

--- a/hooks/secret-check.sh
+++ b/hooks/secret-check.sh
@@ -14,6 +14,37 @@ SKIP_PATTERNS="(\.lock$|\.svg$|\.png$|\.jpg$|\.woff$|/node_modules/|/\.git/)"
 
 FOUND=0
 
+# Write the staged blob for OID $1 into $_blob. Non-zero when it cannot.
+#
+# Two-step on purpose. `GIT_NO_LAZY_FETCH=1` alone was WRONG: in a partial clone
+# or a sparse checkout an out-of-cone blob is legitimately non-local with nothing
+# corrupted, and hard-refusing it FALSE-BLOCKS a clean commit — the "gate nobody
+# can get past" shape, whose only exit is `--no-verify`, i.e. the gate off.
+# Fetching unconditionally was also wrong: a promisor fetch has no timeout, so a
+# hanging remote hangs the commit.
+#
+# So: probe locally first, and only an object that is genuinely absent is allowed
+# to go to the promisor — bounded by `timeout` where that exists. The common path
+# (every object you just staged) is provably network-free. NOTE the honest limit:
+# macOS ships neither `timeout` nor `gtimeout`, and `GIT_NO_LAZY_FETCH` predates
+# git 2.36, so on those the absent-object read is unbounded, exactly as it was
+# before this guard. The claim is "the common path never dials out", not "nothing
+# ever can".
+read_staged_blob() {
+  local oid="$1"
+  if GIT_NO_LAZY_FETCH=1 git cat-file -e "$oid" 2>/dev/null; then
+    GIT_NO_LAZY_FETCH=1 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+    return
+  fi
+  if command -v timeout >/dev/null 2>&1; then
+    timeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout 30 git cat-file blob "$oid" >"$_blob" 2>/dev/null
+  else
+    git cat-file blob "$oid" >"$_blob" 2>/dev/null
+  fi
+}
+
 # True when the PATH is one we never scan. Split out of scan_file so staged mode
 # can decide BEFORE extracting a blob — otherwise a skipped 200MB .png is copied
 # into $TMPDIR only to be discarded.
@@ -124,15 +155,11 @@ else
     if should_skip "$file"; then
       continue
     fi
-    # GIT_NO_LAZY_FETCH: in a partial clone an absent blob would otherwise make
-    # `cat-file` fetch over the NETWORK, with no timeout, from inside a
-    # pre-commit hook — a hanging remote would hang the commit, and the repo's
-    # own coding-style rule says network paths must be guarded so behaviour is
-    # offline-deterministic. Fail fast and block instead.
-    if ! GIT_NO_LAZY_FETCH=1 git cat-file blob "$_dstsha" >"$_blob" 2>/dev/null; then
+    if ! read_staged_blob "$_dstsha"; then
       echo -e "${RED}[SECRET]${NC} cannot read the staged blob for: $file (not scanned)"
-      echo "  The object is missing locally (partial clone, or a damaged object store)."
-      echo "  Run 'git fetch' to hydrate it, or 'git commit --no-verify' if you accept the risk."
+      echo "  The object is missing locally and could not be fetched."
+      echo "  'git fetch' does NOT hydrate it — the clone filter still applies."
+      echo "  Run: git cat-file -e $_dstsha   (or 'git commit --no-verify' to accept the risk)"
       FOUND=$((FOUND + 1))
       continue
     fi

--- a/scanner/tests/test_hook_staged_scan.sh
+++ b/scanner/tests/test_hook_staged_scan.sh
@@ -265,6 +265,120 @@ run_staged_outside_repo() {
   printf '%s' "$rc"
 }
 
+# PARTIAL CLONE (`--filter=blob:none`), the case that makes the local-probe /
+# bounded-fetch split load-bearing. A staged OID whose blob was never fetched is
+# legitimately non-local with NOTHING corrupted, so:
+#   - remote reachable   -> the hook must hydrate it and NOT block a clean commit
+#   - remote unreachable -> it must fail closed
+# Review found that refusing unconditionally (`GIT_NO_LAZY_FETCH=1` on the read
+# itself) false-blocked the reachable case, which is the standard large-monorepo
+# setup. Order matters: the unreachable runs go FIRST, because a successful run
+# caches the object and a later offline test would then pass for the wrong
+# reason. Transport is `file://` — local, no network.
+# Sets PC_OFFLINE_SECRET_RC / PC_OFFLINE_PII_RC / PC_ONLINE_SECRET_RC /
+# PC_ONLINE_PII_RC.
+PC_OFFLINE_SECRET_RC=""
+PC_OFFLINE_PII_RC=""
+PC_ONLINE_SECRET_RC=""
+PC_ONLINE_PII_RC=""
+setup_partial_clone_case() {
+  local src clone i
+  src="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-pcsrc.XXXXXX")"
+  git -C "$src" init -q .
+  git -C "$src" config user.email "test@example.com"
+  git -C "$src" config user.name "test"
+  git -C "$src" config uploadpack.allowFilter true
+  # The OLD revision is CLEAN: "must not block" is then unambiguous.
+  printf 'old but clean\n' >"$src/h.txt"
+  git -C "$src" add h.txt
+  git -C "$src" commit -q -m v0 --no-verify
+  for i in 1 2 3; do
+    printf 'newer %s\n' "$i" >"$src/h.txt"
+    git -C "$src" add h.txt
+    git -C "$src" commit -q -m "v$i" --no-verify
+  done
+
+  clone="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-pcclone.XXXXXX")"
+  rmdir "$clone"
+  if ! git clone -q --filter=blob:none --no-local "file://$src" "$clone" 2>/dev/null; then
+    rm -rf "$src"
+    PC_OFFLINE_SECRET_RC="partial-clone-unavailable"
+    PC_OFFLINE_PII_RC="partial-clone-unavailable"
+    PC_ONLINE_SECRET_RC="partial-clone-unavailable"
+    PC_ONLINE_PII_RC="partial-clone-unavailable"
+    return
+  fi
+  git -C "$clone" config user.email "test@example.com"
+  git -C "$clone" config user.name "test"
+  git -C "$clone" restore --staged --source=HEAD~3 -- h.txt
+
+  # Confirm the fixture is actually exercising an absent object; if the blob is
+  # local, both directions collapse and the assertions would be vacuous.
+  local oid
+  oid="$(git -C "$clone" rev-parse :h.txt)"
+  if GIT_NO_LAZY_FETCH=1 git -C "$clone" cat-file -e "$oid" 2>/dev/null; then
+    rm -rf "$src" "$clone"
+    PC_OFFLINE_SECRET_RC="blob-unexpectedly-local"
+    PC_OFFLINE_PII_RC="blob-unexpectedly-local"
+    PC_ONLINE_SECRET_RC="blob-unexpectedly-local"
+    PC_ONLINE_PII_RC="blob-unexpectedly-local"
+    return
+  fi
+
+  # --- unreachable FIRST (no caching side effect from a successful read) ---
+  git -C "$clone" remote set-url origin "file:///nonexistent-promisor-$$"
+  (cd "$clone" && bash "$SECRET_HOOK" >/dev/null 2>&1)
+  PC_OFFLINE_SECRET_RC=$?
+  (cd "$clone" && bash "$PII_HOOK" >/dev/null 2>&1)
+  PC_OFFLINE_PII_RC=$?
+
+  # --- now reachable ---
+  git -C "$clone" remote set-url origin "file://$src"
+  (cd "$clone" && bash "$SECRET_HOOK" >/dev/null 2>&1)
+  PC_ONLINE_SECRET_RC=$?
+  (cd "$clone" && bash "$PII_HOOK" >/dev/null 2>&1)
+  PC_ONLINE_PII_RC=$?
+
+  rm -rf "$src" "$clone"
+}
+
+# SKIP_PATTERNS was entirely unpinned across three rounds: making should_skip
+# always return false left the suite green. $2 lands in a path the patterns
+# exclude, so a detection here means the skip list stopped working.
+run_staged_skipped_path() {
+  local hook="$1" body="$2" rc
+  reset_repo
+  printf '%s\n' "$body" >"$REPO/deps.lock"
+  git -C "$REPO" add deps.lock
+  (cd "$REPO" && bash "$hook" >/dev/null 2>&1)
+  rc=$?
+  reset_repo
+  rm -f "$REPO/deps.lock"
+  printf '%s' "$rc"
+}
+
+# A SKIPPED path whose blob is missing must not block: the skip decision is made
+# on the path BEFORE extraction, so there is nothing to read and nothing to
+# report. This is the one observable difference the pre-extraction skip makes.
+run_staged_skipped_missing_object() {
+  local hook="$1" rc oid objpath
+  reset_repo
+  printf 'anything\n' >"$REPO/deps.lock"
+  git -C "$REPO" add deps.lock
+  oid="$(git -C "$REPO" rev-parse :deps.lock)"
+  objpath="$REPO/.git/objects/${oid:0:2}/${oid:2}"
+  if [ ! -f "$objpath" ]; then
+    printf 'no-loose-object'
+    return
+  fi
+  rm -f "$objpath"
+  (cd "$REPO" && bash "$hook" >/dev/null 2>&1)
+  rc=$?
+  reset_repo
+  rm -f "$REPO/deps.lock"
+  printf '%s' "$rc"
+}
+
 # UNREADABLE BLOB: the index references an object that is gone, so
 # `git cat-file blob <oid>` fails. The original `|| continue` skipped the file
 # silently; a file that could not be scanned must BLOCK, not pass.
@@ -371,6 +485,27 @@ assert_exit "secret-check: outside a git repository, fails CLOSED" 1 \
   "$(run_staged_outside_repo "$SECRET_HOOK")"
 assert_exit "pii-check: outside a git repository, fails CLOSED" 1 \
   "$(run_staged_outside_repo "$PII_HOOK")"
+
+# --- round 4: the partial-clone split, and SKIP_PATTERNS ------------------------
+# Both directions of the local-probe / bounded-fetch design. Refusing an absent
+# object outright (the round-3 shape) false-blocks the reachable case; fetching
+# unconditionally (round 2) has no bound. These four are the only assertions that
+# can tell the three designs apart.
+setup_partial_clone_case
+assert_exit "secret-check: partial clone, remote unreachable, fails CLOSED" 1 "$PC_OFFLINE_SECRET_RC"
+assert_exit "pii-check: partial clone, remote unreachable, fails CLOSED" 1 "$PC_OFFLINE_PII_RC"
+assert_exit "secret-check: partial clone, remote reachable, clean commit is NOT blocked" 0 "$PC_ONLINE_SECRET_RC"
+assert_exit "pii-check: partial clone, remote reachable, clean commit is NOT blocked" 0 "$PC_ONLINE_PII_RC"
+
+assert_exit "secret-check: a SKIP_PATTERNS path is not scanned" 0 \
+  "$(run_staged_skipped_path "$SECRET_HOOK" "$SECRET_BAD")"
+assert_exit "pii-check: a SKIP_PATTERNS path is not scanned" 0 \
+  "$(run_staged_skipped_path "$PII_HOOK" "$PII_BAD")"
+
+assert_exit "secret-check: a skipped path with a missing blob does not block" 0 \
+  "$(run_staged_skipped_missing_object "$SECRET_HOOK")"
+assert_exit "pii-check: a skipped path with a missing blob does not block" 0 \
+  "$(run_staged_skipped_missing_object "$PII_HOOK")"
 
 echo ""
 echo "Passed: $TEST_PASSED  Failed: $TEST_FAILED"

--- a/scanner/tests/test_hook_staged_scan.sh
+++ b/scanner/tests/test_hook_staged_scan.sh
@@ -215,6 +215,56 @@ run_staged_no_tmpdir() {
   printf '%s' "$rc"
 }
 
+# GITLINK (submodule, mode 160000): has no blob. Pins the mode skip, which is
+# load-bearing in the OTHER direction from everything else here — dropping it
+# makes every submodule commit hit the unreadable-blob branch and be FALSELY
+# BLOCKED, and review measured the suite staying 24/24 green while it did.
+# Set up ONCE and run both hooks against the same staged gitlink: a submodule
+# cannot be re-added at the same path after removal (`.git/modules/<name>`
+# survives), and building the fixture twice also doubled the cost of the
+# slowest case in the file. Sets SUB_SECRET_RC and SUB_PII_RC.
+SUB_SECRET_RC=""
+SUB_PII_RC=""
+setup_submodule_case() {
+  local sub
+  reset_repo
+  sub="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-sub.XXXXXX")"
+  git -C "$sub" init -q .
+  git -C "$sub" config user.email "test@example.com"
+  git -C "$sub" config user.name "test"
+  printf 'inner\n' >"$sub/inner.txt"
+  git -C "$sub" add inner.txt
+  git -C "$sub" commit -q -m inner --no-verify
+  # -c protocol.file.allow=always: git >=2.38 refuses file:// submodules by
+  # default (CVE-2022-39253). Local fixture, no network.
+  if ! git -C "$REPO" -c protocol.file.allow=always \
+    submodule add -q "$sub" mysub >/dev/null 2>&1; then
+    rm -rf "$sub"
+    SUB_SECRET_RC="submodule-add-unavailable"
+    SUB_PII_RC="submodule-add-unavailable"
+    return
+  fi
+  (cd "$REPO" && bash "$SECRET_HOOK" >/dev/null 2>&1)
+  SUB_SECRET_RC=$?
+  (cd "$REPO" && bash "$PII_HOOK" >/dev/null 2>&1)
+  SUB_PII_RC=$?
+  git -C "$REPO" submodule deinit -qf mysub >/dev/null 2>&1
+  git -C "$REPO" rm -qf mysub >/dev/null 2>&1
+  rm -rf "$sub" "$REPO/.gitmodules"
+  reset_repo
+}
+
+# NOT INSIDE A REPOSITORY: the enumeration would come back empty and the hook
+# would exit 0 having scanned nothing — the last fail-open in the staged path.
+run_staged_outside_repo() {
+  local hook="$1" rc dir
+  dir="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-norepo.XXXXXX")"
+  (cd "$dir" && GIT_CEILING_DIRECTORIES="$dir" bash "$hook" >/dev/null 2>&1)
+  rc=$?
+  rm -rf "$dir"
+  printf '%s' "$rc"
+}
+
 # UNREADABLE BLOB: the index references an object that is gone, so
 # `git cat-file blob <oid>` fails. The original `|| continue` skipped the file
 # silently; a file that could not be scanned must BLOCK, not pass.
@@ -308,6 +358,19 @@ assert_exit "secret-check: an unreadable staged blob fails CLOSED" 1 \
   "$(run_staged_missing_object "$SECRET_HOOK" "$SECRET_BAD")"
 assert_exit "pii-check: an unreadable staged blob fails CLOSED" 1 \
   "$(run_staged_missing_object "$PII_HOOK" "$PII_BAD")"
+
+# --- round 3: the mode skip is load-bearing in the FALSE-BLOCK direction -------
+# Review's mutation matrix: dropping the `160000|000000` skip left the suite at
+# 24/24 while false-blocking every submodule commit. These two are the only
+# assertions that can see it.
+setup_submodule_case
+assert_exit "secret-check: a staged submodule (gitlink) does not block" 0 "$SUB_SECRET_RC"
+assert_exit "pii-check: a staged submodule (gitlink) does not block" 0 "$SUB_PII_RC"
+
+assert_exit "secret-check: outside a git repository, fails CLOSED" 1 \
+  "$(run_staged_outside_repo "$SECRET_HOOK")"
+assert_exit "pii-check: outside a git repository, fails CLOSED" 1 \
+  "$(run_staged_outside_repo "$PII_HOOK")"
 
 echo ""
 echo "Passed: $TEST_PASSED  Failed: $TEST_FAILED"

--- a/scanner/tests/test_hook_staged_scan.sh
+++ b/scanner/tests/test_hook_staged_scan.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Unit tests for the STAGED-MODE contract of hooks/secret-check.sh and
+# hooks/pii-check.sh — the pre-commit gates ClaudeSec installs into other repos
+# (hooks/README.md documents `cp secret-check.sh .git/hooks/pre-commit`, and
+# scripts/setup.sh copies both into $TARGET_DIR/.claude/hooks/).
+# Run: bash scanner/tests/test_hook_staged_scan.sh
+#
+# Contract under test
+#   - With NO arguments the hook scans what `git commit` is about to write, i.e.
+#     the STAGED BLOB (`git show :<path>`) — not the working-tree copy.
+#   - With arguments it scans the given paths as-is (the CI path in lint.yml and
+#     the pre-commit-framework path in .pre-commit-config.yaml, both of which
+#     hand it a clean checkout / stashed tree).
+#   - Detected -> exit 1; clean -> exit 0.
+#
+# Regression guards (the defect this file was written for, measured 2026-08-26)
+#   Both hooks read the PATH in staged mode, so they greped the working tree:
+#     - staged secret + secret edited out of the working tree -> exit 0. The
+#       secret went into the commit with the gate reporting success
+#       (OWASP A07 Identification & Authentication Failures / CWE-798
+#       Use of Hard-coded Credentials).
+#     - staged content clean + secret only in an UNSTAGED edit -> exit 1, i.e.
+#       a blocked commit that contained nothing to block.
+#   Wrong in both directions, from one root cause. Both directions are pinned
+#   below, so a revert to path-scanning fails two named tests rather than
+#   silently restoring a gate that cannot see the commit.
+#
+# Positive controls: each hook also gets a same-content case that MUST be
+# detected, so a regex that stops matching anything fails here instead of
+# reading green over a clean repo (the lint.yml `pii-check` job runs the hook
+# against this repo's own files, where finding nothing is the expected result —
+# that job cannot distinguish a working detector from a broken one).
+#
+# Hermetic: builds throwaway git repos under $TMPDIR. No network, no fixtures
+# outside this file, nothing written inside the ClaudeSec checkout.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SECRET_HOOK="$SCRIPT_DIR/../../hooks/secret-check.sh"
+PII_HOOK="$SCRIPT_DIR/../../hooks/pii-check.sh"
+
+TEST_PASSED=0
+TEST_FAILED=0
+
+# Secret-shaped strings are assembled from fragments so no contiguous credential
+# pattern lands in this source file (repo push-protection / gitleaks would block
+# it). The runtime value still exercises the hooks' detectors.
+AWS_KEY="AKIA""IOSFODNN7EXAMPLE"                 # AKIA + 16 chars, split in source
+SECRET_BAD="aws_key = \"${AWS_KEY}\""
+SECRET_OK='aws_key = "REDACTED"'
+
+# The leading fragment is kept separate so the literal "/Users/<name>/" pattern
+# never appears in this source (the repo's own pii-check scans it in CI).
+U="/Users/"
+PII_BAD="DATA_DIR = \"${U}alice/private/data\""
+PII_OK='DATA_DIR = "~/data"'
+
+assert_exit() {
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "  PASS: $desc"
+    ((TEST_PASSED++))
+  else
+    echo "  FAIL: $desc (expected exit $expected, got $actual)"
+    ((TEST_FAILED++))
+  fi
+}
+
+# ONE throwaway repo, reset between cases. A repo per case cost 14 `git init`s
+# and ran ~15s — the kcov job caps a single test at 30s, so a per-case repo would
+# have sat one instrumentation slowdown away from a cap-hit.
+REPO="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-hooktest.XXXXXX")"
+trap 'rm -rf "$REPO"' EXIT
+git -C "$REPO" init -q .
+git -C "$REPO" config user.email "test@example.com"
+git -C "$REPO" config user.name "test"
+git -C "$REPO" config commit.gpgsign false
+printf 'baseline\n' >"$REPO/f.txt"
+git -C "$REPO" add f.txt
+git -C "$REPO" commit -q -m baseline --no-verify
+
+# Back to the baseline commit with a clean index and working tree.
+reset_repo() {
+  git -C "$REPO" reset -q --hard HEAD
+}
+
+# Stage $2 as f.txt, then leave $3 in the working tree, then run hook $1 in
+# staged mode (no arguments). Echoes the exit code; never aborts the suite.
+run_staged() {
+  local hook="$1" staged="$2" worktree="$3" rc
+  reset_repo
+  printf '%s\n' "$staged" >"$REPO/f.txt"
+  git -C "$REPO" add f.txt
+  printf '%s\n' "$worktree" >"$REPO/f.txt"
+  (cd "$REPO" && bash "$hook" >/dev/null 2>&1)
+  rc=$?
+  printf '%s' "$rc"
+}
+
+# Run hook $1 in staged mode with a staged DELETION pending (no blob to read).
+run_staged_deletion() {
+  local hook="$1" rc
+  reset_repo
+  git -C "$REPO" rm -q f.txt
+  (cd "$REPO" && bash "$hook" >/dev/null 2>&1)
+  rc=$?
+  printf '%s' "$rc"
+}
+
+# Run hook $1 with an explicit path argument holding $2 (the CI / pre-commit-
+# framework invocation, which must keep scanning the file it is handed).
+run_with_arg() {
+  local hook="$1" body="$2" rc
+  reset_repo
+  printf '%s\n' "$body" >"$REPO/f.txt"
+  (cd "$REPO" && bash "$hook" f.txt >/dev/null 2>&1)
+  rc=$?
+  printf '%s' "$rc"
+}
+
+echo "== hooks/secret-check.sh + hooks/pii-check.sh (staged-mode contract) =="
+
+# --- REGRESSION: the false-negative direction (a secret in the commit) ---
+assert_exit "secret-check: staged secret, cleaned worktree, is detected" 1 \
+  "$(run_staged "$SECRET_HOOK" "$SECRET_BAD" "$SECRET_OK")"
+assert_exit "pii-check: staged PII, cleaned worktree, is detected" 1 \
+  "$(run_staged "$PII_HOOK" "$PII_BAD" "$PII_OK")"
+
+# --- REGRESSION: the false-alarm direction (blocked with nothing staged) ---
+assert_exit "secret-check: secret only in an unstaged edit is allowed" 0 \
+  "$(run_staged "$SECRET_HOOK" "$SECRET_OK" "$SECRET_BAD")"
+assert_exit "pii-check: PII only in an unstaged edit is allowed" 0 \
+  "$(run_staged "$PII_HOOK" "$PII_OK" "$PII_BAD")"
+
+# --- POSITIVE CONTROLS: the detector must actually detect ---
+assert_exit "secret-check: AWS key staged and in worktree is detected" 1 \
+  "$(run_staged "$SECRET_HOOK" "$SECRET_BAD" "$SECRET_BAD")"
+assert_exit "pii-check: personal path staged and in worktree is detected" 1 \
+  "$(run_staged "$PII_HOOK" "$PII_BAD" "$PII_BAD")"
+
+# --- Clean input must pass ---
+assert_exit "secret-check: clean staged content is allowed" 0 \
+  "$(run_staged "$SECRET_HOOK" "$SECRET_OK" "$SECRET_OK")"
+assert_exit "pii-check: clean staged content is allowed" 0 \
+  "$(run_staged "$PII_HOOK" "$PII_OK" "$PII_OK")"
+
+# --- A staged deletion has no blob: skip it, do not fail the commit ---
+assert_exit "secret-check: staged deletion does not fail the commit" 0 \
+  "$(run_staged_deletion "$SECRET_HOOK")"
+assert_exit "pii-check: staged deletion does not fail the commit" 0 \
+  "$(run_staged_deletion "$PII_HOOK")"
+
+# --- Argument mode is unchanged: it scans the path it is given ---
+assert_exit "secret-check: argument mode still scans the given file" 1 \
+  "$(run_with_arg "$SECRET_HOOK" "$SECRET_BAD")"
+assert_exit "pii-check: argument mode still scans the given file" 1 \
+  "$(run_with_arg "$PII_HOOK" "$PII_BAD")"
+assert_exit "secret-check: argument mode allows a clean file" 0 \
+  "$(run_with_arg "$SECRET_HOOK" "$SECRET_OK")"
+assert_exit "pii-check: argument mode allows a clean file" 0 \
+  "$(run_with_arg "$PII_HOOK" "$PII_OK")"
+
+echo ""
+echo "Passed: $TEST_PASSED  Failed: $TEST_FAILED"
+[[ "$TEST_FAILED" -eq 0 ]]

--- a/scanner/tests/test_hook_staged_scan.sh
+++ b/scanner/tests/test_hook_staged_scan.sh
@@ -379,6 +379,35 @@ run_staged_skipped_missing_object() {
   printf '%s' "$rc"
 }
 
+# CORRUPT object: PRESENT but undecodable. `cat-file -e` returns 0 (it does not
+# inflate) while `cat-file blob` returns 128 — so this takes the probe-succeeded
+# branch, and the advice for the ABSENT case would tell the user to run
+# `git cat-file -e`, which succeeds and changes nothing. Echoes "rc:<has the
+# absent-case advice>" so the assertion pins both the exit code and the fact that
+# the two failures do not share a message.
+run_staged_corrupt_object() {
+  local hook="$1" body="$2" rc oid objpath out
+  reset_repo
+  printf '%s\n' "$body" >"$REPO/f.txt"
+  git -C "$REPO" add f.txt
+  oid="$(git -C "$REPO" rev-parse :f.txt)"
+  objpath="$REPO/.git/objects/${oid:0:2}/${oid:2}"
+  if [ ! -f "$objpath" ]; then
+    printf 'no-loose-object'
+    return
+  fi
+  chmod u+w "$objpath"
+  printf 'not zlib at all' >"$objpath"
+  out="$(cd "$REPO" && bash "$hook" 2>&1)"
+  rc=$?
+  reset_repo
+  case "$out" in
+    *"does NOT hydrate"*) printf '%s:absent-advice' "$rc" ;;
+    *"damaged object store"*) printf '%s:corrupt-advice' "$rc" ;;
+    *) printf '%s:no-advice' "$rc" ;;
+  esac
+}
+
 # UNREADABLE BLOB: the index references an object that is gone, so
 # `git cat-file blob <oid>` fails. The original `|| continue` skipped the file
 # silently; a file that could not be scanned must BLOCK, not pass.
@@ -506,6 +535,14 @@ assert_exit "secret-check: a skipped path with a missing blob does not block" 0 
   "$(run_staged_skipped_missing_object "$SECRET_HOOK")"
 assert_exit "pii-check: a skipped path with a missing blob does not block" 0 \
   "$(run_staged_skipped_missing_object "$PII_HOOK")"
+
+# A corrupt object is PRESENT but undecodable, so it must fail closed with the
+# damaged-store advice, NOT the partial-clone advice whose suggested command
+# succeeds and fixes nothing.
+assert_exit "secret-check: a corrupt object fails CLOSED with damaged-store advice" \
+  "1:corrupt-advice" "$(run_staged_corrupt_object "$SECRET_HOOK" "$SECRET_BAD")"
+assert_exit "pii-check: a corrupt object fails CLOSED with damaged-store advice" \
+  "1:corrupt-advice" "$(run_staged_corrupt_object "$PII_HOOK" "$PII_BAD")"
 
 echo ""
 echo "Passed: $TEST_PASSED  Failed: $TEST_FAILED"

--- a/scanner/tests/test_hook_staged_scan.sh
+++ b/scanner/tests/test_hook_staged_scan.sh
@@ -31,6 +31,25 @@
 # against this repo's own files, where finding nothing is the expected result —
 # that job cannot distinguish a working detector from a broken one).
 #
+# SECOND ROUND — the fix's own fail-opens
+#   Adversarial review of the first version of the fix found THREE fail-open
+#   paths that `main` did not have, and mutation-testing this file showed why
+#   they survived: removing `--diff-filter=ACMR` or `|| continue` left it at
+#   14/14. The assertions could not see the constructs that caused the bugs.
+#   Each is now pinned to its construct:
+#     - TYPE CHANGE (`T`): `ACMR` omits it, so a symlink replaced by a real file
+#       carrying a secret was never scanned. Filter is now `d` (exclude
+#       deletions).
+#     - `:<path>` STAGE SPEC: a staged `0:notes.txt` is parsed as *stage 0 of
+#       notes.txt*, so the hook either skipped it or scanned an unrelated decoy
+#       and read clean. The blob is now addressed by OID from `--raw`.
+#     - UNWRITABLE TMPDIR: `mktemp` failed, `pii-check.sh` has no `set -e`, and
+#       the gate exited 0 having scanned nothing. Both hooks now fail closed, as
+#       does an unreadable staged blob.
+#   Also pinned forward, not as a regression: a RENAME's raw record carries TWO
+#   paths and the DESTINATION is the one entering the commit. Verified by
+#   mutation (dropping the second-path read makes both rename cases fail).
+#
 # Hermetic: builds throwaway git repos under $TMPDIR. No network, no fixtures
 # outside this file, nothing written inside the ClaudeSec checkout.
 set -uo pipefail
@@ -118,6 +137,105 @@ run_with_arg() {
   printf '%s' "$rc"
 }
 
+# --- the three fail-opens adversarial review found in the FIRST version of this
+# --- fix, each pinned to the construct responsible ------------------------------
+
+# TYPE CHANGE (status `T`): a symlink in HEAD, staged as a regular file carrying
+# $2. Pins `--diff-filter=d` (exclude deletions) against the original
+# `--diff-filter=ACMR`, which omits `T` and never scanned this at all.
+run_staged_typechange() {
+  local hook="$1" body="$2" rc
+  reset_repo
+  ln -sf f.txt "$REPO/lnk.txt"
+  git -C "$REPO" add lnk.txt
+  git -C "$REPO" commit -q -m symlink --no-verify
+  rm -f "$REPO/lnk.txt"
+  printf '%s\n' "$body" >"$REPO/lnk.txt"
+  git -C "$REPO" add lnk.txt
+  (cd "$REPO" && bash "$hook" >/dev/null 2>&1)
+  rc=$?
+  # Drop the symlink commit so later cases reset to the plain baseline.
+  git -C "$REPO" reset -q --hard HEAD~1
+  printf '%s' "$rc"
+}
+
+# STAGE-SPEC AMBIGUITY: a path literally named `0:notes.txt`, with a decoy
+# `notes.txt` also staged. `git show ":0:notes.txt"` (and `cat-file blob` on the
+# same string) parses that as *stage 0 of notes.txt* and returns the DECOY's
+# content, so the gate read clean. Pins addressing the blob by OID.
+run_staged_colon_path() {
+  local hook="$1" body="$2" rc
+  reset_repo
+  printf '%s\n' "$body" >"$REPO/0:notes.txt"
+  printf 'nothing to see here\n' >"$REPO/notes.txt"
+  git -C "$REPO" add -- '0:notes.txt' notes.txt
+  (cd "$REPO" && bash "$hook" >/dev/null 2>&1)
+  rc=$?
+  reset_repo
+  rm -f "$REPO/0:notes.txt" "$REPO/notes.txt"
+  printf '%s' "$rc"
+}
+
+# RENAME (status `R`, TWO paths in the raw record): the DESTINATION is the path
+# entering the commit and the one that must be reported. Pins the second-path
+# read; without it the parser desynchronises and mis-pairs metadata with paths.
+run_staged_rename() {
+  local hook="$1" body="$2" rc out
+  reset_repo
+  printf '%s\n' "$body" >"$REPO/src.txt"
+  git -C "$REPO" add src.txt
+  git -C "$REPO" commit -q -m rename-src --no-verify
+  git -C "$REPO" mv src.txt dst.txt
+  out="$(cd "$REPO" && bash "$hook" 2>&1)"
+  rc=$?
+  git -C "$REPO" reset -q --hard HEAD~1
+  rm -f "$REPO/src.txt" "$REPO/dst.txt"
+  # Report the exit code only when the DESTINATION path was named.
+  case "$out" in
+    *dst.txt*) printf '%s' "$rc" ;;
+    *) printf 'reported-wrong-path' ;;
+  esac
+}
+
+# UNWRITABLE TMPDIR: `mktemp` fails. pii-check.sh has no `set -e`, so the
+# redirect failed per file, the loop swallowed it, and the gate exited 0 having
+# scanned nothing — a full or read-only /tmp turned the whole gate off, green.
+# Pins the explicit mktemp check. MUST fail closed.
+run_staged_no_tmpdir() {
+  local hook="$1" body="$2" rc ro
+  reset_repo
+  printf '%s\n' "$body" >"$REPO/f.txt"
+  git -C "$REPO" add f.txt
+  ro="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-ro.XXXXXX")"
+  chmod 500 "$ro"
+  (cd "$REPO" && TMPDIR="$ro/" bash "$hook" >/dev/null 2>&1)
+  rc=$?
+  chmod 700 "$ro"
+  rm -rf "$ro"
+  printf '%s' "$rc"
+}
+
+# UNREADABLE BLOB: the index references an object that is gone, so
+# `git cat-file blob <oid>` fails. The original `|| continue` skipped the file
+# silently; a file that could not be scanned must BLOCK, not pass.
+run_staged_missing_object() {
+  local hook="$1" body="$2" rc oid objpath
+  reset_repo
+  printf '%s\n' "$body" >"$REPO/f.txt"
+  git -C "$REPO" add f.txt
+  oid="$(git -C "$REPO" rev-parse :f.txt)"
+  objpath="$REPO/.git/objects/${oid:0:2}/${oid:2}"
+  # A packed object would not be at that path; this repo is loose-only.
+  if [ ! -f "$objpath" ]; then
+    printf 'no-loose-object'
+    return
+  fi
+  rm -f "$objpath"
+  (cd "$REPO" && bash "$hook" >/dev/null 2>&1)
+  rc=$?
+  printf '%s' "$rc"
+}
+
 echo "== hooks/secret-check.sh + hooks/pii-check.sh (staged-mode contract) =="
 
 # --- REGRESSION: the false-negative direction (a secret in the commit) ---
@@ -159,6 +277,37 @@ assert_exit "secret-check: argument mode allows a clean file" 0 \
   "$(run_with_arg "$SECRET_HOOK" "$SECRET_OK")"
 assert_exit "pii-check: argument mode allows a clean file" 0 \
   "$(run_with_arg "$PII_HOOK" "$PII_OK")"
+
+# --- The three fail-opens review found in the first version of the fix ---------
+# Each is pinned to the construct responsible, because mutation testing showed
+# the assertions above survive removing `--diff-filter=ACMR` and `|| continue`
+# untouched: 14/14 either way. An assertion set that cannot see a construct is
+# not coverage of it.
+
+assert_exit "secret-check: symlink->file TYPE CHANGE with a secret is detected" 1 \
+  "$(run_staged_typechange "$SECRET_HOOK" "$SECRET_BAD")"
+assert_exit "pii-check: symlink->file TYPE CHANGE with PII is detected" 1 \
+  "$(run_staged_typechange "$PII_HOOK" "$PII_BAD")"
+
+assert_exit "secret-check: a '0:'-prefixed path is not read as stage 0 of a decoy" 1 \
+  "$(run_staged_colon_path "$SECRET_HOOK" "$SECRET_BAD")"
+assert_exit "pii-check: a '0:'-prefixed path is not read as stage 0 of a decoy" 1 \
+  "$(run_staged_colon_path "$PII_HOOK" "$PII_BAD")"
+
+assert_exit "secret-check: a RENAME reports the destination path" 1 \
+  "$(run_staged_rename "$SECRET_HOOK" "$SECRET_BAD")"
+assert_exit "pii-check: a RENAME reports the destination path" 1 \
+  "$(run_staged_rename "$PII_HOOK" "$PII_BAD")"
+
+assert_exit "secret-check: an unwritable TMPDIR fails CLOSED" 1 \
+  "$(run_staged_no_tmpdir "$SECRET_HOOK" "$SECRET_BAD")"
+assert_exit "pii-check: an unwritable TMPDIR fails CLOSED" 1 \
+  "$(run_staged_no_tmpdir "$PII_HOOK" "$PII_BAD")"
+
+assert_exit "secret-check: an unreadable staged blob fails CLOSED" 1 \
+  "$(run_staged_missing_object "$SECRET_HOOK" "$SECRET_BAD")"
+assert_exit "pii-check: an unreadable staged blob fails CLOSED" 1 \
+  "$(run_staged_missing_object "$PII_HOOK" "$PII_BAD")"
 
 echo ""
 echo "Passed: $TEST_PASSED  Failed: $TEST_FAILED"

--- a/scanner/tests/test_hook_staged_scan.sh
+++ b/scanner/tests/test_hook_staged_scan.sh
@@ -301,10 +301,16 @@ setup_partial_clone_case() {
   clone="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-pcclone.XXXXXX")"
   rmdir "$clone"
   # -c protocol.file.allow=always for the same reason the submodule fixture needs
-  # it: a hardened config (`protocol.file.allow=never`, `protocol.allow=never`)
-  # makes the clone fail and turns four assertions into loud FAILs for
-  # environmental reasons. Does NOT rescue a restrictive `GIT_ALLOW_PROTOCOL`
-  # env var, which no -c can override.
+  # it: a hardened config makes the clone fail and turns four assertions into
+  # loud FAILs for environmental reasons. It covers `protocol.file.allow=never`
+  # AND `protocol.allow=never` — `protocol.<name>.allow` takes precedence over
+  # `protocol.allow`, verified with a real `GIT_CONFIG_GLOBAL`: without the -c the
+  # clone dies in ~1s with `fatal: transport 'file' not allowed`, with it the
+  # clone succeeds. (An earlier note here claimed that config HANGS; that was an
+  # artifact of the probe harness measuring it, not git. Corrected rather than
+  # left, because a recorded phantom is something a future reader plans around.)
+  # It does NOT rescue a restrictive `GIT_ALLOW_PROTOCOL` env var, which no -c can
+  # override; that fails fast and loud.
   if ! git -c protocol.file.allow=always clone -q --filter=blob:none \
     --no-local "file://$src" "$clone" 2>/dev/null; then
     rm -rf "$src"
@@ -346,6 +352,62 @@ setup_partial_clone_case() {
   PC_ONLINE_PII_RC=$?
 
   rm -rf "$src" "$clone"
+}
+
+# RE-PROBE branch (`READ_UNDECODABLE` reached through the FALLBACK path): the
+# object is absent, the lazy fetch LANDS it, and the read then fails anyway — so
+# the failure is a decode, not an absence, and the advice must say so. Recipe
+# from review, and the trick is that it needs no corruption and no network: a
+# `--filter=tree:0` clone leaves TREES absent, and an absent tree oid staged at
+# mode 100644 fetches fine and then fails on TYPE.
+#
+# Caveat worth knowing: the cause here is a type mismatch rather than a damaged
+# store, so the message is generically right rather than precisely right. The
+# input is a hand-crafted index state nobody reaches by accident; the branch is
+# what is under test.
+# Echoes "<rc>:<which advice>" so a collapse of rc 2 into rc 1 is visible.
+run_staged_fetched_then_undecodable() {
+  local hook="$1" donor clone old_tree out rc
+  donor="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-t0donor.XXXXXX")"
+  git -C "$donor" init -q .
+  git -C "$donor" config user.email "test@example.com"
+  git -C "$donor" config user.name "test"
+  git -C "$donor" config uploadpack.allowFilter true
+  mkdir -p "$donor/sub"
+  printf 'old subtree\n' >"$donor/sub/f.txt"
+  git -C "$donor" add sub/f.txt
+  git -C "$donor" commit -q -m v1 --no-verify
+  old_tree="$(git -C "$donor" rev-parse HEAD:sub)"
+  printf 'new subtree\n' >"$donor/sub/f.txt"
+  git -C "$donor" add sub/f.txt
+  git -C "$donor" commit -q -m v2 --no-verify
+
+  clone="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-t0clone.XXXXXX")"
+  rmdir "$clone"
+  if ! git -c protocol.file.allow=always clone -q --filter=tree:0 \
+    --no-local "file://$donor" "$clone" 2>/dev/null; then
+    rm -rf "$donor"
+    printf 'tree-filter-clone-unavailable'
+    return
+  fi
+  git -C "$clone" config user.email "test@example.com"
+  git -C "$clone" config user.name "test"
+  # Vacuity guard: if the old tree is already local, the fetch never happens and
+  # this exercises the probe-succeeded branch instead.
+  if GIT_NO_LAZY_FETCH=1 git -C "$clone" cat-file -e "$old_tree" 2>/dev/null; then
+    rm -rf "$donor" "$clone"
+    printf 'tree-unexpectedly-local'
+    return
+  fi
+  git -C "$clone" update-index --add --cacheinfo "100644,$old_tree,fake.txt"
+  out="$(cd "$clone" && bash "$hook" 2>&1)"
+  rc=$?
+  rm -rf "$donor" "$clone"
+  case "$out" in
+    *"damaged object store"*) printf '%s:corrupt-advice' "$rc" ;;
+    *"does NOT hydrate"*) printf '%s:absent-advice' "$rc" ;;
+    *) printf '%s:no-advice' "$rc" ;;
+  esac
 }
 
 # SKIP_PATTERNS was entirely unpinned across three rounds: making should_skip
@@ -549,6 +611,14 @@ assert_exit "secret-check: a corrupt object fails CLOSED with damaged-store advi
   "1:corrupt-advice" "$(run_staged_corrupt_object "$SECRET_HOOK" "$SECRET_BAD")"
 assert_exit "pii-check: a corrupt object fails CLOSED with damaged-store advice" \
   "1:corrupt-advice" "$(run_staged_corrupt_object "$PII_HOOK" "$PII_BAD")"
+
+# The same READ_UNDECODABLE code reached through the FALLBACK path — absent, then
+# fetched, then still unreadable. This was the one branch the previous round
+# admitted it could not pin.
+assert_exit "secret-check: fetched-then-undecodable gets damaged-store advice" \
+  "1:corrupt-advice" "$(run_staged_fetched_then_undecodable "$SECRET_HOOK")"
+assert_exit "pii-check: fetched-then-undecodable gets damaged-store advice" \
+  "1:corrupt-advice" "$(run_staged_fetched_then_undecodable "$PII_HOOK")"
 
 echo ""
 echo "Passed: $TEST_PASSED  Failed: $TEST_FAILED"

--- a/scanner/tests/test_hook_staged_scan.sh
+++ b/scanner/tests/test_hook_staged_scan.sh
@@ -300,7 +300,13 @@ setup_partial_clone_case() {
 
   clone="$(mktemp -d "${TMPDIR:-/tmp}/claudesec-pcclone.XXXXXX")"
   rmdir "$clone"
-  if ! git clone -q --filter=blob:none --no-local "file://$src" "$clone" 2>/dev/null; then
+  # -c protocol.file.allow=always for the same reason the submodule fixture needs
+  # it: a hardened config (`protocol.file.allow=never`, `protocol.allow=never`)
+  # makes the clone fail and turns four assertions into loud FAILs for
+  # environmental reasons. Does NOT rescue a restrictive `GIT_ALLOW_PROTOCOL`
+  # env var, which no -c can override.
+  if ! git -c protocol.file.allow=always clone -q --filter=blob:none \
+    --no-local "file://$src" "$clone" 2>/dev/null; then
     rm -rf "$src"
     PC_OFFLINE_SECRET_RC="partial-clone-unavailable"
     PC_OFFLINE_PII_RC="partial-clone-unavailable"


### PR DESCRIPTION
Found by the **#297 quarterly ADR-001 audit**, in the two hooks
`scripts/setup.sh:84` installs into *other people's* repositories.

> **HUMAN REVIEW REQUIRED** — this diff changes secret- and PII-handling code
> (custom-rules §5B). Green CI is not sufficient evidence for this class.

## The defect

In staged mode (no arguments — the shape `hooks/README.md` documents as
`cp secret-check.sh .git/hooks/pre-commit`), both hooks enumerated staged paths
with `git diff --cached --name-only` and then **greped the path** — i.e. the
working-tree copy. The working tree is not what `git commit` writes.

Measured 2026-08-26 in a throwaway repo (`AKIA` + 16 chars):

```console
$ printf 'aws_key = "%s"\n' "$KEY" > creds.txt && git add creds.txt
$ git show :creds.txt
aws_key = "AKIAIOSFODNN7EXAMPLE"          # this is what the commit will contain
$ printf 'aws_key = "REDACTED"\n' > creds.txt
$ bash hooks/secret-check.sh; echo "exit=$?"
exit=0                                     # gate reports success
```

And the mirror image — staged content clean, the secret only in an **unstaged**
edit — exited **1**, blocking a commit that contained nothing to block.

Wrong in both directions from one root cause. The false-negative direction is
the serious one: a secret enters a commit while the gate reports success
(OWASP A07 Identification & Authentication Failures; CWE-798 Use of Hard-coded
Credentials).

## The fix

In staged mode, extract each staged blob with `git show ":$file"` and scan that.
The real path is still used for the skip-pattern check and the report line, so
output is unchanged. `--diff-filter=ACMR` drops deletions, which have no blob.

**Argument mode is untouched.** `lint.yml`'s `pii-check` job and
`.pre-commit-config.yaml` both hand the hook a clean tree, where the path IS the
right thing to read — the `pre-commit` framework stashes unstaged changes, and CI
has a fresh checkout.

## Why there was nothing to catch this

- Nothing exercised `secret-check.sh` at all — no test, no CI job.
- `pii-check.sh` runs in CI, but only over **this repo's own clean files**, where
  finding nothing is the expected result. That job cannot distinguish a working
  detector from a broken one.

`scanner/tests/test_hook_staged_scan.sh` (14 assertions, registered in
`scanner-unit-tests` so it gates on the fast path) pins:

| case | expect |
|---|---|
| staged bad, worktree cleaned (the false negative) | exit 1 |
| staged clean, bad only unstaged (the false alarm) | exit 0 |
| staged bad + worktree bad (**positive control**) | exit 1 |
| staged clean | exit 0 |
| staged deletion (no blob) | exit 0 |
| argument mode, bad / clean | exit 1 / 0 |

…for both hooks. Credential- and path-shaped fixtures are assembled from
fragments at runtime, so no contiguous pattern lands in the source (repo push
protection / gitleaks / the repo's own `pii-check`).

## Verification

```console
$ bash scanner/tests/test_hook_staged_scan.sh
Passed: 14  Failed: 0

# non-vacuity: same test against the PRE-FIX hooks
  FAIL: secret-check: staged secret, cleaned worktree, is detected (expected exit 1, got 0)
  FAIL: pii-check: staged PII, cleaned worktree, is detected (expected exit 1, got 0)
  FAIL: secret-check: secret only in an unstaged edit is allowed (expected exit 0, got 1)
  FAIL: pii-check: PII only in an unstaged edit is allowed (expected exit 0, got 1)
Passed: 10  Failed: 4

$ python3 -m pytest scanner/tests/ -q
2597 passed, 11 skipped in 21.32s

$ python3 -m pytest scanner/tests/test_ci_reachability.py \
    scanner/tests/test_ci_gate_topology.py \
    scanner/tests/test_ci_required_graph_not_disabled.py -q
119 passed

$ shellcheck hooks/secret-check.sh hooks/pii-check.sh scanner/tests/test_hook_staged_scan.sh   # exit 0
$ markdownlint hooks/README.md                                                                  # exit 0
```

**Runtime note:** a fresh repo per case cost 14 `git init`s and ~15s — one
instrumentation slowdown from the kcov job's 30s per-test cap. Reusing one repo
with `git reset --hard` between cases: **5.1s**.

## Not fixed here

`secret-check.sh` flags **itself**: its own `BEGIN.*PRIVATE KEY` detection
pattern matches rule 3. Pre-existing and unrelated — confirmed by running the
unmodified `HEAD` hook against the `HEAD` file. Reported, not touched.

## Reviewer checklist

- [ ] `git show ":$file"` is the right blob accessor (vs `git cat-file`), and the
      `|| continue` on failure is the right posture for an unreadable entry.
- [ ] Skip patterns still evaluate against the PATH, not the temp blob.
- [ ] The `mktemp` blob + `trap … EXIT` cleanup is acceptable in a hook that runs
      on every commit.
- [ ] Argument mode really is unchanged for the CI and `pre-commit` callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)