### PR TITLE
chore(lint): widen ruff to B + PLE, and record what was measured and rejected

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -296,12 +296,15 @@ jobs:
   # because every deleted statement was already COVERED. A gate that scores dead
   # code as fully exercised cannot be the thing that finds it.
   #
-  # VERDICT NARROWED — WHAT IT HIDES: `ruff.toml` selects only `E9` + `F` and
-  # ignores `F541`. Every other ruff rule (548 findings at the time of writing,
-  # dominated by BLE001 blind-except and S110 try-except-pass) does NOT fail this
-  # job. python-lint is in `lint-gate`'s `needs:`, so that narrowing rides the
-  # REQUIRED `Lint` check — widening `select` is a deliberate decision, not a
-  # cleanup. Rationale and the F541 carve-out are argued in `ruff.toml` itself.
+  # VERDICT NARROWED — WHAT IT HIDES: `ruff.toml` selects `E9`, `F`, `B` and
+  # `PLE`, and ignores `F541`. Every other ruff rule does NOT fail this job —
+  # notably BLE001 blind-except (61) and S110 try-except-pass (21), which were
+  # measured and REJECTED on 2026-09-01 because they sit in paths that exist to
+  # degrade rather than crash, so enabling them buys 82 `# noqa` for zero defects.
+  # python-lint is in `lint-gate`'s `needs:`, so that narrowing rides the REQUIRED
+  # `Lint` check — widening `select` is a deliberate decision, not a cleanup. The
+  # per-family measurements, the F541 carve-out, and the rejection rationale are
+  # argued in `ruff.toml` itself; do not re-derive them here.
   #
   # `--no-cache`: a cache hit is keyed on file content, so it cannot mask a
   # finding, but this job runs in seconds and a cache dir would be the only

--- a/MEMORY.md
+++ b/MEMORY.md
@@ -415,10 +415,23 @@ running). Check with `gh issue list --state open` before trusting any entry belo
 - **`#68` ZAP baseline** is the intentional single-tracker issue — keep it open.
 - **`#12` Zscaler MCP integration**, **`#18` GitHub Projects board**, **`#20` marketplace
   plugin update** are `enhancement`-labelled product asks, not correctness work.
-- **ruff ruleset widening** — `python-lint` is in `lint-gate.needs`, so widening `select`
-  changes a REQUIRED check; it needs a decision, not a cleanup pass (see Cycle #469). Measure,
-  don't quote a number: `ruff check --isolated --select BLE001,S110 --statistics scanner/
-  scripts/` (61 + 21 on 2026-09-01).
+- **ruff ruleset widening — DECIDED 2026-09-01, do not re-propose as open.** `select` is now
+  `["E9", "F", "B", "PLE"]`. `B905` (`zip()` without `strict=`) is why: a length mismatch
+  truncates SILENTLY, this repo's recurring theme, and its two sites needed OPPOSITE answers
+  (`strict=True` for two same-length literals; `strict=False` for a helper whose truncation is
+  a tested contract). `BLE001`/`S110` stay REJECTED **with the numbers**: 61 + 21, concentrated
+  in paths that exist to degrade rather than crash, so enabling them buys 82 `# noqa` for zero
+  defects. `PLW1508`'s 7 sites are all `int(os.environ.get(k, 0))` — harmless by construction.
+  The per-family measurements live in `ruff.toml` beside the `select`; read them there rather
+  than re-deriving. Re-measure with `ruff check --config ruff.toml --select <F> --statistics .`.
+- **`_TEMPLATE_KEYS` / caller arity is uncoupled** (found while doing the above, NOT fixed).
+  `scanner/lib/dashboard_html_helpers.py` has 73 template keys and its single production caller
+  `dashboard-gen.py` passes exactly 73 positional values, with nothing asserting they stay
+  equal — `zip` truncates, so a 74th key added without updating the caller leaves that
+  placeholder unreplaced in the rendered dashboard, silently. Fixing it is a behaviour change
+  (the helper's partial application is deliberately tested), so it needs its own decision.
+  Check: `python3 -c "import sys;sys.path.insert(0,'scanner/lib');import
+  dashboard_html_helpers as m;print(len(m._TEMPLATE_KEYS))"` vs the call site's arg count.
 - **zscaler `_unreachable` `reason` — WIRED UP in this PR, do not re-propose.** It had been
   write-only since #472: four distinct states recorded, zero consumers, so all five
   inaccessible sections printed a fixed sentence and SAAS-ZIA-002's said "RBA restricted" —

--- a/ruff.toml
+++ b/ruff.toml
@@ -8,13 +8,35 @@
 # (`loc_html`, `oname`, `has_http_artifacts`) behind a 99% gate, and it is the
 # same "dead renderer" class already recorded twice in this repo's history.
 #
-# SCOPE IS DELIBERATELY NARROW. `E9` (syntax / IO errors) + `F` (Pyflakes) are
-# the tiers where a violation is a defect rather than a preference: F821
-# undefined-name, F811 redefinition, F632 is-literal, F401 unused-import, F841
-# unused-variable. Everything else ruff can emit — 548 further findings at the
-# time of writing, dominated by BLE001 blind-except (65) and S110
-# try-except-pass (24) — needs case-by-case judgement and is NOT enabled here.
-# Widening `select` is a deliberate decision, not a cleanup.
+# SCOPE IS DELIBERATELY NARROW, AND THE TEST IS "IS A VIOLATION A DEFECT, OR A
+# PREFERENCE?" `E9` (syntax / IO errors) + `F` (Pyflakes) were the original tiers:
+# F821 undefined-name, F811 redefinition, F632 is-literal, F401 unused-import,
+# F841 unused-variable.
+#
+# `B` (bugbear) and `PLE` (pylint ERRORS, not warnings) were added 2026-09-01
+# after measuring every candidate family against that same test. They cost 9
+# findings, and B905 — `zip()` without an explicit `strict=` — is the reason:
+# a length mismatch makes `zip` truncate SILENTLY, which is this repo's whole
+# recurring theme. `PLE2515` caught a literal zero-width space sitting invisibly
+# in a docstring.
+#
+# MEASURED AND REJECTED, so the next reviewer does not re-litigate (counts from
+# `ruff check --config ruff.toml --select <F> --statistics .`, 2026-09-01):
+#
+#   BLE001 blind-except        61  concentrated in paths that exist to DEGRADE
+#   S110   try-except-pass     21  rather than crash (sync-cost-xlsx 13,
+#                                  build-dashboard 9; compliance-map.py's is
+#                                  documented deliberate in-line). Enabling
+#                                  these buys 82 `# noqa` or behaviour-changing
+#                                  except-narrowing for zero defects found.
+#   PLW1508 envvar-default      7  ALL are `int(os.environ.get(k, 0))` — the
+#                                  `int()` wrapper makes them harmless.
+#   PLW1510 subprocess-check    9  8 of 9 are tests that assert on returncode
+#                                  themselves.
+#   RUF 170 / SIM 55 / PERF 43     preference, not defect.
+#
+# Widening `select` changes a REQUIRED check (`python-lint` is in
+# `lint-gate.needs`), so it is a decision, not a cleanup.
 
 target-version = "py311"
 
@@ -23,7 +45,7 @@ target-version = "py311"
 extend-exclude = ["node_modules", ".venv", "assets"]
 
 [lint]
-select = ["E9", "F"]
+select = ["E9", "F", "B", "PLE"]
 
 # F541 f-string-missing-placeholders: 48 sites, all `f"literal"` with nothing to
 # interpolate. Cosmetic — it cannot change behaviour — and folding it in would

--- a/scanner/lib/dashboard_html_helpers.py
+++ b/scanner/lib/dashboard_html_helpers.py
@@ -244,4 +244,16 @@ _TEMPLATE_KEYS = [
 
 
 def _build_replacements(*values):
-    return dict(zip(_TEMPLATE_KEYS, (str(v) for v in values)))
+    # `strict=False` is the DELIBERATE answer to B905 here, not a silencer.
+    # Truncation is this helper's tested contract — `test_fewer_values_truncates_result`
+    # and `test_no_values_returns_empty_dict` pin partial application on purpose — so
+    # `strict=True` would change documented behaviour, not just add a check.
+    #
+    # WHERE THE REAL RISK LIVES, since making it explicit means naming it: the
+    # coupling is between `_TEMPLATE_KEYS` (73 entries) and its single production
+    # caller `dashboard-gen.py`, which passes exactly 73 positional values. Nothing
+    # asserts those two stay equal, so adding a 74th key without updating the caller
+    # leaves the 74th placeholder unreplaced in the rendered dashboard, silently.
+    # That is a separate change from widening the lint ruleset and is reported
+    # rather than folded in here.
+    return dict(zip(_TEMPLATE_KEYS, (str(v) for v in values), strict=False))

--- a/scanner/tests/test_ci_scanner_lib_reachability.py
+++ b/scanner/tests/test_ci_scanner_lib_reachability.py
@@ -36,7 +36,7 @@ because one cascades into `output_prowler.sh` + several test files):
 
 The guard asserts the computed dead set EQUALS this baseline, so:
   * a NEW dead top-level function fails the guard (it is not in the baseline);
-  * removing/​wiring-up a baselined function ALSO fails until it is dropped from
+  * removing/wiring-up a baselined function ALSO fails until it is dropped from
     `KNOWN_UNREFERENCED` — keeping the allowlist honest and the backlog visible.
 
 Detection is conservative: a name appearing anywhere in production (even inside a

--- a/scanner/tests/test_dashboard_mapping_pure.py
+++ b/scanner/tests/test_dashboard_mapping_pure.py
@@ -150,7 +150,7 @@ class TestOwaspCheckMap(unittest.TestCase):
             assert len(dm.OWASP_CHECK_MAP[oid]) > 0
 
     def test_all_keywords_are_lowercase_strings(self):
-        for oid, kws in dm.OWASP_CHECK_MAP.items():
+        for _oid, kws in dm.OWASP_CHECK_MAP.items():
             for kw in kws:
                 assert isinstance(kw, str)
                 assert kw == kw.lower()
@@ -430,7 +430,7 @@ class TestOwaspToArch(unittest.TestCase):
 
     def test_values_are_domain_index_lists(self):
         max_idx = len(dm.ARCH_DOMAINS) - 1
-        for key, indices in dm.OWASP_TO_ARCH.items():
+        for _key, indices in dm.OWASP_TO_ARCH.items():
             assert isinstance(indices, list)
             for idx in indices:
                 assert 0 <= idx <= max_idx

--- a/scripts/build-dashboard.py
+++ b/scripts/build-dashboard.py
@@ -980,7 +980,7 @@ def collect_sheets():
             proxy_overrides = (
                 proxy_overrides_raw if isinstance(proxy_overrides_raw, list) else []
             )
-            for month_key, rows in cost_data["details"].items():
+            for _month_key, rows in cost_data["details"].items():
                 for r in rows:
                     for ovr in proxy_overrides:
                         if r["software"] == ovr.get("software") and r.get(

--- a/scripts/full-asset-sync.py
+++ b/scripts/full-asset-sync.py
@@ -99,7 +99,7 @@ def collect_datadog_hosts() -> list:
     hosts = []
     for h in data.get("host_list", []):
         tags = {}
-        for source, tag_list in h.get("tags_by_source", {}).items():
+        for _source, tag_list in h.get("tags_by_source", {}).items():
             for t in tag_list:
                 if ":" in t:
                     k, v = t.split(":", 1)

--- a/scripts/generate_ai_devsecops_from_template.py
+++ b/scripts/generate_ai_devsecops_from_template.py
@@ -207,7 +207,7 @@ def set_shape_paragraphs(shape: ET.Element, paragraphs: list[str]) -> None:
         tx_body.insert(0, ET.Element(qn("a", "bodyPr")))
     if tx_body.find("a:lstStyle", NS) is None:
         tx_body.insert(1, ET.Element(qn("a", "lstStyle")))
-    for idx, paragraph in enumerate(paragraphs):
+    for _idx, paragraph in enumerate(paragraphs):
         p = ET.Element(qn("a", "p"))
         if template_ppr is not None:
             p.append(copy.deepcopy(template_ppr))

--- a/scripts/generate_ai_devsecops_ppt.py
+++ b/scripts/generate_ai_devsecops_ppt.py
@@ -513,7 +513,7 @@ def render_framework_overview(slide_no: int) -> Image.Image:
         (220, 635, 900, 905),
         (1020, 635, 1700, 905),
     ]
-    for (title, desc, img, color), box in zip(cards, positions):
+    for (title, desc, img, color), box in zip(cards, positions, strict=True):
         image_title_card(image, draw, box, img, title, desc, color)
     rounded_rect(draw, (120, 920, 1800, 980), fill="#1A1918", radius=22)
     draw.text((156, 942), "공통점", font=BODY_SMALL_FONT, fill="#FFF6EE")

--- a/scripts/isms-p-report.py
+++ b/scripts/isms-p-report.py
@@ -126,7 +126,7 @@ def generate_report():
         "3. 개인정보 처리단계별": {"controls": [], "prefix": "3."},
     }
     for c in isms_p:
-        for dname, dinfo in domains.items():
+        for _dname, dinfo in domains.items():
             if c["control"].startswith(dinfo["prefix"]):
                 dinfo["controls"].append(c)
                 break


### PR DESCRIPTION
Resolves the "ruff ruleset widening" backlog item. `python-lint` is in `lint-gate.needs`, so this changes a **required** check — every family was measured against `ruff.toml`'s own stated test ("is a violation a defect, or a preference?") rather than adopted wholesale.

## Enabled: `B` (bugbear) + `PLE` (pylint ERRORS, not warnings) — 9 findings

**B905 `zip()` without an explicit `strict=` is the reason to do this at all.** A length mismatch makes `zip` truncate **silently** — this repo's whole recurring theme. Two sites, and they needed *opposite* answers, which is itself the argument for the rule:

| Site | Fix | Why |
|---|---|---|
| `scripts/generate_ai_devsecops_ppt.py:516` | `strict=True` | `cards` and `positions` are both 5-element literals in the same function (measured via AST). A card added without a position should fail loudly, not vanish from the rendered slide. |
| `scanner/lib/dashboard_html_helpers.py:247` | `strict=False` | Truncation is that helper's **tested contract** — `test_fewer_values_truncates_result` and `test_no_values_returns_empty_dict` pin partial application on purpose. `strict=True` would change documented behaviour, not just add a check. |

Making the second one explicit means naming where the risk actually lives, so the comment does: `_TEMPLATE_KEYS` has 73 entries and its single production caller passes exactly 73 positional values, and **nothing asserts those stay equal**. Adding a 74th key without updating the caller leaves the 74th placeholder unreplaced in the rendered dashboard, silently.

That is **reported, not fixed here** — it is a behaviour change, not a lint widening, and it deserves its own decision.

**PLE2515** caught a literal zero-width space sitting invisibly inside prose in `test_ci_scanner_lib_reachability.py`'s module docstring (`removing/<ZWSP>wiring-up`). Removed rather than escaped to `​`: it was a paste artifact with no purpose.

Six **B007** unused loop-control variables renamed to `_`-prefixed — minimal and obviously behaviour-preserving. The point is that they are a dead-code signal, the exact blind spot ruff was added for (a 99% coverage floor scores dead code as *fully exercised*).

## Measured and REJECTED

Recorded in `ruff.toml` beside the `select`, so the next reviewer does not re-litigate. Counts from `ruff check --config ruff.toml --select <F> --statistics .`, 2026-09-01:

| Family | n | Why not |
|---|---|---|
| `BLE001` blind-except | 61 | Concentrated in paths that exist to **degrade rather than crash** (`sync-cost-xlsx` 13, `build-dashboard` 9; `compliance-map.py`'s is documented deliberate in-line). Enabling buys 82 `# noqa` or behaviour-changing except-narrowing, for **zero defects found**. |
| `S110` try-except-pass | 21 | Same class. |
| `PLW1508` envvar-default | 7 | **All seven** are `int(os.environ.get(k, 0))` — the `int()` wrapper makes every one harmless. A textbook false-positive family here. |
| `PLW1510` subprocess-check | 9 | 8 of 9 are tests that assert on returncode themselves. |
| `RUF` 170 / `SIM` 55 / `PERF` 43 | 268 | Preference, not defect. |

The prior decision against `BLE001`/`S110` is **confirmed with numbers**, not inherited.

## Test plan

- [x] `ruff check --config ruff.toml . --no-cache` — **All checks passed**, exit 0
- [x] `pytest scanner/` — 2731 passed, 11 skipped (unchanged; no behaviour touched)
- [x] **The widened gate is not decorative** — four planted violations, each reverted afterwards:

  | Planted | ruff |
  |---|---|
  | `B905` `zip(a, b)` | exit 1 |
  | `B006` mutable default arg | exit 1 |
  | `PLE2515` zero-width space | exit 1 |
  | `PLE0101` return in `__init__` | exit 1 |

  Before this change all four were ignored.
- [x] `strict=True` at the PPT site proven safe by AST: `cards` 5 elements, `positions` 5 elements
- [ ] Pre-existing and unrelated: `actionlint .github/workflows/lint.yml` reports SC2215 at the same `run:` block on `main` (line shifts 1000 → 1003 only because this comment grew)

🤖 Generated with [Claude Code](https://claude.com/claude-code)