### PR TITLE
fix(tests): `branches:` existed — just not on the trigger that publishes

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -347,38 +347,84 @@ The largest block in this log and the one whose *method* matters more than its d
   "11 shared functions" were both wrong (real: 15 and 12) — multi-line tuples and structural
   clones need `ast.walk`. And **grep for other implementations before closing a fix.**
 
+### Cycle #497–#504 — the two ways a scheduled check stops, and attribution (merged 2026-08-26 → 09-01)
+
+- **A gate that never fires reads exactly like one that found nothing.** The nightly DAST was
+  gated on an unset `DAST_TARGET_URL`, so 42 consecutive nights reported a clean `skipped`
+  (#399/#497). The gate is gone — the nightly scans this repo's own dashboard container, the
+  same target `dast-baseline.yml` already uses — so it cannot skip.
+- **Removing the skip left the quieter half open: a schedule that never FIRES.** No run at
+  all, so nothing is skipped, nothing is red, and an Actions list sorted by recency still
+  shows the last green run. Five real causes (60-day inactivity shutdown, `gh workflow
+  disable`, best-effort cron — a ~10h delay is on record in run `33070461602` — rename/
+  default-branch change, all-runs-fail). `dast-freshness-watch.yml` (#502) watches the AGE of
+  the newest **`event=schedule`** run and self-heals into one issue. Three load-bearing
+  choices: `event=schedule` only (a `workflow_dispatch` proves someone pressed a button, not
+  that cron is alive); it also runs on `push` to `main` (a cron-only watcher shares the exact
+  failure mode it watches); 48h not 24h (a threshold at the cron period trips on ordinary
+  jitter, and a notifier that cries wolf gets muted — silence again).
+  **Its first commit was INERT**: `listWorkflowRuns` is an Actions-API read and the job had no
+  `actions: read`. Reviewing the logic and not the token grant is how a watcher ships dead.
+- **Guard-scoping, round N: presence is not attribution.** `test_ci_npm_publish.py` asserted
+  `branches:` and `branches: … main` against the whole comment-stripped `npm-publish.yml`.
+  Comment-stripping (#383) answers the *commented-out* regression only. Measured 2026-09-01,
+  PyYAML-confirmed: leave `push:` with just `tags:` and move `branches: - main` to a new
+  `pull_request:` — the version-bump auto-release is dead (`push -> {'tags': ['v*']}`) and
+  **1181 CI guards repo-wide stay GREEN**. Two sibling shapes were equally invisible (`push:`
+  deleted with the filter re-planted elsewhere; `branches:` → its opposite `branches-ignore:`).
+  Fixed by the documented discipline — scope to the block, then assert a COUNT of exactly one
+  — with `trigger_block()` promoted into `_ci_guard_util` so `test_ci_pr_trigger_scope.py`'s
+  copy of that logic became a thin binding rather than a second implementation.
+- **A guard's mutation self-tests must drive the real detector.** The old
+  `TestAutoReleaseTriggerScoping` asserted against a re-implementation of the pattern, so it
+  could not have noticed the block scoping was missing. Same family as #485's `assertIs`
+  identity guard: pin the object the guard actually calls.
+- Related sweeps in the same window: the inline-handler guard scanned 11 of 23 dashboard
+  sources because `_SOURCE_FILES` was hand-written (#501 → glob over `git ls-files`), and four
+  guard checks passed while the control they protect was gone (#503).
+
 ## Open Backlog
 
-Derived from `gh issue list` + verified repo state on 2026-08-26. **Verify before working an
-item** — this list rotted twice (see the maintenance note below).
+Re-derived from `gh issue list` + verified repo state on **2026-09-01**. **Verify before
+working an item** — this list rotted twice before, and the previous revision (2026-08-26)
+listed FOUR already-closed issues (#295, #297, #381, #399) as open.
 
-- **`#295` prowler / alpine freeze — DONE, needs closing, not working.** Verified 2026-08-26:
-  `Dockerfile` is on `alpine:3.23` with `PROWLER_VERSION=5.39.1` and its comment block
-  already records why the alert does not lift the freeze. **The alert was about the wrong
-  boundary:** prowler moving `<3.13` → `<3.14` does not help because **no alpine minor ships
-  py3.13** — alpine jumps 3.12 → 3.14 at the 3.23/3.24 line, and py3.14 is outside prowler's
-  range, so 3.24 reintroduces #220 (build green, `prowler -v` crashes on the backtracked
-  3.11.3/pydantic-v1). The real unblock condition is **prowler accepting py3.14**.
-- **`#405` branch-protection drift-watch is not running** (`REPO_ADMIN_TOKEN` missing). The
-  workflow self-heals into this issue rather than reporting green (#396), so the issue IS the
-  alert — it needs a token, not a code fix.
-- **`#399` DAST nightly full scan is not running** (`DAST_TARGET_URL` unset). Same shape as
-  #405: deliberate, self-reported (#397). Set the repo variable to an authorized target to
-  re-enable; do not point CI at a real external target without written authorization.
-- **`#381` lychee monthly sweep found redirects / link rot.** Use the
-  `lychee-redirect-triage` skill. Remember CI accepts `100..=599`, so a 404 passes.
-- **`#297` quarterly ADR-001 guard adversarial audit due.** The recurring cadence item. Its
-  Class-2 backlog is empty; what it exists for now is the NEXT round of shapes.
+**Closed since the last revision — do NOT re-propose as open:** `#295` (prowler/alpine
+freeze), `#297` (quarterly ADR-001 audit), `#381` (lychee sweep), `#399` (DAST nightly not
+running). Check with `gh issue list --state open` before trusting any entry below.
+
+- **`#405` branch-protection drift-watch is not running** (`REPO_ADMIN_TOKEN` missing).
+  **BLOCKED ON A HUMAN — there is no code fix.** The workflow self-heals into this issue
+  rather than reporting green (#396), so the issue IS the alert, and it re-confirms itself on
+  every scheduled run (last 2026-08-31T21:08). Unblock: a fine-grained PAT scoped to this repo
+  with **Administration: read**, stored as the `REPO_ADMIN_TOKEN` repo secret; the next clean
+  run closes the issue. Check: `gh run list --workflow=protection-drift-watch.yml` runs green
+  either way, so the ISSUE state is the signal, not the run conclusion.
+- **`#498` ZAP full-scan tracker — the BODY is stale, the comments are current.** The nightly
+  reuses one issue and **appends a comment**; it never rewrites the body. So #498's body is
+  still the 2026-08-26 snapshot listing style-src `unsafe-inline` + COEP/COOP/CORP as live,
+  while its own 2026-08-28 comment reports all four under **"Resolved Alerts"** (fixed by
+  #500 on 08-27). Everything still open on it is ZAP INFO-tier: suspicious comments,
+  storable/cacheable content, User Agent Fuzzer. The `.../'+safeHref(hubUrl)+'` "URL" is ZAP
+  scraping a JS string literal out of inline `<script>` source — not an endpoint. Check the
+  NEWEST comment, never the body. The body-never-refreshed behaviour is itself worth fixing:
+  a tracker that shows fixed MEDIUMs as live is the red-while-fixed twin of this repo's
+  green-while-defeated class.
 - **`#39` ISMS-P 29 FAIL controls prioritised remediation plan** and **`#15` incident-response
   process 65% → 80%** are product/content work, not CI.
 - **`#68` ZAP baseline** is the intentional single-tracker issue — keep it open.
-- **ruff ruleset widening** — 548 findings behind `BLE001`/`S110` etc. Changes a required
-  check; needs a decision, not a cleanup pass. See Cycle #469.
-- **zscaler `_unreachable` `reason` is still write-only.** Now unblocked (#472 merged):
-  `transport_error` / `permission_denied` / `unexpected_payload` / `http_error` are produced
-  in `scanner/lib/zscaler-api.py` and no consumer reads them, so `scanner/checks/saas/
-  zscaler.sh` still prints "RBA restricted" for what may be a DNS failure. Also outstanding
-  from that review: `_unreachable`'s docstring says "the three states" then lists four, and
+- **`#12` Zscaler MCP integration**, **`#18` GitHub Projects board**, **`#20` marketplace
+  plugin update** are `enhancement`-labelled product asks, not correctness work.
+- **ruff ruleset widening** — `python-lint` is in `lint-gate.needs`, so widening `select`
+  changes a REQUIRED check; it needs a decision, not a cleanup pass (see Cycle #469). Measure,
+  don't quote a number: `ruff check --isolated --select BLE001,S110 --statistics scanner/
+  scripts/` (61 + 21 on 2026-09-01).
+- **zscaler `_unreachable` `reason` is still write-only** (re-verified 2026-09-01: produced at
+  `scanner/lib/zscaler-api.py:90-93`, zero consumers under `scanner/checks/` or `scripts/`).
+  Unblocked since #472 merged. Four distinct reasons are recorded and none is read, so
+  `scanner/checks/saas/zscaler.sh:81` still prints "RBA restricted" for what may be a DNS
+  failure — a diagnosis the data already contradicts. Also outstanding from that review:
+  `_unreachable`'s docstring says "the three states" then lists four, and
   `_load_saas_sso_stats` rejects the whole file if **any** `saas` entry is a non-dict
   (confirm deliberate before changing).
 - **`MEMORY.md` maintenance** — this file went **~185 PRs stale** once (#470), and then the

--- a/scanner/tests/_ci_guard_util.py
+++ b/scanner/tests/_ci_guard_util.py
@@ -515,6 +515,55 @@ def extract_on_block(text: str) -> str:
     return "\n".join(body)
 
 
+_TRIGGER_KEY_RE_CACHE = {}
+
+
+def trigger_block(on_block: str, trigger: str) -> str:
+    """The content nested under ONE trigger key inside an `on:` block.
+
+    `on_block` is the output of `extract_on_block`, so whole-line comments and
+    trailing inline comments are already gone and a prose line naming a trigger
+    cannot open a block here.
+
+    Membership is decided by INDENTATION relative to the trigger key, and the
+    block ends at the first non-blank line indented at or above it — a sibling
+    trigger (`push:`, `schedule:`, ...) ends it. A flow-style value on the key
+    line itself (`push: {branches: [main]}`) is captured too, so that form
+    cannot slip past a block-only scan.
+
+    The key is matched bare OR quoted via `yaml_key_pattern`, and the `:` is
+    required immediately after the name, so `pull_request_target:` is never
+    attributed to `pull_request:`.
+
+    Returns "" when the trigger is absent — callers MUST assert the trigger
+    exists separately, or every check against the empty block passes vacuously.
+
+    Shared because a whole-`on:`-block scan proves a token EXISTS, never that it
+    belongs to the trigger that fires: moving `branches: - main` from `push:` to
+    `pull_request:` killed npm-publish.yml's version-bump auto-release with all
+    1181 CI guards green (measured 2026-09-01). Scope to the block, then count.
+    """
+    key_re = _TRIGGER_KEY_RE_CACHE.get(trigger)
+    if key_re is None:
+        key_re = re.compile(rf"^(\s*){yaml_key_pattern(trigger)}:\s*(.*)$")
+        _TRIGGER_KEY_RE_CACHE[trigger] = key_re
+    body, indent = [], None
+    for line in on_block.splitlines():
+        if indent is None:
+            m = key_re.match(line)
+            if m:
+                indent = len(m.group(1))
+                if m.group(2).strip():
+                    body.append(m.group(2))  # flow-style value on the key line
+            continue
+        if not line.strip():
+            continue
+        if len(line) - len(line.lstrip()) <= indent:
+            break  # dedent to a sibling trigger
+        body.append(line)
+    return "\n".join(body)
+
+
 # A mapping key at the start of a line, bare or quoted, capturing the key NAME.
 #
 # Deliberately generic rather than composed from `yaml_key_pattern`: that

--- a/scanner/tests/test__ci_guard_util.py
+++ b/scanner/tests/test__ci_guard_util.py
@@ -67,6 +67,7 @@ from _ci_guard_util import (  # noqa: E402
     strip_inline_comment,
     strip_inline_comment_sh,
     top_level_jobs,
+    trigger_block,
     uses_refs,
     workflow_and_action_files,
     yaml_key_pattern,
@@ -279,6 +280,55 @@ class TestExtractOnBlock(unittest.TestCase):
     def test_flow_style_and_quoted_on_key(self):
         self.assertIn("pull_request", extract_on_block("on: [push, pull_request]  # ci\njobs: {}"))
         self.assertIn("schedule", extract_on_block("'on':\n  schedule:\n    - cron: '0 0 * * *'\njobs: {}"))
+
+
+class TestTriggerBlock(unittest.TestCase):
+    """Attribution, not presence: which trigger a filter key BELONGS to."""
+
+    _ON = ("on:\n"
+           "  push:\n    branches:\n      - main\n    tags: ['v*']\n"
+           "  pull_request:\n    paths: ['**.md']\n"
+           "jobs: {}\n")
+
+    def _on(self, text=None):
+        return extract_on_block(text if text is not None else self._ON)
+
+    def test_returns_only_the_named_triggers_children(self):
+        block = trigger_block(self._on(), "push")
+        self.assertIn("branches:", block)
+        self.assertIn("tags:", block)
+        self.assertNotIn("paths:", block, "a sibling trigger's key leaked in")
+
+    def test_sibling_trigger_ends_the_block(self):
+        self.assertNotIn("branches:", trigger_block(self._on(), "pull_request"))
+
+    def test_absent_trigger_returns_empty(self):
+        # The vacuity contract: callers MUST assert the trigger exists, because
+        # every check against "" passes.
+        self.assertEqual(trigger_block(self._on(), "schedule"), "")
+
+    def test_flow_style_value_on_the_key_line_is_captured(self):
+        wf = "on:\n  push: {branches: [main]}\njobs: {}"
+        self.assertIn("branches:", trigger_block(self._on(wf), "push"))
+
+    def test_quoted_trigger_key_is_matched(self):
+        wf = "on:\n  \"push\":\n    branches: [main]\njobs: {}"
+        self.assertIn("branches:", trigger_block(self._on(wf), "push"))
+
+    def test_longer_trigger_name_is_not_matched(self):
+        # `pull_request_target:` is a different trigger; the `:` must follow the
+        # name immediately or its filters get attributed to `pull_request:`.
+        wf = "on:\n  pull_request_target:\n    branches: [main]\njobs: {}"
+        self.assertEqual(trigger_block(self._on(wf), "pull_request"), "")
+
+    def test_comment_line_does_not_end_the_block(self):
+        wf = "on:\n  push:\n    tags: ['v*']\n    # regrouped\n    branches: [main]\njobs: {}"
+        self.assertIn(
+            "branches:",
+            trigger_block(self._on(wf), "push"),
+            "a comment truncated the block — every key after it went invisible "
+            "(the #419 shape).",
+        )
 
 
 class TestTopLevelJobs(unittest.TestCase):

--- a/scanner/tests/test_ci_npm_publish.py
+++ b/scanner/tests/test_ci_npm_publish.py
@@ -49,6 +49,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _ci_guard_util import (  # noqa: E402
     apply_regex_mutation,
     block_ends_at,
+    extract_on_block,
+    trigger_block,
     yaml_key_pattern,
 )
 from _ci_guard_util import strip_inline_comment as _strip_comment  # noqa: E402
@@ -56,6 +58,39 @@ from _ci_guard_util import strip_inline_comment as _strip_comment  # noqa: E402
 # scanner/tests/this_file -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 NPM_PUBLISH = REPO_ROOT / ".github" / "workflows" / "npm-publish.yml"
+
+# `branches:` bare OR quoted, anchored to a mapping key so the substring inside a
+# value (or the longer `branches-ignore`) is not counted, and matched in both
+# block and flow style (`{branches: [main]}` after a `{` or `,`).
+# The boundary is a fixed-width negative lookbehind rather than a consuming
+# `(?:^|[\s{,])`, so `findall` returns the key itself and two adjacent keys
+# cannot overlap-swallow each other's delimiter.
+_BRANCHES_KEY_RE = re.compile(
+    rf"(?<![^\s{{,]){yaml_key_pattern('branches')}\s*:"
+)
+_BRANCHES_MAIN_RE = re.compile(
+    rf"{yaml_key_pattern('branches')}\s*:\s*(?:-\s*|\[\s*)['\"]?main\b"
+)
+
+
+def push_trigger_block(text: str) -> str:
+    """The body of the top-level `on:` -> `push:` trigger, or "" if absent."""
+    return trigger_block(extract_on_block(text), "push")
+
+
+def push_branch_filter_keys(text: str) -> list:
+    """Every `branches:` key declared under `on: push:` — the auto-release filter.
+
+    Scoped to the `push:` block on purpose. The predecessor scanned the whole
+    comment-stripped workflow, which answers "does `branches:` exist anywhere",
+    a question a decoy under any other trigger also answers yes to.
+    """
+    return _BRANCHES_KEY_RE.findall(push_trigger_block(text))
+
+
+def push_targets_main(text: str) -> bool:
+    """Whether `on: push:`'s own `branches:` filter includes `main`."""
+    return bool(_BRANCHES_MAIN_RE.search(push_trigger_block(text)))
 
 
 class TestNpmPublishProvenance(unittest.TestCase):
@@ -205,20 +240,41 @@ class TestNpmPublishAutoRelease(unittest.TestCase):
         )
 
     def test_auto_release_push_to_main_trigger(self):
-        # The `on:` block must include a push trigger to main (auto-publish on a
-        # merged version bump). Tolerant to YAML list form (`branches:\n  - main`)
-        # and flow form (`branches: [main]`), with optional quoting.
-        self.assertIn(
-            "branches:",
-            self.scan,
-            "npm-publish.yml lost its push `branches:` trigger — auto-publish on a "
-            "main version bump is gone (manual-tag-only regression).",
-        )
+        # The `push:` trigger must target main (auto-publish on a merged version
+        # bump). Tolerant to YAML list form (`branches:\n  - main`) and flow form
+        # (`branches: [main]`), with optional quoting on key and value.
+        #
+        # Scoped to the `push:` BLOCK, not the whole file. Both checks used to
+        # scan the comment-stripped workflow text, which proves `branches:` EXISTS
+        # somewhere — never that it belongs to the trigger that fires. Measured
+        # 2026-09-01 on the real file: move the `branches: - main` under a new
+        # `pull_request:` and leave `push:` with only its `tags:` filter, and the
+        # version-bump auto-release is dead (PyYAML: `push -> {'tags': ['v*']}`)
+        # with 14 tests here and 1181 CI guards repo-wide GREEN.
         self.assertRegex(
-            self.scan,
-            r"branches:\s*(?:-\s*|\[\s*)['\"]?main\b",
-            "push trigger no longer targets `main` — version-bump auto-release "
-            "would silently stop firing.",
+            extract_on_block(self.text),
+            rf"(?m)^\s*{yaml_key_pattern('push')}\s*:",
+            "npm-publish.yml lost its `push:` trigger entirely — no auto-release "
+            "path remains (manual-dispatch-only regression).",
+        )
+        block = push_trigger_block(self.text)
+        keys = push_branch_filter_keys(self.text)
+        # COUNT, not presence: exactly one, so a second copy cannot shadow the
+        # first and leave the `main` check satisfied by the wrong one.
+        self.assertEqual(
+            len(keys),
+            1,
+            "Expected exactly one `branches:` filter under `push:` in "
+            f"npm-publish.yml, found {len(keys)}. None means auto-publish on a "
+            "main version bump is gone (manual-tag-only regression); more than "
+            "one means the effective filter is ambiguous.\n"
+            f"push block:\n{block}",
+        )
+        self.assertTrue(
+            push_targets_main(self.text),
+            "the `push:` trigger no longer targets `main` — version-bump "
+            "auto-release would silently stop firing.\n"
+            f"push block:\n{block}",
         )
 
     def test_publish_job_can_tag(self):
@@ -265,27 +321,95 @@ class TestNpmPublishFsixHardening(unittest.TestCase):
 
 
 class TestAutoReleaseTriggerScoping(unittest.TestCase):
-    """The push-`branches:` trigger checks were aimed at the RAW workflow text,
-    so commenting the trigger out left both of them green (inert)."""
+    """Non-vacuity for the auto-release trigger check, in two rounds.
 
-    _PATTERN = r"branches:\s*(?:-\s*|\[\s*)['\"]?main\b"
+    Round 1 (2026-08-11): the checks were aimed at the RAW workflow text, so
+    commenting the trigger out left both green. `extract_on_block` fixed that.
+
+    Round 2 (2026-09-01): comment-stripping answers the *commented-out*
+    regression and nothing else. The checks still scanned the whole file, so a
+    `branches:` living under ANY other trigger satisfied them — the
+    wrong-location shape. Measured on the real `npm-publish.yml`: `push:` left
+    with only `tags:` and `branches: - main` moved to a new `pull_request:`
+    (PyYAML-confirmed `push -> {'tags': ['v*']}`, so the version-bump
+    auto-release is dead) passed 14 tests here and 1181 CI guards repo-wide.
+
+    These exercise the real detectors by name; a surrogate re-implementation of
+    the pattern would go stale against the functions the guard actually calls.
+    """
 
     @staticmethod
-    def _scan(text):
-        return "\n".join(_strip_comment(ln) for ln in text.splitlines())
+    def _wf(on_body):
+        return "on:\n" + on_body + "\njobs:\n  publish:\n    runs-on: ubuntu-latest\n"
 
-    def test_commented_trigger_is_not_counted(self):
-        for mutant in ("    # branches: [main]",
-                       "    tags: ['v*']  # branches: [main]"):
-            with self.subTest(mutant=mutant):
-                scan = self._scan(mutant)
-                self.assertNotIn("branches:", scan)
-                self.assertNotRegex(scan, self._PATTERN)
+    _LIVE = "  push:\n    branches:\n      - main\n    tags:\n      - 'v*'"
 
     def test_live_trigger_is_counted(self):
-        scan = self._scan("    branches: [main]")
-        self.assertIn("branches:", scan)
-        self.assertRegex(scan, self._PATTERN)
+        wf = self._wf(self._LIVE)
+        self.assertEqual(push_branch_filter_keys(wf), ["branches:"])
+        self.assertTrue(push_targets_main(wf))
+
+    def test_commented_trigger_is_not_counted(self):
+        for mutant in ("  push:\n    # branches: [main]\n    tags: ['v*']",
+                       "  push:\n    tags: ['v*']  # branches: [main]"):
+            with self.subTest(mutant=mutant):
+                wf = self._wf(mutant)
+                self.assertEqual(push_branch_filter_keys(wf), [])
+                self.assertFalse(push_targets_main(wf))
+
+    def test_filter_under_a_sibling_trigger_is_not_attributed_to_push(self):
+        # The shipped bypass. `branches: [main]` is present and targets main —
+        # just not on the trigger that publishes.
+        wf = self._wf("  push:\n    tags: ['v*']\n  pull_request:\n    branches:\n      - main")
+        self.assertIn("branches:", wf, "probe is inert: no `branches:` planted")
+        self.assertEqual(
+            push_branch_filter_keys(wf),
+            [],
+            "a sibling trigger's `branches:` was attributed to `push:` — the "
+            "auto-release filter would read as live while it is gone.",
+        )
+        self.assertFalse(push_targets_main(wf))
+
+    def test_filter_in_a_job_body_is_not_attributed_to_push(self):
+        wf = ("on:\n  push:\n    tags: ['v*']\n"
+              "jobs:\n  publish:\n    runs-on: ubuntu-latest\n"
+              "    steps:\n      - run: echo 'branches: [main]'\n")
+        self.assertEqual(push_branch_filter_keys(wf), [])
+        self.assertFalse(push_targets_main(wf))
+
+    def test_quoted_and_flow_forms_are_counted(self):
+        for on_body in ('  push:\n    "branches": [main]',
+                        "  push:\n    'branches': ['main']",
+                        '  push:\n    branches: ["main"]',
+                        "  push: {branches: [main]}",
+                        '  "push":\n    branches:\n      - main'):
+            with self.subTest(on_body=on_body):
+                wf = self._wf(on_body)
+                self.assertEqual(
+                    len(push_branch_filter_keys(wf)),
+                    1,
+                    "a standard authoring style evaded the filter count — the "
+                    "guard would fail on a workflow that is actually correct.",
+                )
+                self.assertTrue(push_targets_main(wf))
+
+    def test_branches_ignore_is_not_counted_as_branches(self):
+        wf = self._wf("  push:\n    branches-ignore:\n      - main")
+        self.assertEqual(
+            push_branch_filter_keys(wf),
+            [],
+            "`branches-ignore:` is the OPPOSITE filter and must not satisfy the "
+            "auto-release check.",
+        )
+
+    def test_a_second_copy_is_reported_not_shadowed(self):
+        wf = self._wf("  push:\n    branches: [release]\n    branches: [main]")
+        self.assertEqual(
+            len(push_branch_filter_keys(wf)),
+            2,
+            "a duplicate `branches:` under `push:` must be reported — with only "
+            "a presence check the second copy silently shadows the first.",
+        )
 
 
 class TestPermissionsBlockTruncation(unittest.TestCase):

--- a/scanner/tests/test_ci_pr_trigger_scope.py
+++ b/scanner/tests/test_ci_pr_trigger_scope.py
@@ -54,6 +54,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from _ci_guard_util import (  # noqa: E402
     explicit_key_lines,
     extract_on_block,
+    trigger_block,
     yaml_key_pattern,
 )
 
@@ -71,47 +72,21 @@ REQUIRED_WORKFLOWS = {
 # base ref (the stacked-PR blind spot); `paths*` narrows by diff content (#186).
 FORBIDDEN_FILTER_KEYS = ("branches", "branches-ignore", "paths", "paths-ignore")
 
-# `pull_request:` bare OR quoted — a quoted key resolves to the same trigger,
-# and `"on":` is already a normalized idiom in GitHub's docs (bare `on` is the
-# YAML-1.1 boolean `True`), so quoting here is realistic authoring.
-_PR_KEY_RE = re.compile(rf"^(\s*){yaml_key_pattern('pull_request')}:\s*(.*)$")
-
-
 def pull_request_block(text: str) -> str:
     """The content nested under the top-level `on:` -> `pull_request:` key.
 
-    Built on `extract_on_block`, which already drops whole-line comments and
-    trailing inline comments and handles bare/quoted `on:` keys — so the
-    rationale comment sitting above `pull_request:` in each workflow cannot
-    satisfy or trip a check here.
-
-    Membership is decided by INDENTATION relative to the `pull_request:` key,
-    and the block ends at the first non-blank line indented at or above it. A
-    flow-style value on the key line itself (`pull_request: {branches: [main]}`)
-    is captured too, so that form cannot slip past a block-only scan.
-
-    `pull_request_target:` is a different key and is never matched: the regex
-    requires the `:` immediately after `pull_request`.
+    A thin binding over the shared `trigger_block` primitive, kept as a named
+    function because the mutation self-tests below are this guard's non-vacuity
+    evidence and they exercise it by name. See `trigger_block` for the
+    indentation/quoting/flow-style semantics and for why block scoping (not a
+    whole-`on:` scan) is the invariant.
 
     Returns "" when the workflow has no `pull_request:` trigger at all — callers
-    must assert the trigger exists separately (see `test_pull_request_trigger_present`),
-    or an empty block would pass the filter checks vacuously.
+    must assert the trigger exists separately (see
+    `test_pull_request_trigger_present`), or an empty block would pass the
+    filter checks vacuously.
     """
-    body, indent = [], None
-    for line in extract_on_block(text).splitlines():
-        if indent is None:
-            m = _PR_KEY_RE.match(line)
-            if m:
-                indent = len(m.group(1))
-                if m.group(2).strip():
-                    body.append(m.group(2))  # flow-style value on the key line
-            continue
-        if not line.strip():
-            continue
-        if len(line) - len(line.lstrip()) <= indent:
-            break  # dedent to a sibling trigger (`push:`, `schedule:`, ...)
-        body.append(line)
-    return "\n".join(body)
+    return trigger_block(extract_on_block(text), "pull_request")
 
 
 def filter_violations(text: str, label: str) -> list:


### PR DESCRIPTION
Closes the last site of the presence-vs-attribution guard class, found by re-running the AST scan across all 60 `test_ci_*.py` guards.

## The gap

`test_auto_release_push_to_main_trigger` scanned the whole comment-stripped `npm-publish.yml` for `branches:` and for `branches: … main`. That answers *"does this token exist anywhere in the file"* — a question a copy under **any other trigger** also answers yes to.

#383 had already fixed the *commented-out* half of this check by routing it through `extract_on_block`. Comment-stripping defeats the comment-out regression and nothing else. The *wrong-location* half stayed open.

## Measured, not argued

Each mutation applied to the real file, PyYAML used to confirm it took effect, then reverted:

| Mutation | PyYAML `push ->` | Guard verdict (before) |
|---|---|---|
| `branches: - main` moved to a new `pull_request:`, `push:` left with only `tags:` | `{'tags': ['v*']}` | **14 passed** here, **1181 CI guards repo-wide GREEN** |
| `push:` deleted outright, filter re-planted on a sibling trigger | `None` | green |
| `branches:` → its opposite `branches-ignore:` | `{'branches-ignore': ['main'], …}` | green |

In every case a merged version bump no longer publishes, with no failure signal anywhere. All three now fail, each printing the extracted `push:` block.

## The fix

The discipline from the earlier sweeps — **scope to the structure, then assert a COUNT**:

- **`trigger_block(on_block, trigger)` promoted into `_ci_guard_util.py`.** `test_ci_pr_trigger_scope.py` had already written this logic privately as `pull_request_block`; rather than adding a second copy it is now a thin binding over the shared primitive, keeping its own mutation self-tests. One implementation, not two that drift — the #485/#488 lesson applied before the drift.
- **Exactly one `branches:` under `push:`**, not "at least one", so a second copy cannot shadow the first and satisfy the `main` check by the wrong one.
- The key boundary is a **fixed-width negative lookbehind**, so `findall` returns the key itself and `branches-ignore` is never counted as `branches`.

## One more shape, worth naming

The old `TestAutoReleaseTriggerScoping` asserted against **its own re-implementation** of the pattern, not against the code the guard runs — so it could not have noticed the scoping was missing. It was testing a surrogate. The detectors are now module-level (`push_branch_filter_keys` / `push_targets_main`) and both the guard and its self-tests call them by name.

## Second commit — `MEMORY.md` re-derivation

The file's own maintenance note says this list "rotted twice". It rotted a third time: **four of its eight issue references were already closed** (#295, #297, #381, #399). `CLAUDE.md` points the continuous-improvement workflow at this file to pick work, so half the backlog was aiming the next session at finished work.

Re-derived from `gh issue list` on 2026-09-01, applying the file's own rule to itself — state the *decision condition* and the command that checks it, never the current pin:

- **#405 is blocked on a human, not on code** — needs a fine-grained PAT with `Administration: read` as `REPO_ADMIN_TOKEN`. Recorded with the distinguishing check, because the workflow runs GREEN either way; the ISSUE state is the signal, not the run conclusion.
- **#498 added with the reason it misreads** — the nightly reuses one tracker and only *appends a comment*, never rewriting the body, so the body still shows style-src `unsafe-inline` + COEP/COOP/CORP as live while its own 2026-08-28 comment reports all four **Resolved** (#500 fixed them 08-27).
- ruff-widening entry now carries the command (61 + 21) instead of a stale number; zscaler entry re-verified (`zscaler-api.py:90-93` produces four reasons, zero consumers).

Plus the #497–#504 cycle entry: the two independent ways a scheduled check stops delivering, and the watchdog that shipped inert for want of `actions: read`.

## Test plan

- [x] `pytest scanner/` — **2706 passed, 11 skipped** (was 2699; +7)
- [x] `ruff check --config ruff.toml .` — All checks passed
- [x] Three real-workflow bypass mutations now FAIL the guard (table above), workflow reverted and verified byte-identical
- [x] Shared primitive mutation-verified: breaking the dedent-break / the quoted-key match / the flow-style capture fails **4 / 3 / 3** tests respectively — the new tests are not inert
- [x] `markdownlint MEMORY.md` clean
- [x] **`.github/workflows/npm-publish.yml` is unchanged** — this PR is tests + docs only

Refs OWASP CICD-SEC-1 (insufficient flow control); continues #383 / #391 / #402 / #404 / #501 / #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)