### PR TITLE
test(dashboard): the SaaS SSO denominator was correct but unpinned

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -429,9 +429,18 @@ running). Check with `gh issue list --state open` before trusting any entry belo
   `_unreachable_detail` (Python, covered by the `scanner/lib` gate) rather than in bash, and
   is keyed on `reason` rather than recomputed from the status code so the two cannot disagree.
   The docstring's "the three states" / lists four is fixed in the same change.
-  **Still open from that review:** `_load_saas_sso_stats` rejects the whole file if **any**
-  `saas` entry is a non-dict — confirm deliberate before changing. Check:
-  `grep -n "_load_saas_sso_stats" -A20 scanner/lib/*.py`.
+  **The last item from that review is now CLOSED as CONFIRMED-DELIBERATE, do not re-propose:**
+  `_load_saas_sso_stats` rejecting the whole `saas` list over one non-dict entry is correct,
+  because the function's output is a DENOMINATOR ("X of Y SaaS apps use SSO") and dropping an
+  entry shrinks Y silently while the percentage keeps looking as confident. Measured
+  2026-09-01: a skip implementation turns a five-app file with one unreadable entry into
+  `{'sso_count': 3, 'total': 4, 'pct': 75}` — byte-identical to a CLEAN four-app file. Same
+  "corrupt is worse than missing" shape as [[project-ocsf-loader-false-pass]] (#471) and #489.
+  **The reason it needed work at all is that the choice was UNPINNED:** the all-entries-bad
+  fixture cannot distinguish the two designs (with every entry dropped, a skip implementation's
+  survivor list is empty, so it also returns `None`), and a skip variant that warns once passed
+  all 54 tests. Four mixed-list cases now pin it, including one asserting the mixed result is
+  NOT EQUAL to the clean four-app result.
 - **`MEMORY.md` maintenance** — this file went **~185 PRs stale** once (#470), and then the
   freshly-written `#295` entry was **false within five hours** of being written: it asserted
   `PROWLER_VERSION=5.30.1 on alpine:3.20` while #473/#479/#481 moved both the same day. The

--- a/scanner/lib/dashboard_auth.py
+++ b/scanner/lib/dashboard_auth.py
@@ -120,6 +120,29 @@ def _load_saas_sso_stats():
     ``None`` ("no SaaS SSO data") plus a ``RuntimeWarning`` — a malformed asset
     file must not take down the whole dashboard build via
     ``build_auth_summary_html``.
+
+    ONE UNREADABLE ENTRY REJECTS THE WHOLE LIST, DELIBERATELY. The obvious
+    alternative — drop the bad entry, keep the rest — was raised in review and is
+    wrong here, because this function's output is a DENOMINATOR. It reports "X of
+    Y SaaS apps use SSO", and dropping an entry shrinks Y silently while the
+    percentage keeps looking exactly as confident. Measured on a five-app file
+    with one unreadable entry, a skip-the-entry implementation returns
+    ``{'sso_count': 3, 'total': 4, 'pct': 75}`` — byte-identical to what it
+    returns for a CLEAN four-app file. Nothing downstream can tell a fifth app
+    existed, and the true coverage is somewhere in 60-80%.
+
+    That is the "corrupt is worse than missing" shape this repo has paid for
+    twice: #471, where an unreadable Prowler file became an empty-but-present
+    provider and scored as a clean prowler-backed PASS instead of degrading to
+    keyword matching; and #489, where a corrupt nmap artifact made
+    ``network_evidence`` truthy and suppressed the very warning that said the
+    evidence was missing. Returning ``None`` renders the section as "N/A" with a
+    named ``RuntimeWarning`` — visibly weaker, and therefore honest.
+
+    Pinned by ``test_dashboard_auth_asset_degradation``'s mixed-list cases. They
+    exist because the all-entries-bad fixture CANNOT distinguish the two designs:
+    a skip implementation that warns once passes all 54 pre-existing tests while
+    silently truncating the denominator (measured 2026-09-01).
     """
     scan_dir = os.environ.get("SCAN_DIR", ".")
     data_path = os.path.join(scan_dir, ".claudesec-assets", "dashboard-data.json")

--- a/scanner/tests/test_dashboard_auth_asset_degradation.py
+++ b/scanner/tests/test_dashboard_auth_asset_degradation.py
@@ -146,6 +146,89 @@ def test_saas_list_of_strings_degrades_with_warning():
     assert "'saas' entry is str, expected an object" in msgs[0]
 
 
+# ---------------------------------------------------------------------------
+# The DENOMINATOR, and why one bad entry rejects the whole list
+# ---------------------------------------------------------------------------
+#
+# `_load_saas_sso_stats` reports "X of Y SaaS apps use SSO". The obvious
+# alternative to rejecting the list — drop the unreadable entry, keep the rest —
+# was raised in the #472 review, and it shrinks Y SILENTLY while the percentage
+# keeps looking exactly as confident.
+#
+# The all-entries-bad fixture above CANNOT tell the two designs apart: with every
+# entry dropped the survivor list is empty, so a skip implementation also returns
+# None. Measured 2026-09-01, a skip implementation that warns ONCE (the shape a
+# careful author would write) passed all 54 tests in this file and
+# test_dashboard_auth_gaps.py, and turned a five-app file with one unreadable
+# entry into `{'sso_count': 3, 'total': 4, 'pct': 75}` — byte-identical to a
+# CLEAN four-app file. Nothing downstream could tell a fifth app existed.
+#
+# That is the "corrupt is worse than missing" shape of #471 (an unreadable
+# Prowler file became an empty-but-present provider and scored as a clean
+# prowler-backed PASS) and #489 (a corrupt nmap artifact made `network_evidence`
+# truthy and suppressed the warning that the evidence was missing).
+#
+# These cases pin the choice with a MIXED list, so the two designs diverge.
+
+_MIXED = '{"saas": [{"auth": "Okta SSO"}, {"auth": "SAML"}, "corrupted", ' \
+         '{"auth": "local password"}, {"auth": "sso"}]}'
+_CLEAN_FOUR = '{"saas": [{"auth": "Okta SSO"}, {"auth": "SAML"}, ' \
+              '{"auth": "local password"}, {"auth": "sso"}]}'
+
+
+def test_one_bad_entry_rejects_the_whole_list():
+    stats, msgs = _load_with(_MIXED)
+    assert stats is None, (
+        "a single unreadable entry must reject the list. Skipping it would "
+        f"report {stats} over a silently truncated denominator."
+    )
+    assert len(msgs) == 1
+    assert "'saas' entry is str, expected an object" in msgs[0]
+
+
+def test_the_mixed_result_is_not_the_clean_four_app_result():
+    """The assertion that makes the two designs distinguishable.
+
+    A skip implementation returns the CLEAN four-app stats for the mixed file.
+    Comparing against that exact value is what a `stats is None` check alone
+    cannot do — with the all-bad fixture both designs return None.
+    """
+    mixed, _ = _load_with(_MIXED)
+    clean, clean_msgs = _load_with(_CLEAN_FOUR)
+    assert clean == {"sso_count": 3, "total": 4, "pct": 75, "non_sso": 1}
+    assert clean_msgs == []
+    assert mixed != clean, (
+        "a five-app file with one unreadable entry produced the same stats as a "
+        "clean four-app file — the fifth app vanished from the denominator with "
+        "the percentage unchanged."
+    )
+
+
+def test_a_bad_entry_last_still_rejects_the_list():
+    """Position must not decide the verdict.
+
+    An implementation that breaks out of the loop after accumulating earlier
+    entries would pass the leading-bad-entry case and fail this one.
+    """
+    stats, msgs = _load_with(
+        '{"saas": [{"auth": "sso"}, {"auth": "sso"}, {"auth": "local"}, 42]}'
+    )
+    assert stats is None
+    assert len(msgs) == 1
+    assert "'saas' entry is int, expected an object" in msgs[0]
+
+
+def test_valid_entries_alone_are_still_computed():
+    """No-false-alarm direction.
+
+    A guard that rejected every list would satisfy the cases above for free, so
+    the clean path must be asserted alongside them.
+    """
+    stats, msgs = _load_with(_CLEAN_FOUR)
+    assert stats == {"sso_count": 3, "total": 4, "pct": 75, "non_sso": 1}
+    assert msgs == []
+
+
 def test_saas_key_present_but_null_returns_none_without_warning():
     """`{"saas": null}` is falsy, so it is the same "no data" case as [] ."""
     stats, msgs = _load_with('{"saas": null}')
@@ -233,6 +316,18 @@ class DashboardAuthAssetDegradationTestCase(unittest.TestCase):
 
     def test_saas_list_of_strings(self):
         test_saas_list_of_strings_degrades_with_warning()
+
+    def test_mixed_one_bad_entry(self):
+        test_one_bad_entry_rejects_the_whole_list()
+
+    def test_mixed_is_not_the_clean_result(self):
+        test_the_mixed_result_is_not_the_clean_four_app_result()
+
+    def test_bad_entry_last(self):
+        test_a_bad_entry_last_still_rejects_the_list()
+
+    def test_clean_list_still_computed(self):
+        test_valid_entries_alone_are_still_computed()
 
     def test_saas_null(self):
         test_saas_key_present_but_null_returns_none_without_warning()


### PR DESCRIPTION
Closes the last open item from the #472 review: *"`_load_saas_sso_stats` rejects the whole file if **any** `saas` entry is a non-dict — confirm deliberate before changing."*

**Verdict: deliberate and correct. Do not relax it.** But it was not enforced, so this pins it.

## Why reject-all is right

The function's output is a **denominator**: "X of Y SaaS apps use SSO". The obvious alternative — drop the unreadable entry, keep the rest — shrinks Y silently while the percentage keeps looking exactly as confident.

Measured on a five-app file with one unreadable entry:

| Implementation | Result |
|---|---|
| current (reject-all) | `None` + `RuntimeWarning` → card renders "N/A" |
| skip-the-entry | `{'sso_count': 3, 'total': 4, 'pct': 75}` |
| a **clean four-app file** | `{'sso_count': 3, 'total': 4, 'pct': 75}` |

The skip result is **byte-identical to the clean four-app file**. Nothing downstream can tell a fifth app existed; true coverage is somewhere in 60–80%.

That is the "corrupt is worse than missing" shape this repo has already paid for twice — #471 (an unreadable Prowler file became an empty-but-present provider and scored as a clean prowler-backed PASS instead of degrading to keyword matching) and #489 (a corrupt nmap artifact made `network_evidence` truthy and suppressed the very warning that said the evidence was missing).

## Why it needed a change at all

**The existing suite could not tell the two designs apart.** Its fixture makes *every* entry bad, and with every entry dropped a skip implementation's survivor list is empty — so it also returns `None`.

Measured 2026-09-01: a skip implementation that warns **once** — the shape a careful author would write — **passed all 54 tests** across the two auth test files while silently truncating the denominator. The one existing test that did fail a naive skip variant failed on a warning *count*, an accident of that fixture having two bad entries, not on the semantics.

## What this adds

Four mixed-list cases where the designs actually diverge:

- one bad entry among four good ones rejects the list
- **the mixed result is asserted `!=` the clean four-app result** — the assertion `stats is None` alone cannot make
- a bad entry **last** still rejects it (position must not decide the verdict; a `break` variant passes the leading case and fails this one)
- the clean path still computes, so a guard that rejected everything would not satisfy the above for free

Plus the reasoning in the docstring, so the next reviewer does not re-raise a settled question, and the `MEMORY.md` backlog entry closed with the measurement rather than the verdict alone.

## Test plan

- [x] `pytest scanner/` — **2739 passed, 11 skipped** (was 2731; +8)
- [x] Coverage, exact CI invocation: `scanner/lib/dashboard_auth.py` **100.00%**, TOTAL **99.43%**, "Required test coverage of 99% reached"
- [x] Three alternative designs mutation-tested against the real module, all now caught (each reverted):

  | Variant | Before | After |
  |---|---|---|
  | skip-bad-entries, warn once | **54 passed** | 6 failed |
  | `break` out of the loop | 2 failed (on a warning count) | 4 failed |
  | shape check removed entirely | — | 7 failed |

- [x] `ruff check --config ruff.toml .` clean; `markdownlint MEMORY.md` clean

**No behaviour change** — `dashboard_auth.py`'s only edit is the docstring.

Refs NIST SP 800-92 §4 (diagnostic quality) and the #471/#489 decode-boundary series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)