### PR TITLE
fix(ci): the nightly DAST scans this repo's own container instead of nothing

### DIFF
--- a/.github/workflows/dast-full-scan.yml
+++ b/.github/workflows/dast-full-scan.yml
@@ -6,8 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       target_url:
-        description: "Target URL for DAST scan (no default — supply a real, authorized target)"
-        required: true
+        description: >-
+          Optional. An authorized external target. LEAVE EMPTY to scan this
+          repo's own dashboard container, which is what the nightly run does.
+          Pointing an ACTIVE scan at infrastructure you do not own requires
+          documented authorization (NIST SP 800-115); never a third party, never
+          production.
+        required: false
 
 permissions:
   contents: read
@@ -18,138 +23,73 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  # NOTE ON THE REMOVED `coverage-notice` JOB (#399, 2026-08-26)
   # ---------------------------------------------------------------------------
-  # Job: coverage-notice
-  # The scan below is gated on the DAST_TARGET_URL repo variable. When that
-  # variable is unset the job is SKIPPED, the workflow conclusion is a clean
-  # `skipped`, and nothing anywhere is red — so "DAST Full Scan (Nightly)" can
-  # promise coverage it is not delivering, indefinitely and invisibly.
+  # The scan used to be gated on the `DAST_TARGET_URL` repo variable. With the
+  # variable unset the job was SKIPPED, the workflow conclusion was a clean
+  # `skipped`, and nothing was red — so this workflow promised nightly coverage
+  # it was not delivering. Measured 2026-08-06: 42 consecutive nightly runs
+  # reported `skipped` after the variable was unset around 2026-06-25, i.e. six
+  # weeks of ZERO automated DAST, with `gh api .../actions/variables` returning
+  # total_count: 0. `coverage-notice` existed to make that state visible without
+  # deciding the underlying question.
   #
-  # Measured (2026-08-06): 42 consecutive nightly runs reported `skipped` after
-  # the variable was unset around 2026-06-25, i.e. ZERO automated DAST for six
-  # weeks, with `gh api .../actions/variables` returning total_count: 0.
+  # The question is now decided: the nightly scans THIS REPO'S OWN dashboard
+  # container, the same target `dast-baseline.yml` already uses on pull requests.
+  # So the gate is gone, the run cannot skip, and a notice about a missing
+  # variable would be actively wrong — it would report "not running" on every
+  # night the scan ran fine.
   #
-  # This job makes that state VISIBLE without deciding the underlying question
-  # (restore a real authorized target, or drop the nightly claim). Same pattern
-  # and rationale as protection-drift-watch.yml (#396): Actions has no `neutral`
-  # conclusion for a regular job, so the honest signal is an artifact, and a
-  # notifier that fails daily forever is fatigue rather than signal.
+  # What this deliberately does NOT do is restore an external target. An active
+  # full scan against a host you do not own needs documented authorization
+  # (NIST SP 800-115), and the placeholder-host incident (#283) is what a default
+  # target buys. `workflow_dispatch` still accepts one for an authorized run.
+  #
+  # HONEST LIMIT: the nightly now scans a static page served by the repo's own
+  # nginx, which `dast-baseline.yml` already scans per PR. The added signal is the
+  # active-attack ruleset over the same surface, not new surface. That is a real
+  # reduction in claimed coverage versus scanning a live staging deployment —
+  # traded for a run that actually happens and cannot scan someone else's host.
+  #
+  # The invariant that replaced the notice job is pinned by
+  # `scanner/tests/test_ci_security_gate.py`: this job must not be gated on a
+  # repo variable, and the target must fall back to the local container.
   # ---------------------------------------------------------------------------
-  coverage-notice:
-    runs-on: ubuntu-latest
-    # Schedule only: a manual workflow_dispatch always supplies its own URL, so
-    # there is no coverage gap to report.
-    if: github.event_name == 'schedule'
-    permissions:
-      contents: read
-      issues: write
-    steps:
-      - name: Open or close the "nightly DAST not running" issue
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
-        env:
-          # Read through env, never interpolated into a script body.
-          DAST_TARGET_URL: ${{ vars.DAST_TARGET_URL }}
-        with:
-          script: |
-            const TITLE =
-              '[DAST] Nightly full scan is NOT running (DAST_TARGET_URL unset)';
-            const target = (process.env.DAST_TARGET_URL || '').trim();
-            const runUrl =
-              `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
-              `/actions/runs/${context.runId}`;
-
-            // Match by exact title so the separate findings tracker
-            // ('[DAST] Full Scan — open critical/high findings') is never touched.
-            const existing = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'all',
-              labels: 'dast',
-              per_page: 100,
-            });
-            const notice = existing.data.find((i) => i.title === TITLE);
-
-            if (target) {
-              core.info('DAST_TARGET_URL is set — nightly coverage is live.');
-              if (notice && notice.state === 'open') {
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: notice.number,
-                  body: `DAST_TARGET_URL is configured again — nightly coverage restored as of ${runUrl}. Closing automatically.`,
-                });
-                await github.rest.issues.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: notice.number,
-                  state: 'closed',
-                  state_reason: 'completed',
-                });
-              }
-              return;
-            }
-
-            const body =
-              `The scheduled **DAST Full Scan (Nightly)** workflow ran, but the scan job was\n` +
-              `SKIPPED: the \`DAST_TARGET_URL\` repository variable is not set, so no target\n` +
-              `was scanned. The workflow conclusion is a clean \`skipped\`, which is why this\n` +
-              `has produced no red build and no notification.\n\n` +
-              `GitHub Actions has no \`neutral\` conclusion for a regular job, so a gated-off\n` +
-              `scan looks identical to a healthy one. This issue exists so the gap is visible.\n\n` +
-              `### Two valid resolutions — this is a product decision\n\n` +
-              `1. **Restore coverage.** Set \`DAST_TARGET_URL\` to a target you are\n` +
-              `   **explicitly authorized to scan**. Never point it at third-party\n` +
-              `   infrastructure. The next scheduled run closes this issue automatically.\n` +
-              `2. **Drop the claim.** If nightly DAST is intentionally paused, rename the\n` +
-              `   workflow and update its header so it no longer promises nightly coverage,\n` +
-              `   and remove this notice job in the same change.\n\n` +
-              `Either is fine. Leaving it as-is is not: the workflow currently advertises\n` +
-              `coverage that does not exist.\n\n` +
-              `_Run: ${runUrl}_`;
-
-            if (notice) {
-              if (notice.state === 'closed') {
-                await github.rest.issues.update({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: notice.number,
-                  state: 'open',
-                });
-              }
-              await github.rest.issues.update({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: notice.number,
-                body,
-              });
-              core.warning(`Nightly DAST is not running — updated issue #${notice.number}.`);
-            } else {
-              const created = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: TITLE,
-                labels: ['security', 'dast'],
-                body,
-              });
-              core.warning(`Nightly DAST is not running — opened issue #${created.data.number}.`);
-            }
-
   dast-full:
     runs-on: ubuntu-latest
+    # `environment: staging` is kept for the workflow_dispatch-with-external-target
+    # path, which is the only one that touches a real deployment. It has ZERO
+    # protection rules today (verified via `gh api .../environments`), so it does
+    # not gate the nightly. If reviewers are ever added to it, the nightly
+    # localhost scan starts waiting for approval — decide that deliberately.
     environment: staging
-    # Skip the nightly run unless a real target is configured. Manual
-    # workflow_dispatch always runs (the caller supplies an explicit URL);
-    # the schedule only runs when the repo variable DAST_TARGET_URL is set,
-    # so we never waste a nightly scan on a placeholder host.
-    #
-    # NOTE: when this skips on a schedule, `coverage-notice` above is what makes
-    # the gap visible — do not remove one without the other.
-    if: >-
-      github.event_name == 'workflow_dispatch' || vars.DAST_TARGET_URL != ''
+    # DELIBERATELY UNGATED. A repo-variable gate is what made 42 consecutive
+    # nightly runs report a clean `skipped`; see the note above the job.
 
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # The three steps below run only for the local target. Same shape as
+      # dast-baseline.yml: the dashboard is static, so placeholder files are
+      # enough to give nginx something to serve.
+      - name: Generate dashboard files for mount
+        if: github.event.inputs.target_url == ''
+        run: |
+          echo '<!DOCTYPE html><html><body>DAST target</body></html>' > claudesec-asset-dashboard-live.html
+          echo '<!DOCTYPE html><html><body>DAST scan dashboard</body></html>' > claudesec-dashboard.html
+          echo '{}' > scan-report.json
+          mkdir -p .claudesec-assets
+
+      - name: Start application (docker-compose)
+        if: github.event.inputs.target_url == ''
+        run: |
+          docker compose up -d dashboard
+          timeout 60 bash -c 'until curl -sf http://localhost:11777/; do sleep 2; done'
+
+      - name: Prepare workspace for ZAP
+        if: github.event.inputs.target_url == ''
+        run: chmod -R a+w .
 
       - name: ZAP Full Scan
         # VERDICT SUPPRESSED — WHAT IT HIDES: `continue-on-error` stops a ZAP
@@ -164,7 +104,12 @@ jobs:
         id: zap
         continue-on-error: true
         with:
-          target: ${{ github.event.inputs.target_url || vars.DAST_TARGET_URL }}
+          # No repo variable and no placeholder host: an empty input means the
+          # local container, which is always there. `vars.DAST_TARGET_URL` is
+          # deliberately NOT read — reading it would restore the gate's failure
+          # mode by the back door (a stale variable silently redirecting the
+          # nightly at whatever host it names).
+          target: ${{ github.event.inputs.target_url || 'http://localhost:11777' }}
           rules_file_name: ".zap/rules.tsv"
           cmd_options: >-
             -z "-config scanner.maxScanDurationInMins=30"
@@ -268,3 +213,7 @@ jobs:
                 body,
               });
             }
+
+      - name: Teardown
+        if: always() && github.event.inputs.target_url == ''
+        run: docker compose down

--- a/scanner/tests/test_ci_security_gate.py
+++ b/scanner/tests/test_ci_security_gate.py
@@ -38,6 +38,7 @@ No network, no subprocess. Runs under pytest (CI) and `python3 -m unittest`.
 Does not import scanner/lib, so it does not affect the measured coverage gate.
 """
 
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -280,43 +281,98 @@ class TestDastFullScanSchedule(unittest.TestCase):
             "failure (parallels the dast-baseline pull_request guard).",
         )
 
-    def test_unset_target_is_surfaced_not_silently_skipped(self):
-        # Keeping the `schedule:` trigger is NOT enough: the scan job is gated on
-        # `vars.DAST_TARGET_URL != ''`, so with the variable unset the job is
-        # SKIPPED and the workflow conclusion is a clean `skipped`. Measured
-        # 2026-08-06: 42 consecutive nightly runs reported `skipped` after the
-        # variable was unset around 2026-06-25 — six weeks of ZERO automated DAST,
-        # with no red build anywhere, while the workflow name still promised
-        # nightly coverage. Actions has no `neutral` conclusion for a regular job,
-        # so the only honest signal is an artifact.
-        #
-        # Direction: PRESENCE of the escalation path. Scanned comment-stripped so a
-        # `#`-parked notice job cannot satisfy it (inert-guard class, ADR-001 §2).
+    def test_nightly_cannot_be_gated_into_silence(self):
+        """The scan must not be gated on a repo variable, and its target must not
+        depend on one being set.
+
+        HISTORY, and why the invariant moved (#399, 2026-08-26). The job used to
+        carry `if: … || vars.DAST_TARGET_URL != ''`. With the variable unset it
+        was SKIPPED, the workflow conclusion was a clean `skipped`, and nothing
+        was red — measured 2026-08-06: 42 consecutive nightly runs reported
+        `skipped` after the variable was unset around 2026-06-25, six weeks of
+        ZERO automated DAST, with `gh api .../actions/variables` returning
+        total_count: 0. Actions has no `neutral` conclusion for a regular job.
+
+        The previous version of this guard required a `coverage-notice` job to
+        make that state visible. The state is now impossible instead: the nightly
+        scans this repo's own dashboard container, so there is nothing to
+        configure and nothing to skip. A notice about a missing variable would
+        report "not running" on every night the scan ran fine, so requiring one
+        would now be requiring a lie.
+
+        Direction: ABSENCE of the configuration dependency. Re-adding a `vars.`
+        gate, or making the target read a variable, trips this.
+        """
         active = "\n".join(
             strip_inline_comment(ln)
             for ln in self.text.splitlines()
             if not ln.lstrip().startswith("#")
         )
-        self.assertRegex(
+        self.assertNotIn(
+            "vars.DAST_TARGET_URL",
             active,
-            r"(?m)^\s*coverage-notice\s*:",
-            "dast-full-scan.yml lost its `coverage-notice` job. Without it, an unset "
-            "DAST_TARGET_URL makes the nightly scan skip SILENTLY (clean `skipped`, "
-            "no red build) while the workflow still advertises nightly coverage. If "
-            "nightly DAST is intentionally paused, rename the workflow and drop the "
-            "claim in the same change — then update this guard.",
+            "dast-full-scan.yml reads `vars.DAST_TARGET_URL` again. That is the "
+            "construct that made 42 consecutive nightly runs report a clean "
+            "`skipped`: an unset variable either skips the job or points the scan "
+            "at whatever host a stale variable names. The nightly target is the "
+            "repo's own container; an authorized external target goes through "
+            "`workflow_dispatch`.",
+        )
+        self.assertNotRegex(
+            active,
+            r"(?m)^\s*if:.*vars\.",
+            "the scan job is gated on a repo variable again — a gate whose "
+            "unset state is a clean `skipped` rather than a failure.",
+        )
+        # Bound to the `target:` LINE, not to the file. A bare
+        # `assertIn("http://localhost:11777", active)` was satisfied by the
+        # `until curl -sf http://localhost:11777/` wait loop in the container-start
+        # step, so deleting the fallback from the target expression left this
+        # green — the inert-assertion class (ADR-001 §2), found by mutating it.
+        target_lines = [
+            ln for ln in active.splitlines() if re.match(r"^\s*target:\s*", ln)
+        ]
+        self.assertEqual(
+            len(target_lines),
+            1,
+            f"expected exactly one `target:` line, found {len(target_lines)}: "
+            f"{target_lines}",
         )
         self.assertIn(
-            "issues.create",
-            active,
-            "the `coverage-notice` job no longer opens an issue — a `core.warning` "
-            "alone is invisible, which is exactly the failure mode this guards.",
+            "http://localhost:11777",
+            target_lines[0],
+            "the scan's `target:` lost its local-container fallback, so an empty "
+            "`workflow_dispatch` input has nothing to scan and the nightly is back "
+            f"to depending on configuration. Line: {target_lines[0].strip()}",
         )
         self.assertIn(
-            "DAST_TARGET_URL",
+            "docker compose up -d dashboard",
             active,
-            "the notice job must read DAST_TARGET_URL to know whether coverage is "
-            "live; without it the notice cannot self-heal when the target returns.",
+            "nothing starts the container the scan targets, so the nightly would "
+            "scan a closed port and report a clean run.",
+        )
+
+    def test_external_target_input_is_not_required(self):
+        """`workflow_dispatch` must accept an EMPTY target.
+
+        `required: true` on the input would force every manual run to name an
+        external host — the opposite of the #399 decision, and the shape that
+        makes someone paste in a host they are not authorized to scan
+        (NIST SP 800-115). Empty means the local container.
+        """
+        active = "\n".join(
+            strip_inline_comment(ln)
+            for ln in self.text.splitlines()
+            if not ln.lstrip().startswith("#")
+        )
+        idx = active.find("target_url:")
+        self.assertNotEqual(idx, -1, "the `target_url` input is gone")
+        block = active[idx : idx + 400]
+        self.assertNotRegex(
+            block,
+            r"(?m)^\s*required:\s*true",
+            "`target_url` is `required: true` again, so a manual run cannot scan "
+            "the local container and must name an external host.",
         )
 
 


### PR DESCRIPTION
Closes #399 without pointing an active scan at anything we do not own.

## The state being fixed

The scan was gated on the `DAST_TARGET_URL` repo variable. With the variable unset the job was **skipped**, the workflow conclusion was a clean `skipped`, and nothing was red — so "DAST Full Scan (Nightly)" promised coverage it was not delivering.

Measured 2026-08-06: **42 consecutive nightly runs** reported `skipped` after the variable was unset around 2026-06-25 — six weeks of zero automated DAST, with `gh api .../actions/variables` returning `total_count: 0`.

## What it now does

The nightly scans `http://localhost:11777` — this repo's own dashboard container, started the same way `dast-baseline.yml` already starts it for pull requests. Nothing to configure, so nothing to skip.

`workflow_dispatch` still accepts a `target_url` for an authorized external run, but it is now **`required: false`** — an empty input means the local container. Forcing a value is the shape that gets someone to paste in a host they are not authorized to scan; an active full scan against infrastructure you do not own needs documented authorization (NIST SP 800-115), and a *default* target is what produced the `staging.example.com` incident (#283).

`vars.DAST_TARGET_URL` is deliberately **not read anywhere**. Reading it would restore the old failure mode by the back door: a stale variable silently redirecting the nightly at whatever host it names.

## `coverage-notice` is removed, and its invariant is now enforced directly

That job existed to make the silent-skip *visible* without deciding the underlying question. The question is decided — and a notice about a missing variable would report "not running" on every night the scan ran fine, so requiring one would now be requiring a lie.

`test_ci_security_gate.py` replaces it with the stronger property:

| assertion | mutant | result |
|---|---|---|
| no `vars.` gate on the job | re-add the gate | **FAIL** |
| `target:` keeps the local fallback | drop the fallback | **FAIL** |
| something starts the container | drop `docker compose up` | **FAIL** |
| input is not `required: true` | set it back | **FAIL** |

## Honest limit, stated because it is a real reduction

The nightly now scans a static page served by the repo's own nginx — **the same surface `dast-baseline.yml` already covers per PR**. The added signal is the active-attack ruleset over that surface, not new surface. Versus scanning a live staging deployment this is *less* coverage; it is traded for a run that actually happens and cannot scan someone else's host. Restoring a real target is one `workflow_dispatch` away once one exists and is authorized in writing.

`environment: staging` is kept for the external-target path, and annotated: it has **zero** protection rules today (verified via `gh api .../environments`), so it does not gate the nightly — but adding reviewers to it would make the localhost run wait for approval. Worth deciding deliberately rather than discovering.

## One of the four new assertions was inert, and mutation testing caught it

```console
$ # mutant: drop the localhost fallback from the target expression
17 passed        # <- guard stayed GREEN
```

`assertIn("http://localhost:11777", active)` was satisfied by the `until curl -sf http://localhost:11777/` wait loop in the container-start step — the token survived somewhere else in the file. Now bound to the `target:` line, with the line count asserted so a second `target:` cannot shadow it:

```console
$ # same mutant, after the fix
FAILED …::TestDastFullScanSchedule::test_nightly_cannot_be_gated_into_silence
```

## Verification

```console
$ python3 -m pytest scanner/tests/test_ci_*.py -q     # 976 passed
$ python3 -m pytest scanner/tests/ -q                 # 2606 passed, 11 skipped
$ ruff check --select E9,F scanner/tests/test_ci_security_gate.py   # All checks passed
```

Note for the reviewer: the workflow's own behaviour cannot be proven from a PR — `schedule` does not fire here, and the localhost path only executes on a real run. The first nightly after merge is the actual evidence, and #399 should stay open until one lands green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)