### PR TITLE
fix(hooks): the secret gate flagged itself, and skipped node_modules only in subdirs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -995,7 +995,13 @@ jobs:
           find . -type f \( -name '*.py' -o -name '*.sh' -o -name '*.md' -o -name '*.yml' -o -name '*.yaml' -o -name '*.json' -o -name '*.html' -o -name '*.svg' \) \
             ! -path './node_modules/*' ! -path './.git/*' ! -path './package-lock.json' \
             ! -path './.claudesec-assets/*' ! -path './.claudesec-saas-best-practices/*' \
-            -print0 | xargs -0 bash hooks/pii-check.sh
+            # -r (--no-run-if-empty): without it GNU xargs runs the command ONCE
+            # with no arguments when find matches nothing, and the hook's
+            # no-argument form is a DIFFERENT mode — it scans the git index
+            # instead of the paths it was meant to check, then exits 0. A mode
+            # switch that reads as a pass. BSD xargs already declines to run on
+            # empty input; this job is ubuntu-only, so -r is the portable-here fix.
+            -print0 | xargs -0 -r bash hooks/pii-check.sh
 
   workflow-fork-guard:
     # Regression-prevention: every job in a pull_request_target workflow must

--- a/hooks/pii-check.sh
+++ b/hooks/pii-check.sh
@@ -11,7 +11,12 @@ RED='\033[0;31m'
 YELLOW='\033[0;33m'
 NC='\033[0m'
 
-SKIP_PATTERNS="(\.lock$|\.svg$|\.png$|\.jpg$|\.woff$|/node_modules/|/\.git/)"
+# Path-component alternatives are anchored with `(^|/)`: the enumeration in
+# staged mode yields REPO-ROOT-RELATIVE paths with no leading slash, so plain
+# `/node_modules/` matched `a/node_modules/x.js` but NOT a repo-root
+# `node_modules/x.js`. `(^|/)` matches both and still rejects
+# `my_node_modules/` (verified).
+SKIP_PATTERNS="(\.lock$|\.svg$|\.png$|\.jpg$|\.woff$|(^|/)node_modules/|(^|/)\.git/)"
 FOUND=0
 
 # Write the staged blob for OID $1 into $_blob. Non-zero when it cannot.

--- a/hooks/secret-check.sh
+++ b/hooks/secret-check.sh
@@ -10,7 +10,16 @@ RED='\033[0;31m'
 NC='\033[0m'
 
 # Files to skip
-SKIP_PATTERNS="(\.lock$|\.svg$|\.png$|\.jpg$|\.woff$|/node_modules/|/\.git/)"
+# Path-component alternatives are anchored with `(^|/)`: the enumeration in
+# staged mode yields REPO-ROOT-RELATIVE paths with no leading slash, so plain
+# `/node_modules/` matched `a/node_modules/x.js` but NOT a repo-root
+# `node_modules/x.js`. `(^|/)` matches both and still rejects
+# `my_node_modules/` (verified).
+SKIP_PATTERNS="(\.lock$|\.svg$|\.png$|\.jpg$|\.woff$|(^|/)node_modules/|(^|/)\.git/)"
+
+# Fragment for the private-key rule below — see the comment there. The name
+# deliberately does NOT contain the fragment, or the use site would match again.
+_PK_HEAD="BEGIN"
 
 FOUND=0
 
@@ -98,8 +107,17 @@ scan_file() {
     FOUND=$((FOUND + 1))
   fi
 
-  # Private keys
-  if grep -q "BEGIN.*PRIVATE KEY" "$content" 2>/dev/null; then
+  # Private keys. The pattern is ASSEMBLED from `$_PK_HEAD` so that no single
+  # line of this file carries both halves of it — grep is line-based, so the
+  # literal form matched THIS FILE and made secret-check.sh report itself. That
+  # was a permanent false positive for anyone pointing the hook at a tree
+  # containing it, and the reason this repo has a `pii-check` CI job and no
+  # matching secret-check one.
+  #
+  # Two traps, both hit while fixing it: the explanatory comment must not spell
+  # the pattern out either, and the variable NAME must not contain the fragment
+  # (`_PK_BEGIN` put it back on the use line).
+  if grep -q "${_PK_HEAD}.*PRIVATE KEY" "$content" 2>/dev/null; then
     echo -e "${RED}[SECRET]${NC} Private key in: $file"
     FOUND=$((FOUND + 1))
   fi

--- a/scanner/tests/test_hook_staged_scan.sh
+++ b/scanner/tests/test_hook_staged_scan.sh
@@ -620,6 +620,59 @@ assert_exit "secret-check: fetched-then-undecodable gets damaged-store advice" \
 assert_exit "pii-check: fetched-then-undecodable gets damaged-store advice" \
   "1:corrupt-advice" "$(run_staged_fetched_then_undecodable "$PII_HOOK")"
 
+# --- the hooks must not flag THEMSELVES, and must still flag the real thing ----
+# These live here rather than in a new file because they are properties of the
+# same two hooks and a separate file would need its own lint.yml registration and
+# fixtures for no extra signal. `secret-check.sh` used to match its own
+# private-key rule, so anyone pointing the hook at a tree containing it got a
+# permanent false positive — which is why this repo has a `pii-check` CI job and
+# no matching secret-check one. Both directions are pinned, because the cheap
+# wrong "fix" for self-detection is to delete the rule.
+#
+# Third time paying for this: naming the two halves of that rule adjacently in
+# PROSE reintroduces it. It has now bitten the hook's own comment, its variable
+# name, and this comment. Refer to it as "the private-key rule".
+for _hook_a in "$SECRET_HOOK" "$PII_HOOK"; do
+  for _hook_b in "$SECRET_HOOK" "$PII_HOOK"; do
+    _rc=0
+    bash "$_hook_a" "$_hook_b" >/dev/null 2>&1 || _rc=$?
+    assert_exit "$(basename "$_hook_a") does not flag $(basename "$_hook_b")" 0 "$_rc"
+  done
+done
+
+# Positive control for the rule that had to be split: assembled at runtime so
+# this test file does not carry the pattern either.
+_pk_fixture="$(mktemp "${TMPDIR:-/tmp}/claudesec-pk.XXXXXX")"
+printf -- '-----%s RSA PRIVATE KEY-----\nMIIabcdef\n' "BEGIN" >"$_pk_fixture"
+_rc=0
+bash "$SECRET_HOOK" "$_pk_fixture" >/dev/null 2>&1 || _rc=$?
+assert_exit "secret-check still detects a real private-key header" 1 "$_rc"
+rm -f "$_pk_fixture"
+
+# SKIP_PATTERNS path-component anchoring: a repo-ROOT node_modules/ was not
+# skipped because the pattern required a leading slash.
+# Each hook gets content ITS OWN rules detect. The first version of this fed the
+# AWS key to pii-check, which has no rule for it, so that assertion passed with
+# the anchor reverted — a vacuous assertion, caught by mutating the anchor.
+_nm_dir="$REPO/node_modules"
+mkdir -p "$_nm_dir"
+printf '%s\n' "$SECRET_BAD" >"$_nm_dir/s.js"
+printf '%s\n' "$PII_BAD" >"$_nm_dir/p.js"
+_rc=0
+(cd "$REPO" && bash "$SECRET_HOOK" node_modules/s.js) >/dev/null 2>&1 || _rc=$?
+assert_exit "secret-check skips a repo-root node_modules/ path" 0 "$_rc"
+_rc=0
+(cd "$REPO" && bash "$PII_HOOK" node_modules/p.js) >/dev/null 2>&1 || _rc=$?
+assert_exit "pii-check skips a repo-root node_modules/ path" 0 "$_rc"
+# ...and the anchor must not swallow a lookalike directory.
+_lk_dir="$REPO/my_node_modules"
+mkdir -p "$_lk_dir"
+printf '%s\n' "$SECRET_BAD" >"$_lk_dir/x.js"
+_rc=0
+(cd "$REPO" && bash "$SECRET_HOOK" my_node_modules/x.js) >/dev/null 2>&1 || _rc=$?
+assert_exit "secret-check still scans my_node_modules/ (anchor is not a substring)" 1 "$_rc"
+rm -rf "$_nm_dir" "$_lk_dir"
+
 echo ""
 echo "Passed: $TEST_PASSED  Failed: $TEST_FAILED"
 [[ "$TEST_FAILED" -eq 0 ]]


### PR DESCRIPTION
The three pre-existing items #493 reported and deliberately left alone. All are over-detection or mode-confusion direction — none is a fail-open — which is why they were out of scope there and are a PR of their own here.

> Touches secret/PII-handling code, so **§5B human review** applies as it did for #493.

## 1. `secret-check.sh` reported ITSELF

Its private-key rule was written literally, and grep is line-based, so the file matched its own pattern:

```console
$ bash hooks/secret-check.sh hooks/secret-check.sh
[SECRET] Private key in: hooks/secret-check.sh
exit=1
```

A permanent false positive for anyone pointing the hook at a tree containing it — and the reason this repo has a `pii-check` CI job and no matching secret-check one. The pattern is now assembled from a fragment so no single line carries both halves.

**That fix took three attempts, and the failures are the useful part:**

| attempt | why it still matched |
|---|---|
| split the pattern | the explanatory **comment** spelled it out |
| rename to `_PK_BEGIN` | the variable NAME carried the fragment, so `"${_PK_BEGIN}.*PRIVATE KEY"` had both halves on one line |
| add the test | the **test file's** comment did it a third time |

Every one was found by *running* the hook, never by reading it. Recorded at all three sites: refer to it as "the private-key rule", never adjacently by its halves.

## 2. `SKIP_PATTERNS` skipped `node_modules` only in subdirectories

`/node_modules/` requires a leading slash, and staged-mode enumeration yields repo-root-relative paths:

```console
node_modules/x.js       -> no-match   # scanned
a/node_modules/x.js     -> MATCH      # skipped
```

Now `(^|/)node_modules/` (and the same for `.git/`), verified in both directions — it matches the root case and still rejects `my_node_modules/`.

## 3. `xargs -0` ran the hook with NO arguments on empty input

`lint.yml:998`. GNU xargs invokes the command once even with nothing to pass, and the hook's no-argument form is a **different mode**: it scans the git index instead of the paths the job meant to check, then exits 0. A mode switch that reads as a pass. `-r` added; BSD xargs already declines to run on empty input and this job is ubuntu-only.

## Verification — 40 → 48 assertions, all three mutation-verified

```console
revert the private-key split      -> Passed: 47  Failed: 1
delete the private-key rule       -> Passed: 46  Failed: 2     # the cheap wrong "fix"
revert the SKIP_PATTERNS anchor   -> Passed: 46  Failed: 2
```

The second mutant is why the positive control exists: without it, deleting the rule would "fix" self-detection and pass.

**One of my own new assertions was vacuous, and mutation testing caught it.** The pii-check `node_modules` case fed it the AWS-key fixture, which pii-check has no rule for — so it passed with the anchor reverted. Each hook now gets content its own rules detect.

```console
$ bash scanner/tests/test_hook_staged_scan.sh      # Passed: 48  Failed: 0
$ python3 -m pytest scanner/tests/ -q              # 2605 passed, 11 skipped
$ python3 -m pytest scanner/tests/test_ci_*.py -q  # 975 passed
$ shellcheck hooks/secret-check.sh hooks/pii-check.sh scanner/tests/test_hook_staged_scan.sh   # rc=0
$ # both hooks over this PR's own diff
secret exit=0    pii exit=0
```

## Reported, not acted on

With the split, `secret-check.sh` can finally scan this repo — and doing so flags **6 files**:

```
scanner/checks/access-control/secrets-scan.sh   (private key + connection string)
hooks/security-lint.sh                           (private key)
scanner/tests/test_check_access_control.sh       (AWS key)
scanner/tests/test_hook_security_lint.sh         (private key)
docs/devsecops/ci-config-regression-guards.md    (private key)
```

All are detectors, fixtures or prose carrying the patterns on purpose. So a repo-wide secret-check CI job — the symmetry with `pii-check` this unblocks — needs an exclusion story first. That is a design decision, not a cleanup, and it is not in this PR.

Also still out of scope, unchanged: the enumeration's `2>/dev/null` (capturing its status needs command substitution, which strips NULs and breaks `-z`), and `GIT_ALLOW_PROTOCOL=https` fixture fragility (fails loud in ~1s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)