### PR TITLE
refactor(tests): the inline-handler guard scanned 11 of 23 dashboard sources

### DIFF
--- a/scanner/tests/_ci_guard_util.py
+++ b/scanner/tests/_ci_guard_util.py
@@ -1,5 +1,8 @@
 """
-Shared text-scanning helpers for the `test_ci_*.py` CI config regression guards.
+Shared text-scanning helpers for the `test_ci_*.py` CI config regression guards,
+plus the two dashboard source guards (`test_dashboard_no_inline_handlers.py`,
+`test_dashboard_style_nonce.py`) which share this module's comment strippers and
+the canonical `dashboard_source_files()` enumeration.
 
 WHY THIS FILE EXISTS
 --------------------
@@ -39,6 +42,7 @@ root):
 
 import json
 import re
+import subprocess
 from glob import glob
 from pathlib import Path
 
@@ -124,6 +128,60 @@ def workflow_and_action_files() -> list:
     for name in ("action.yml", "action.yaml"):
         out += glob(str(ACTION_DIR / "**" / name), recursive=True)
     return sorted(out)
+
+
+# Globs covering every source that contributes markup to the two CSP'd dashboard
+# pages. Matched against `git ls-files`, so a pattern that stops matching shows up
+# as a shrinking file count rather than as silence.
+DASHBOARD_SOURCE_GLOBS = (
+    "scanner/lib/dashboard*.html",
+    "scanner/lib/dashboard*.py",
+    "scanner/lib/dashboard_*.py",
+    "claudesec-asset-dashboard.html",
+)
+
+
+def tracked_files() -> list:
+    """Repo-relative paths of every git-TRACKED file.
+
+    Tracked, NOT the filesystem. A gitignored or untracked local file is not what
+    CI builds from, so scanning the filesystem makes a guard's verdict depend on
+    the machine it runs on — the asymmetry that produced a red CI over a green
+    local run when `docs/architecture/*.svg` (gitignored) flipped the dashboard's
+    arch-diagram render branch.
+
+    Raises rather than returning `[]` when git is unavailable: an empty list makes
+    every downstream scan pass vacuously, and a guard that cannot enumerate its
+    inputs must fail loudly, not quietly agree.
+    """
+    out = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "ls-files"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in out.stdout.splitlines() if line]
+
+
+def dashboard_source_files() -> list:
+    """Tracked sources that emit dashboard markup, de-duplicated and sorted.
+
+    CANONICAL HOME — do not re-glob this per guard. Two guards need the same set
+    (`test_dashboard_no_inline_handlers.py` for dead `on*=` handlers,
+    `test_dashboard_style_nonce.py` for un-nonced `<style>` tags), and the first
+    of them carried a HAND-WRITTEN list of eleven paths that was missing twelve
+    files, including `dashboard_html_network.py` and `dashboard_html_helpers.py`
+    (both plainly emit markup) and `dashboard_template.py` — which held a real
+    un-nonced `<style>` that CI caught and that guard could not see. Measured
+    2026-08-27: the glob is a strict superset, 11 -> 23 files, nothing dropped.
+
+    A list is a thing to forget; a glob is a thing to widen.
+    """
+    tracked = tracked_files()
+    hits = set()
+    for pattern in DASHBOARD_SOURCE_GLOBS:
+        hits.update(p for p in tracked if Path(p).match(pattern))
+    return sorted(hits)
 
 
 # `uses:` bare OR quoted, with an optionally QUOTED VALUE.

--- a/scanner/tests/test_dashboard_no_inline_handlers.py
+++ b/scanner/tests/test_dashboard_no_inline_handlers.py
@@ -47,6 +47,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LIB_DIR = REPO_ROOT / "scanner" / "lib"
 sys.path.insert(0, str(LIB_DIR))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from _ci_guard_util import dashboard_source_files  # noqa: E402
 
 # Matches an inline HTML event-handler attribute: whitespace, then `on<name>`,
 # then `=`, then an opening quote. `content=`, `font=`, `data-*` etc. never begin
@@ -54,23 +56,56 @@ sys.path.insert(0, str(LIB_DIR))
 # no `=` after the handler name so it never matches either.
 INLINE_HANDLER_RE = re.compile(r"""\son[a-z]+\s*=\s*["']""", re.IGNORECASE)
 
-# Every source that emits dashboard markup, as a REPO-RELATIVE path. Repo-relative
-# (not bare names resolved under LIB_DIR) so the repo-root asset dashboard can be
-# scanned by the same rule instead of needing a `../..` escape hatch.
-_SOURCE_FILES = [
-    "scanner/lib/dashboard-template.html",
-    "scanner/lib/dashboard-gen.py",
-    "scanner/lib/dashboard_html_overview.py",
-    "scanner/lib/dashboard_html_arch.py",
-    "scanner/lib/dashboard_html_owasp.py",
-    "scanner/lib/dashboard_html_compliance.py",
-    "scanner/lib/dashboard_html_builders.py",
-    "scanner/lib/dashboard_html_sections.py",
-    "scanner/lib/dashboard_html_audit_points.py",
-    "scanner/lib/dashboard_html_audit_sources.py",
-    # ISMS asset dashboard: repo-root template, same CSP, same delegation model.
-    "claudesec-asset-dashboard.html",
-]
+# Sources that MUST be scanned, whatever the glob returns. This is a vacuity
+# floor, not the source list: `_source_files()` is the list. Each entry is here
+# because it is known to emit markup, so a glob that stops matching it is a
+# silent coverage loss rather than an error.
+_REQUIRED_SOURCES = frozenset(
+    {
+        "scanner/lib/dashboard-template.html",
+        "scanner/lib/dashboard-gen.py",
+        "scanner/lib/dashboard_html_builders.py",
+        "scanner/lib/dashboard_html_sections.py",
+        "scanner/lib/dashboard_html_owasp.py",
+        "scanner/lib/dashboard_html_audit_points.py",
+        "scanner/lib/dashboard_html_audit_sources.py",
+        # Missing from the hand-written list this replaced, and both emit markup.
+        "scanner/lib/dashboard_html_network.py",
+        "scanner/lib/dashboard_html_helpers.py",
+        # Held a real un-nonced `<style>` that CI caught and this guard could not
+        # see, because the hand-written list did not name it.
+        "scanner/lib/dashboard_template.py",
+        # ISMS asset dashboard: repo-root template, same CSP, same delegation model.
+        "claudesec-asset-dashboard.html",
+    }
+)
+
+# The hand-written list this replaced held 11 paths; the glob finds 23. Floor set
+# just under, so adding a builder stays green and a glob that silently narrows
+# does not.
+_MIN_SOURCES = 20
+
+
+def _source_files() -> list:
+    """Every source that emits dashboard markup, as REPO-RELATIVE paths.
+
+    Was a hand-written list of 11 entries until 2026-08-27. It was missing TWELVE
+    files — including `dashboard_html_network.py` and `dashboard_html_helpers.py`,
+    which plainly emit markup, and `dashboard_template.py`, which held a real
+    un-nonced `<style>` that CI caught while this guard read green over it. The
+    list had been correct when written and simply was not extended as builders
+    were added, which is the failure mode of every such list: nothing about a
+    green run distinguishes "scanned and clean" from "never looked".
+
+    Enumeration is shared with `test_dashboard_style_nonce.py` via
+    `_ci_guard_util.dashboard_source_files()` rather than re-globbed here, so the
+    two guards cannot drift apart in what they consider a dashboard source.
+
+    Repo-relative (not bare names resolved under LIB_DIR) so the repo-root asset
+    dashboard is scanned by the same rule instead of needing a `../..` escape
+    hatch.
+    """
+    return dashboard_source_files()
 
 
 # The two elements whose bodies leave the haystack. These are the ONLY spans
@@ -576,7 +611,7 @@ class TestStripPyComments(unittest.TestCase):
         # Regression pin on the nine affected lines: the `href="#"` markup must
         # survive stripping in every builder that emits it.
         seen = 0
-        for name in _SOURCE_FILES:
+        for name in _source_files():
             if not name.endswith(".py"):
                 continue
             scan = _scannable(name, (REPO_ROOT / name).read_text(encoding="utf-8"))
@@ -589,10 +624,96 @@ class TestStripPyComments(unittest.TestCase):
         )
 
 
+class TestSourceEnumeration(unittest.TestCase):
+    """The glob replaced a hand-written list; these are the checks that make the
+    replacement safe. Without them a narrowed glob turns every scan below vacuous
+    and the suite still reads green — the same silence the old list produced, just
+    reached a different way."""
+
+    def test_enough_sources_are_found(self):
+        found = _source_files()
+        self.assertGreaterEqual(
+            len(found),
+            _MIN_SOURCES,
+            f"only {len(found)} dashboard source(s) enumerated (floor "
+            f"{_MIN_SOURCES}): {found}. The glob in "
+            "`_ci_guard_util.DASHBOARD_SOURCE_GLOBS` is matching too little, so "
+            "the handler scan is passing over files it never opened. If a builder "
+            "was genuinely deleted, lower the floor here and say which.",
+        )
+
+    def test_every_required_source_is_enumerated(self):
+        missing = sorted(_REQUIRED_SOURCES - set(_source_files()))
+        self.assertEqual(
+            missing,
+            [],
+            f"known markup-emitting source(s) not enumerated: {missing}. These "
+            "are pinned individually because a count floor cannot tell WHICH file "
+            "fell out of the glob, and the file that matters most is the one "
+            "nobody notices.",
+        )
+
+    def test_enumerated_sources_all_exist(self):
+        """`git ls-files` lists the index; a path in the index with no file on
+        disk would make `read_text` raise mid-scan."""
+        for name in _source_files():
+            self.assertTrue(
+                (REPO_ROOT / name).is_file(),
+                f"enumerated source is not on disk: {name}",
+            )
+
+    def test_glob_covers_the_old_hand_written_list(self):
+        """No-regression direction: the glob must be a strict SUPERSET.
+
+        Pins the eleven paths the list carried, so a future narrowing of the glob
+        cannot quietly drop coverage that already existed. Measured 2026-08-27:
+        11 -> 23 files, nothing dropped.
+        """
+        previously_scanned = {
+            "scanner/lib/dashboard-template.html",
+            "scanner/lib/dashboard-gen.py",
+            "scanner/lib/dashboard_html_overview.py",
+            "scanner/lib/dashboard_html_arch.py",
+            "scanner/lib/dashboard_html_owasp.py",
+            "scanner/lib/dashboard_html_compliance.py",
+            "scanner/lib/dashboard_html_builders.py",
+            "scanner/lib/dashboard_html_sections.py",
+            "scanner/lib/dashboard_html_audit_points.py",
+            "scanner/lib/dashboard_html_audit_sources.py",
+            "claudesec-asset-dashboard.html",
+        }
+        lost = sorted(previously_scanned - set(_source_files()))
+        self.assertEqual(
+            lost,
+            [],
+            f"the glob no longer covers {lost}, which the hand-written list this "
+            "replaced did scan. Converting a list to a glob must only ever widen "
+            "coverage.",
+        )
+
+    def test_scan_actually_reads_content(self):
+        """Anti-tautology: `_scannable` must return real text for these files.
+
+        A `_source_files()` full of paths whose haystack comes back empty passes
+        the handler scan exactly like a clean repo does.
+        """
+        total = 0
+        for name in _source_files():
+            total += len(
+                _scannable(name, (REPO_ROOT / name).read_text(encoding="utf-8"))
+            )
+        self.assertGreater(
+            total,
+            100_000,
+            f"the enumerated sources yielded only {total} scannable characters; "
+            "the strippers are eating the haystack.",
+        )
+
+
 class TestNoInlineHandlersInSource(unittest.TestCase):
     def test_no_inline_handlers_in_builder_sources(self):
         offenders = []
-        for name in _SOURCE_FILES:
+        for name in _source_files():
             path = REPO_ROOT / name
             self.assertTrue(path.is_file(), f"builder source missing: {path}")
             scan = _scannable(name, path.read_text(encoding="utf-8"))
@@ -649,7 +770,7 @@ class TestNoInlineHandlersInRenderedMarkup(unittest.TestCase):
 
 # Bare test_* functions so pytest function-collection also runs the core checks.
 def test_source_has_no_inline_handlers():
-    for name in _SOURCE_FILES:
+    for name in _source_files():
         scan = _scannable(name, (REPO_ROOT / name).read_text(encoding="utf-8"))
         assert not INLINE_HANDLER_RE.search(scan), f"inline handler in {name}"
 

--- a/scanner/tests/test_dashboard_style_nonce.py
+++ b/scanner/tests/test_dashboard_style_nonce.py
@@ -36,9 +36,15 @@ sees the branch that ran. This guard is branch-INDEPENDENT: it reads source, so 
 DIRECTION
 ---------
 - Sources are enumerated by GLOB over `git ls-files`, never a hand-maintained
-  list. The sibling `test_dashboard_no_inline_handlers.py` carries an explicit
-  `_SOURCE_FILES` of ten paths and `scanner/lib/dashboard_template.py` — the file
-  that held this very defect — is not among them. A list is a thing to forget.
+  list, via the canonical `_ci_guard_util.dashboard_source_files()` shared with
+  `test_dashboard_no_inline_handlers.py`. That sibling carried a hand-written
+  `_SOURCE_FILES` of eleven paths until 2026-08-27, and
+  `scanner/lib/dashboard_template.py` — the file that held this very defect — was
+  not among them; nor were `dashboard_html_network.py` or
+  `dashboard_html_helpers.py`, which plainly emit markup. Converting it to this
+  same glob took coverage 11 -> 23 files and was measured green-while-defeated
+  first: a live `onclick="alert(1)"` planted in `dashboard_template.py` left the
+  old guard at 32 passed and fails the new one. A list is a thing to forget.
 - `git ls-files`, not the filesystem: a gitignored or untracked local file is not
   what CI builds from, and scanning it makes results differ by machine, which is
   the exact asymmetry above.
@@ -46,20 +52,22 @@ DIRECTION
   the policy reverts to `'unsafe-inline'`, and dropping `style-src-attr` unstyles
   the page without producing a single violation report.
 
-stdlib-only (`re`, `subprocess` for `git ls-files`, `pathlib`, `unittest`). No
-network. Runs under pytest and `python3 -m unittest`.
+stdlib-only (`re`, `pathlib`, `unittest`); the `git ls-files` enumeration lives
+in `_ci_guard_util`. No network. Runs under pytest and `python3 -m unittest`.
 
 OWASP A05 (Security Misconfiguration); OWASP Secure Headers Project (CSP).
 """
 
 import re
-import subprocess
 import sys
 import unittest
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from _ci_guard_util import strip_html_comments  # noqa: E402
+from _ci_guard_util import (  # noqa: E402
+    dashboard_source_files,
+    strip_html_comments,
+)
 
 # Reused, NOT re-implemented. `_strip_py_comments` is tokenizer-based and already
 # carries the fix for the hazard a second copy would walk straight into: a
@@ -81,43 +89,10 @@ DASHBOARD_PAGES = (
     "claudesec-asset-dashboard.html",
 )
 
-# Globs covering every source that contributes markup to those pages. Matched
-# against `git ls-files` output.
-SOURCE_GLOBS = (
-    "scanner/lib/dashboard*.html",
-    "scanner/lib/dashboard*.py",
-    "scanner/lib/dashboard_*.py",
-    "claudesec-asset-dashboard.html",
-)
-
 # `<style` followed by anything up to the closing `>` of the OPENING tag. `[^>]*`
 # rather than a greedy match so a later `>` in the stylesheet body cannot extend
 # the span past the tag it is meant to describe.
 STYLE_OPEN_TAG_RE = re.compile(r"<style\b[^>]*>", re.IGNORECASE)
-
-
-def tracked_files() -> list:
-    """Repo-relative paths of every git-TRACKED file.
-
-    Tracked, not on-disk: an untracked or gitignored file is not what CI builds
-    from, so scanning it would make this guard's verdict depend on the machine.
-    """
-    out = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "ls-files"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return [line for line in out.stdout.splitlines() if line]
-
-
-def dashboard_sources() -> list:
-    """Tracked files matching any SOURCE_GLOBS pattern, de-duplicated and sorted."""
-    tracked = tracked_files()
-    hits = set()
-    for pattern in SOURCE_GLOBS:
-        hits.update(p for p in tracked if Path(p).match(pattern))
-    return sorted(hits)
 
 
 def strip_comments_for(rel: str, text: str) -> str:
@@ -163,7 +138,7 @@ class TestDashboardSourceEnumeration(unittest.TestCase):
         `dashboard_template.py` — the one the hand-maintained list in
         `test_dashboard_no_inline_handlers.py` omits.
         """
-        sources = dashboard_sources()
+        sources = dashboard_source_files()
         self.assertGreaterEqual(
             len(sources),
             10,
@@ -179,7 +154,8 @@ class TestDashboardSourceEnumeration(unittest.TestCase):
             self.assertIn(
                 required,
                 sources,
-                f"{required} is no longer matched by SOURCE_GLOBS. It emits "
+                f"{required} is no longer matched by "
+                "_ci_guard_util.DASHBOARD_SOURCE_GLOBS. It emits "
                 "dashboard markup, so a `<style>` added to it would go unchecked.",
             )
 
@@ -190,7 +166,7 @@ class TestDashboardSourceEnumeration(unittest.TestCase):
         every assertion in this file.
         """
         total = 0
-        for rel in dashboard_sources():
+        for rel in dashboard_source_files():
             total += len(STYLE_OPEN_TAG_RE.findall(source_text(rel)))
         self.assertGreaterEqual(
             total,
@@ -204,7 +180,7 @@ class TestDashboardSourceEnumeration(unittest.TestCase):
 class TestEveryStyleTagIsNonced(unittest.TestCase):
     def test_no_unnonced_style_tag_in_any_source(self):
         offenders = {}
-        for rel in dashboard_sources():
+        for rel in dashboard_source_files():
             bad = unnonced_style_tags(source_text(rel))
             if bad:
                 offenders[rel] = bad


### PR DESCRIPTION
`_SOURCE_FILES` in `test_dashboard_no_inline_handlers.py` was a hand-written list
of eleven paths. It was correct when written and simply was not extended as
builders were added, so it had drifted to missing **twelve** files — including
`dashboard_html_network.py` and `dashboard_html_helpers.py`, which plainly emit
markup, and `dashboard_template.py`, which held a real un-nonced `<style>` that
CI caught in #500 while this guard read green over the same file.

Nothing about a green run distinguished *"scanned and clean"* from *"never
looked"*.

## Measured green-while-defeated before changing anything

A live `onclick="alert(1)"` planted on a `<rect>` in `dashboard_template.py`:

| guard | result |
|---|---|
| old (hand-written list, from `origin/main`) | **32 passed** — defeated, reads green |
| new (glob) | **2 failed** |

That is the whole justification. This is not tidying: the old list was not
enforcing what the file's own docstring claims it enforces.

## Strict superset, verified before switching

```
current list : 11 files
glob matches : 23 files
dropped      : none
new findings : none  (all 12 added files are clean under INLINE_HANDLER_RE)
```

So coverage roughly doubles with no remediation diff.
`test_glob_covers_the_old_hand_written_list` pins the eleven former paths, so a
future narrowing of the glob cannot quietly drop coverage that already existed.

## Enumeration is shared, not duplicated

`dashboard_source_files()` + `tracked_files()` land in `_ci_guard_util.py` — the
canonical helper home — and **both** guards import them.
`test_dashboard_style_nonce.py` (added in #500) had its own copy of the same
glob, which is exactly how #471 fixed one of two copies of a loader and left the
guard importing only the fixed one. Its local `SOURCE_GLOBS`, `tracked_files`
and `dashboard_sources` are deleted in favour of the shared pair.

`git ls-files`, not the filesystem: a gitignored file is not what CI builds from,
and scanning it makes a verdict depend on the machine — the asymmetry that made
#500 green locally and red in CI. `tracked_files()` **raises** rather than
returning `[]` when git is unavailable, because an empty list makes every
downstream scan pass vacuously.

## Guarding the guard

A glob can narrow as silently as a list can go stale, so `TestSourceEnumeration`
adds five checks:

- a **count floor** (20, just under the current 23);
- an individually pinned **`_REQUIRED_SOURCES`** set — a count cannot say *which*
  file fell out, and the one that matters is the one nobody notices;
- an **on-disk existence** check (`git ls-files` lists the index);
- the **no-regression superset** check above;
- an **anti-tautology canary**: the enumerated sources must yield >100k scannable
  characters, because a source list whose haystack comes back empty passes the
  handler scan exactly like a clean repo does.

Narrowing the shared glob to `dashboard_html_*.py` fails **6 tests across both
guards**.

## Test plan

- [x] `pytest scanner/` — **2659 passed, 11 skipped**
- [x] Dual-runner: `python3 -m unittest` — 49 tests for the two guards
- [x] `ci-guards` discover path — **1010 tests OK**
- [x] `ruff check .` at CI settings — 170 files, all checks passed
- [x] Green-while-defeated counterfactual measured against `origin/main`
- [x] Narrowed-glob mutation fails 6 tests
- [x] Test-only: `git diff --name-only` touches nothing outside `scanner/tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)