### PR TITLE
test(ci): two guards hunting one bug class disagreed about the corpus

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -1109,6 +1109,40 @@ survives a matcher audit because there is no matcher to attack:
   a run that cannot distinguish a working detector from a broken one. Coverage of
   a *detector* means a positive control, not an execution.
 
+**Follow-up differential, same date — the generalisation.** Finding one
+enumeration gap by hand is luck; the reusable move is to diff *every*
+file-scanning guard's enumeration against the tracked files that carry its
+trigger token. Done for the four source-pattern guards:
+
+| guard | out-of-scope tracked files carrying its trigger |
+|---|---|
+| `test_ci_no_code_injection_regression` (CWE-94) | **none** |
+| `test_ci_decode_boundary_handlers` (decode boundary, `.py`) | **none** |
+| `test_ci_no_ere_pipe_regression` (ERE `\|`) | `scanner/claudesec` (**19** sites), `scripts/gh-merge-ready-pr.sh` (3), `scripts/og-meta-verify.sh` (1) |
+
+So the ERE guard was the only narrow one, and the widest gap was not a directory
+but a **file with no extension**: `scanner/claudesec`, which no `*.sh` glob can
+reach and which both the CWE-94 guard and `test_ci_scanner_lib_reachability`
+already list explicitly. All 23 sites verified clean, so again a blind spot and
+not a live bug — `scripts/gh-merge-ready-pr.sh:245` shows the stake, a
+`grep -qiE "…expected|not mergeable|base branch policy…"` whose plain `|`
+someone escapes stops matching every alternative at once and the
+merge-readiness probe reports clean forever.
+
+Fixed structurally rather than by adding two roots: the ERE guard's scan set is
+now a `_production_files()` **asserted EQUAL** to the CWE-94 guard's function of
+the same name (`TestScanSetParityWithInjectionGuard`). Two guards hunting a bug
+class over the same corpus must not disagree about the corpus, equality catches
+the reverse direction too, and the assertion is where the next divergence
+surfaces instead of in the next audit.
+
+**Method note, because it cut both ways:** the same differential run over
+`test_ci_scanner_lib_reachability` reported 16 out-of-scope files. All 16 were
+false positives — the trigger used was "any shell function definition", which is
+not what that guard hunts (`scanner/lib` functions reachable from the scanner, a
+scope in which `scripts/` functions have no business). Attack the trigger before
+believing the diff; a loose trigger manufactures a backlog.
+
 **Judged and deliberately NOT changed** (recorded so the next audit does not
 re-file them):
 

--- a/scanner/tests/test_ci_no_ere_pipe_regression.py
+++ b/scanner/tests/test_ci_no_ere_pipe_regression.py
@@ -71,13 +71,23 @@ Coverage extensions (PRs #244 → this PR)
   and treats `\\s` as whitespace — the control `TOKEN\\s*=` did NOT match
   `TOKENsss=`, so it is not degrading to a literal `s`.
 
+* `scripts/**/*.sh` AND the extensionless `scanner/claudesec` entrypoint joined
+  the scan set immediately after, from the #297 follow-up differential: each
+  file-scanning guard's enumeration was diffed against the tracked files carrying
+  its trigger token.  The entrypoint alone holds **19** ERE call sites and no
+  `*.sh` glob can reach it; `scripts/` holds 4 more.  The scan set is now
+  `_production_files()`, asserted EQUAL to the CWE-94 guard's set of the same
+  name — two guards hunting a bug class over the same corpus must not disagree
+  about the corpus, and a scope difference is invisible in a green suite.
+
 * Enumeration is a FILESYSTEM walk (`rglob`), not `git ls-files`.  Deliberate:
   `git ls-files` would need a subprocess, dropping the stdlib-only/no-subprocess
   property this guard is built on, and the failure direction here is loud, not
-  silent — an untracked scratch `.sh` under these three roots would make the
-  suite RED locally (over-report), never green-while-defeated.  The #488 case
-  that forced `git ls-files` elsewhere was a gitignored operator script under
-  `scripts/`, which this guard does not scan.
+  silent — an untracked scratch `.sh` under these roots would make the suite RED
+  locally (over-report), never green-while-defeated.  The #488 case that forced
+  `git ls-files` elsewhere was a gitignored operator script under `scripts/`,
+  which this guard DOES now scan — so if that script reappears locally, expect a
+  local-only red and check `git ls-files` before believing it.
 
 * Multi-line call detection: when a `_code_grep`, `files_contain`, or
   `file_contains` call uses a backslash line-continuation (the function name
@@ -91,15 +101,24 @@ Passes under `pytest` (CI) and `python3 -m unittest`.
 """
 
 import re
+import sys
 import textwrap
 import unittest
 from pathlib import Path
+
+# The scan-set parity test imports the CWE-94 guard by module name, which must
+# work under both runners (pytest from the repo root, and `python3 -m unittest`
+# from anywhere).
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 # scanner/tests/<this> -> parents[0]=scanner/tests, [1]=scanner, [2]=repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHECKS_DIR = REPO_ROOT / "scanner" / "checks"
 LIB_DIR = REPO_ROOT / "scanner" / "lib"
 HOOKS_DIR = REPO_ROOT / "hooks"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+# The CLI entrypoint has NO extension, so no `*.sh` glob reaches it.
+ENTRYPOINT = REPO_ROOT / "scanner" / "claudesec"
 
 # ---------------------------------------------------------------------------
 # Allowlist of intentional \\| occurrences.
@@ -220,9 +239,40 @@ def _logical_lines(
     return result
 
 
-def _scan_dir(scan_dir: Path) -> list[tuple[Path, int, str]]:
+def _production_files() -> list[Path]:
+    """Every production shell file this guard scans (whichever paths exist).
+
+    Deliberately the SAME set as `test_ci_no_code_injection_regression.
+    _production_files()`. Two guards hunting bug classes in the same corpus with
+    different scopes means one of them is wrong, and a scope difference is
+    invisible in a green suite. The 2026-08-26 differential (each guard's
+    enumeration vs the tracked files carrying its trigger token) found this one
+    narrower in both directions that matter:
+
+    - `scanner/claudesec`, the CLI entrypoint, carries **19** ERE call sites and
+      has no `.sh` extension, so no directory glob would ever reach it. Both the
+      CWE-94 guard and `test_ci_scanner_lib_reachability` list it explicitly.
+    - `scripts/**/*.sh` carries 4 more (`gh-merge-ready-pr.sh` x3,
+      `og-meta-verify.sh` x1). The CWE-94 guard already treats `scripts/` as
+      production shell surface, so the narrower set here was not a policy choice.
+
+    All 23 verified clean when the scope was widened, so this closes a blind spot
+    rather than a live bug. `gh-merge-ready-pr.sh:245` is the shape that shows why
+    it matters: a `grep -qiE "…expected|not mergeable|base branch policy…"` whose
+    plain `|` someone "helpfully" escapes stops matching every alternative at
+    once, and the merge-readiness probe then reports clean forever.
     """
-    Walk scan_dir recursively for *.sh files.
+    files: list[Path] = []
+    if ENTRYPOINT.is_file():
+        files.append(ENTRYPOINT)
+    for d in (LIB_DIR, CHECKS_DIR, SCRIPTS_DIR, HOOKS_DIR):
+        if d.is_dir():
+            files += sorted(d.rglob("*.sh"))
+    return files
+
+
+def _scan_files(files: list[Path]) -> list[tuple[Path, int, str]]:
+    """
     Return a list of (filepath, lineno, logical_line) for each violation:
     a logical line that (a) is in an ERE context, (b) contains \\|, and
     (c) is NOT allowlisted.
@@ -230,7 +280,7 @@ def _scan_dir(scan_dir: Path) -> list[tuple[Path, int, str]]:
     The lineno is the first physical line of the logical group.
     """
     violations: list[tuple[Path, int, str]] = []
-    for sh_file in sorted(scan_dir.rglob("*.sh")):
+    for sh_file in files:
         physical = sh_file.read_text(encoding="utf-8").splitlines()
         for lineno, logical in _logical_lines(physical):
             if r"\|" not in logical:
@@ -241,17 +291,6 @@ def _scan_dir(scan_dir: Path) -> list[tuple[Path, int, str]]:
                 continue
             violations.append((sh_file, lineno, logical.rstrip()))
     return violations
-
-
-def _scan_dirs(
-    dirs: list[Path],
-) -> list[tuple[Path, int, str]]:
-    """Scan multiple directories and merge results."""
-    all_violations: list[tuple[Path, int, str]] = []
-    for d in dirs:
-        if d.is_dir():
-            all_violations.extend(_scan_dir(d))
-    return all_violations
 
 
 def _scan_text_lines(
@@ -317,17 +356,78 @@ class TestScanDirectoriesExist(unittest.TestCase):
             f"No .sh files found under {HOOKS_DIR} -- glob assumption broke",
         )
 
+    def test_scripts_dir_exists(self):
+        self.assertTrue(
+            SCRIPTS_DIR.is_dir(),
+            f"scripts directory not found at {SCRIPTS_DIR} -- path assumption broke",
+        )
+
+    def test_scripts_dir_contains_sh_files(self):
+        sh_files = list(SCRIPTS_DIR.rglob("*.sh"))
+        self.assertTrue(
+            sh_files,
+            f"No .sh files found under {SCRIPTS_DIR} -- glob assumption broke",
+        )
+
+    def test_entrypoint_is_in_the_scan_set(self):
+        """The extensionless CLI entrypoint carries ERE call sites and cannot be
+        reached by a `*.sh` glob, so it is listed explicitly. If it is ever
+        renamed or given an extension, fail here rather than scan 19 fewer sites
+        in silence."""
+        self.assertTrue(
+            ENTRYPOINT.is_file(),
+            f"CLI entrypoint not found at {ENTRYPOINT} -- if it moved, update "
+            "_production_files(), and check the two other guards that list it "
+            "explicitly (test_ci_no_code_injection_regression, "
+            "test_ci_scanner_lib_reachability).",
+        )
+        self.assertIn(
+            ENTRYPOINT,
+            _production_files(),
+            "The CLI entrypoint exists but is NOT in this guard's scan set.",
+        )
+
+
+class TestScanSetParityWithInjectionGuard(unittest.TestCase):
+    """The production-shell scan set must EQUAL the CWE-94 guard's.
+
+    Both guards hunt a bug class in the same corpus, so a scope difference means
+    one of them is wrong — and it is invisible in a green suite, which is exactly
+    how `scanner/claudesec` (19 ERE sites) and `scripts/**` (4 more) stayed
+    unscanned here while the CWE-94 guard covered them. Asserting EQUALITY rather
+    than containment also catches the reverse direction: a path added here and
+    not there.
+    """
+
+    def test_scan_set_equals_injection_guard_scan_set(self):
+        import test_ci_no_code_injection_regression as injection_guard
+
+        ours = set(_production_files())
+        theirs = set(injection_guard._production_files())
+        only_theirs = sorted(str(p.relative_to(REPO_ROOT)) for p in theirs - ours)
+        only_ours = sorted(str(p.relative_to(REPO_ROOT)) for p in ours - theirs)
+        self.assertEqual(
+            (only_theirs, only_ours),
+            ([], []),
+            "Production-shell scan sets have DIVERGED between this guard and "
+            "test_ci_no_code_injection_regression.\n"
+            f"  scanned only by the CWE-94 guard: {only_theirs}\n"
+            f"  scanned only by this guard:       {only_ours}\n"
+            "Both hunt a bug class over production shell; decide the surface once "
+            "and change both, or document why they must differ.",
+        )
+
 
 class TestNoEREPipeInChecksAndLib(unittest.TestCase):
     """
-    Scans every scanner/checks/**/*.sh, scanner/lib/**/*.sh AND hooks/**/*.sh
-    for \\| in an ERE context.  Only the two explicitly allowlisted intentional
-    occurrences are permitted.  Any other \\| in an ERE pattern is flagged as a
-    regression.
+    Scans every production shell file — `scanner/claudesec` plus `scanner/lib`,
+    `scanner/checks`, `scripts` and `hooks` recursively — for \\| in an ERE
+    context.  Only the two explicitly allowlisted intentional occurrences are
+    permitted.  Any other \\| in an ERE pattern is flagged as a regression.
     """
 
     def test_no_unallowlisted_ere_pipe(self):
-        violations = _scan_dirs([CHECKS_DIR, LIB_DIR, HOOKS_DIR])
+        violations = _scan_files(_production_files())
         if violations:
             lines = [
                 f"  {v[0].relative_to(REPO_ROOT)}:{v[1]}: {v[2]!r}"


### PR DESCRIPTION
Follow-up to #494. Finding one enumeration gap by hand was luck. This generalises
it: diff **every** file-scanning guard's enumeration against the tracked files
that carry its trigger token.

## The differential

| guard | out-of-scope tracked files carrying its trigger |
|---|---|
| `test_ci_no_code_injection_regression` (CWE-94) | **none** |
| `test_ci_decode_boundary_handlers` (decode boundary, `.py`) | **none** |
| `test_ci_no_ere_pipe_regression` (ERE `\|`) | `scanner/claudesec` (**19** sites), `scripts/gh-merge-ready-pr.sh` (3), `scripts/og-meta-verify.sh` (1) |

The ERE guard was the only narrow one — and the widest gap was not a directory
but a **file with no extension**: `scanner/claudesec`, which no `*.sh` glob can
reach, and which both the CWE-94 guard and `test_ci_scanner_lib_reachability`
already list explicitly.

All 23 sites verified clean, so this is a blind spot rather than a live bug.
`scripts/gh-merge-ready-pr.sh:245` shows the stake:

```bash
if grep -qiE "required status checks are expected|not mergeable|base branch policy prohibits" <<<"$merge_output"; then
```

Escape that plain `|` and it stops matching **every** alternative at once, and the
merge-readiness probe reports clean forever.

## Fixed structurally, not by adding two roots

The scan set is now `_production_files()`, **asserted EQUAL** to the CWE-94
guard's function of the same name (`TestScanSetParityWithInjectionGuard`).

Two guards hunting a bug class over the same corpus must not disagree about the
corpus. Equality (not containment) also catches the reverse direction — a path
added here and not there — and the next divergence surfaces at that assertion
instead of in the next quarterly audit.

## Both directions verified, not just asserted

```console
# the widened scope really reaches scripts/
$ printf '#!/bin/bash\ngrep -qE "foo\\|bar" "$1"\n' > scripts/_audit_probe.sh
$ python3 -m pytest scanner/tests/test_ci_no_ere_pipe_regression.py -q
E    scripts/_audit_probe.sh:2: 'grep -qE "foo\\|bar" "$1"'
1 failed, 34 passed
# (before this change: passed)

# the parity test is not vacuous — drop SCRIPTS_DIR back out
$ python3 -m pytest scanner/tests/test_ci_no_ere_pipe_regression.py -q
FAILED …::TestScanSetParityWithInjectionGuard::test_scan_set_equals_injection_guard_scan_set
  scanned only by the CWE-94 guard: ['scripts/check-prowler-python-ceiling.sh', … 23 files]
```

## Method note — the differential cut both ways

The same run over `test_ci_scanner_lib_reachability` reported **16** out-of-scope
files. All 16 were **false positives**: the trigger used was "any shell function
definition", which is not what that guard hunts (`scanner/lib` functions
reachable from the scanner — `scripts/` functions have no business in that
scope). Recorded in the audit section as a method warning: **attack the trigger
before believing the diff; a loose trigger manufactures a backlog.**

## Verification

```console
$ python3 -m pytest scanner/tests/ -q
2605 passed, 11 skipped in 25.82s

$ python3 -m pytest scanner/tests/test_ci_no_ere_pipe_regression.py -q   # 35 passed
$ python3 -m unittest -q scanner.tests.test_ci_no_ere_pipe_regression    # Ran 35 tests, OK

$ python3 -m pytest scanner/tests/test_ci_catalog_completeness.py \
    scanner/tests/test_ci_strip_before_match.py \
    scanner/tests/test_ci_guard_assertion_scoping.py \
    scanner/tests/test_ci_collector_table_completeness.py -q
48 passed

$ markdownlint docs/devsecops/ci-config-regression-guards.md   # exit 0
```

The parity test imports a sibling guard module, so the dual-runner path needed
the `sys.path.insert` this repo already uses for `_ci_guard_util`; both runners
verified above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)