### PR TITLE
test(ci): the ERE guard never looked at the two hooks we install elsewhere

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -164,7 +164,11 @@ audit 2026-07-28** (issue #297): all 38 `test_ci_*.py` guards re-audited — see
 and the matcher-completeness backlog opened. **Re-reviewed 2026-08-10** (see
 "Backlog sweep 2026-08-10" below): the Tier-3 list was checked against the live
 workflow set for the first time and was found to be *stale by omission* —
-`guard-audit-reminder.yml` had never been triaged into it.
+`guard-audit-reminder.yml` had never been triaged into it. **Quarterly ADR-001
+adversarial audit 2026-08-26** (issue #297): 57 guard files / 1102 tests
+re-audited — see "Quarterly audit 2026-08-26" below. The matcher classes came up
+empty; the finding was an ENUMERATION gap (`hooks/` outside the ERE guard's scan
+set), and following it into the hooks surfaced a live defect no guard covered.
 
 ### Tier 2 — incident-backed (now implemented)
 
@@ -172,8 +176,9 @@ Both former Tier-2 candidates landed in #258 and are now in the Catalog above:
 
 - `test_ci_prowler_version_pinned.py` — exact `prowler==${PROWLER_VERSION}` pin
   in `Dockerfile` (#237).
-- `test_ci_dockerfile_base_pinned.py` — `@sha256:` digest pins + `alpine:3.20`
-  minor freeze + version-agnostic site resolution (#233/#234/#220).
+- `test_ci_dockerfile_base_pinned.py` — `@sha256:` digest pins + the alpine minor
+  freeze (`3.20` when written; moved to `3.23`, the last minor on the py3.12
+  line, in #479) + version-agnostic site resolution (#233/#234/#220).
 
 ### Tier 3 — monitor only (no guard yet; would be sprawl)
 
@@ -1071,6 +1076,57 @@ alarms, all fixed with both directions pinned — docker-compose hardening keys
 instead of as a missing pin), the `permissions:` header, and the `ARG
 TRIVY_VERSION=` / `ARG PROWLER_VERSION=` defaults (Docker strips quotes, so a
 quoted default is the identical pin).
+
+### Quarterly audit 2026-08-26 (ADR-001, issue #297)
+
+Baseline first: `pytest scanner/tests/test_ci_*.py
+scanner/tests/test__ci_guard_util.py -q` → **1102 passed** across **57 guard
+files** (967 tests), 45 of which route through `_ci_guard_util`.
+
+The comment-evasion and key-quoting classes came up **empty this round** — the
+2026-08-06 sweep and #404's execute-the-gate redesign closed them, and the
+primitives' docstrings now carry the shapes a fresh attempt would try. The
+strippers (`strip_inline_comment`, `strip_inline_comment_sh`),
+`workflow_and_action_files()`, `uses_refs()` and the template pin policy were
+attacked directly and held.
+
+What this round found instead was an **enumeration** gap, which is the class that
+survives a matcher audit because there is no matcher to attack:
+
+- **`test_ci_no_ere_pipe_regression.py` did not scan `hooks/`.** It covered
+  `scanner/checks` and `scanner/lib` because that is where the detections live —
+  but `hooks/pii-check.sh` and `hooks/secret-check.sh` are detections too, they
+  gate commits, and `scripts/setup.sh` installs them into *other people's*
+  repositories. 17 ERE call sites sat outside the scan set, 14 in those two
+  files. Verified clean at extension time, so this closed a blind spot, not a
+  live bug; a planted `hooks/` violation now fails the guard and did not before.
+- **Following that gap into the hooks found a live defect the guards were never
+  going to catch** — both hooks scanned the working tree instead of the staged
+  blob, so a staged secret edited out of the working tree committed with the gate
+  exiting 0 (fixed separately; `scanner/tests/test_hook_staged_scan.sh`). The
+  reusable half: `hooks/secret-check.sh` had **no test and no CI job at all**,
+  and the `pii-check` job runs its hook only over this repo's own clean files —
+  a run that cannot distinguish a working detector from a broken one. Coverage of
+  a *detector* means a positive control, not an execution.
+
+**Judged and deliberately NOT changed** (recorded so the next audit does not
+re-file them):
+
+- `test_ci_no_ere_pipe_regression.py` (`rglob`) and
+  `test_ci_guard_assertion_scoping.py` (`glob`) enumerate from the FILESYSTEM,
+  not `git ls-files`. Switching needs a subprocess, which drops the
+  stdlib-only property, and the failure direction is loud: an untracked scratch
+  `.sh` makes the suite RED locally, never green-while-defeated. The #488 case
+  that forced `git ls-files` was a gitignored operator script under `scripts/`,
+  which neither guard scans. Same reasoning already recorded for
+  `test_ci_requirements_pinned.py`'s root-only discovery.
+- `\s` in the hooks' ERE patterns is **not** a portability bug. Stock
+  `/usr/bin/grep` on macOS reports "BSD grep, GNU compatible" 2.6.0-FreeBSD and
+  treats `\s` as whitespace — control: `TOKEN\s*=` did NOT match `TOKENsss=`.
+  Hypothesis raised, tested, disproven.
+- `hooks/secret-check.sh` flags **itself**, because its own
+  `BEGIN.*PRIVATE KEY` detection pattern matches its private-key rule. Verified
+  pre-existing against the unmodified `HEAD` file. Reported, not "fixed".
 
 ## Adding a new guard
 

--- a/scanner/tests/test_ci_no_ere_pipe_regression.py
+++ b/scanner/tests/test_ci_no_ere_pipe_regression.py
@@ -56,6 +56,29 @@ Coverage extensions (PRs #244 → this PR)
   `_code_grep` helpers are defined in scanner/lib/checks.sh; any \\|-in-ERE
   bug introduced there would have been invisible to the #244 guard.
 
+* hooks/**/*.sh is now in the scan set (the #297 quarterly ADR-001 audit,
+  2026-08-26).  The guard covered `scanner/checks` because that is where the
+  detections live — but `hooks/pii-check.sh` and `hooks/secret-check.sh` are
+  detections too, they gate commits, and `scripts/setup.sh` installs them into
+  OTHER repositories.  17 ERE call sites sat outside the scan set, 14 of them in
+  those two files.  Verified clean at the time of the extension, so this closes a
+  blind spot rather than a live bug: a `\\|` planted in `secret-check.sh`'s
+  `(AKIA|ASIA)` rule makes it match a literal pipe, i.e. neither alternative,
+  and the secret gate then passes everything with nothing in CI going red.
+
+  Also checked and NOT a finding: `\\s` in those hooks' patterns is portable.
+  Stock `/usr/bin/grep` on macOS reports "BSD grep, GNU compatible" 2.6.0-FreeBSD
+  and treats `\\s` as whitespace — the control `TOKEN\\s*=` did NOT match
+  `TOKENsss=`, so it is not degrading to a literal `s`.
+
+* Enumeration is a FILESYSTEM walk (`rglob`), not `git ls-files`.  Deliberate:
+  `git ls-files` would need a subprocess, dropping the stdlib-only/no-subprocess
+  property this guard is built on, and the failure direction here is loud, not
+  silent — an untracked scratch `.sh` under these three roots would make the
+  suite RED locally (over-report), never green-while-defeated.  The #488 case
+  that forced `git ls-files` elsewhere was a gitignored operator script under
+  `scripts/`, which this guard does not scan.
+
 * Multi-line call detection: when a `_code_grep`, `files_contain`, or
   `file_contains` call uses a backslash line-continuation (the function name
   on line N ends with `\\`, or the pattern argument is on the next physical
@@ -76,6 +99,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHECKS_DIR = REPO_ROOT / "scanner" / "checks"
 LIB_DIR = REPO_ROOT / "scanner" / "lib"
+HOOKS_DIR = REPO_ROOT / "hooks"
 
 # ---------------------------------------------------------------------------
 # Allowlist of intentional \\| occurrences.
@@ -280,16 +304,30 @@ class TestScanDirectoriesExist(unittest.TestCase):
             f"No .sh files found under {LIB_DIR} -- glob assumption broke",
         )
 
+    def test_hooks_dir_exists(self):
+        self.assertTrue(
+            HOOKS_DIR.is_dir(),
+            f"hooks directory not found at {HOOKS_DIR} -- path assumption broke",
+        )
+
+    def test_hooks_dir_contains_sh_files(self):
+        sh_files = list(HOOKS_DIR.rglob("*.sh"))
+        self.assertTrue(
+            sh_files,
+            f"No .sh files found under {HOOKS_DIR} -- glob assumption broke",
+        )
+
 
 class TestNoEREPipeInChecksAndLib(unittest.TestCase):
     """
-    Scans every scanner/checks/**/*.sh AND scanner/lib/**/*.sh for \\| in an
-    ERE context.  Only the two explicitly allowlisted intentional occurrences
-    are permitted.  Any other \\| in an ERE pattern is flagged as a regression.
+    Scans every scanner/checks/**/*.sh, scanner/lib/**/*.sh AND hooks/**/*.sh
+    for \\| in an ERE context.  Only the two explicitly allowlisted intentional
+    occurrences are permitted.  Any other \\| in an ERE pattern is flagged as a
+    regression.
     """
 
     def test_no_unallowlisted_ere_pipe(self):
-        violations = _scan_dirs([CHECKS_DIR, LIB_DIR])
+        violations = _scan_dirs([CHECKS_DIR, LIB_DIR, HOOKS_DIR])
         if violations:
             lines = [
                 f"  {v[0].relative_to(REPO_ROOT)}:{v[1]}: {v[2]!r}"
@@ -441,6 +479,32 @@ class TestMutationSelfTest(unittest.TestCase):
             hits,
             "MUTATION SELF-TEST FAILED: file_contains with \\\\| in lib context "
             "should be detected but was NOT flagged.",
+        )
+
+    # --- BAD snippets: hooks/ coverage (added by the #297 audit) ---
+
+    def test_detects_ere_pipe_in_secret_detection_hook(self):
+        """
+        The shape that motivated widening the scan set: a \\| planted in
+        `hooks/secret-check.sh`'s AWS-key rule.  Under ERE that is a literal
+        pipe, so the rule would stop matching either alternative and the
+        pre-commit secret gate would pass everything, silently.
+        """
+        snippet = '  if grep -qE "(AKIA\\|ASIA)[A-Z0-9]{16}" "$content"; then'
+        hits = _scan_text_lines(snippet, "secret-check.sh")
+        self.assertTrue(
+            hits,
+            "MUTATION SELF-TEST FAILED: grep -qE with \\\\| in a detection hook "
+            "(secret-check.sh) should be detected but was NOT flagged.",
+        )
+
+    def test_detects_ere_pipe_in_pii_detection_hook(self):
+        snippet = '  if grep -qE "(SHEET_ID\\|NOTION_DB_ID)" "$content"; then'
+        hits = _scan_text_lines(snippet, "pii-check.sh")
+        self.assertTrue(
+            hits,
+            "MUTATION SELF-TEST FAILED: grep -qE with \\\\| in a detection hook "
+            "(pii-check.sh) should be detected but was NOT flagged.",
         )
 
     # --- BAD snippets: multi-line continuation (new in this PR) ---


### PR DESCRIPTION
The **#297 quarterly ADR-001 adversarial audit**. Baseline first:

```console
$ python3 -m pytest scanner/tests/test_ci_*.py scanner/tests/test__ci_guard_util.py -q
1102 passed
```

57 guard files, 967 tests, 45 routing through `_ci_guard_util`.

## The classes this cadence exists for came up empty

Comment evasion, key quoting, unhandled YAML forms — nothing. The 2026-08-06
sweep and #404's execute-the-gate redesign closed them, and the primitives'
docstrings already carry the shapes a fresh attempt would try. Attacked directly
and held: `strip_inline_comment` / `strip_inline_comment_sh`,
`workflow_and_action_files()`, `uses_refs()`, and the template pin policy (whose
installed-vs-example split is derived from `scripts/setup.sh`, so a third
installed template is covered the day it lands).

## What it did find: an enumeration gap

The class that survives a matcher audit, because there is no matcher to attack.

`test_ci_no_ere_pipe_regression.py` scanned `scanner/checks/**/*.sh` and
`scanner/lib/**/*.sh` — where the detections live. But `hooks/pii-check.sh` and
`hooks/secret-check.sh` are detections too, they gate commits, and
`scripts/setup.sh:84` installs them into **other people's repositories**.
**17 ERE call sites sat outside the scan set, 14 of them in those two files.**

The bug shape matters more there than in `scanner/checks`: `\|` in ERE is a
literal pipe, so an `(AKIA\|ASIA)` rule matches **neither** alternative and the
pre-commit secret gate passes everything, with nothing in CI going red.

## Change

`hooks/**/*.sh` joins the scan set, with the existence canaries the other two
roots already have and two mutation self-tests keyed to the real hook filenames.

Verified clean at extension time — so this closes a blind spot, not a live bug —
and verified **live**, not merely synthetic:

```console
# plant a real violation in a real hooks/ file
$ printf '#!/bin/bash\ngrep -qE "foo\\|bar" "$1"\n' > hooks/_audit_probe.sh
$ python3 -m pytest scanner/tests/test_ci_no_ere_pipe_regression.py -q
E    hooks/_audit_probe.sh:2: 'grep -qE "foo\\|bar" "$1"'
1 failed, 30 passed
$ rm hooks/_audit_probe.sh && python3 -m pytest scanner/tests/test_ci_no_ere_pipe_regression.py -q
31 passed
```

Before this change that probe passed. 27 → 31 tests.

## Following the gap into the hooks (separate PR)

It surfaced a live defect no guard was ever going to catch: both hooks scanned
the working tree instead of the staged blob, so a staged secret edited out of the
working tree committed with the gate exiting 0. Fixed in a separate PR
(§5B human-review) with `scanner/tests/test_hook_staged_scan.sh`.

The reusable half is recorded in the audit section: `hooks/secret-check.sh` had
**no test and no CI job at all**, and the `pii-check` job runs its hook only over
this repo's own clean files — a run that cannot distinguish a working detector
from a broken one. **Coverage of a detector means a positive control, not an
execution.**

## Judged and deliberately NOT changed

Recorded in the doc so the next audit does not re-file them:

- This guard (`rglob`) and `test_ci_guard_assertion_scoping.py` (`glob`)
  enumerate from the **filesystem**, not `git ls-files`. Switching needs a
  subprocess, dropping the stdlib-only property, and the direction is loud: an
  untracked scratch `.sh` makes the suite RED locally, never
  green-while-defeated. The #488 case that forced `git ls-files` was a gitignored
  operator script under `scripts/`, which neither guard scans. Same reasoning
  already recorded for `test_ci_requirements_pinned.py`'s root-only discovery.
- **`\s` in the hooks' ERE patterns is not a portability bug.** Raised as a
  hypothesis, tested, disproven: stock `/usr/bin/grep` on macOS reports
  `BSD grep, GNU compatible 2.6.0-FreeBSD` and treats `\s` as whitespace —
  control `TOKEN\s*=` did **not** match `TOKENsss=`.
- `hooks/secret-check.sh` flags **itself** (its own `BEGIN.*PRIVATE KEY`
  detection pattern matches its private-key rule). Confirmed pre-existing against
  the unmodified `HEAD` file.

## Also

One stale fact in the doc this touches, same class as #491: the Tier-2 entry
still described the alpine freeze as `3.20`, four minors after #479 moved it.

## Verification

```console
$ python3 -m pytest scanner/tests/ -q
2601 passed, 11 skipped in 17.68s

$ markdownlint docs/devsecops/ci-config-regression-guards.md   # exit 0
```

Issue #297's remaining checklist item is closing the issue once this and the
hook fix land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)