### PR TITLE
fix: stop discarding stdout in run_with_timeout python3 fallback

### DIFF
--- a/scanner/lib/checks.sh
+++ b/scanner/lib/checks.sh
@@ -17,11 +17,15 @@ run_with_timeout() {
   elif has_command gtimeout; then
     gtimeout "$timeout_sec" "$@" 2>/dev/null
   elif has_command python3; then
+    # stdout must pass through to the caller: many call sites capture it via
+    # `$(...)` or pipe it to grep. Discarding it here silently broke every such
+    # check on hosts without GNU timeout/gtimeout (e.g. stock macOS).
+    # stderr stays suppressed to match the timeout/gtimeout branches above.
     python3 -c 'import subprocess, sys
 timeout=float(sys.argv[1])
 cmd=sys.argv[2:]
 try:
-  p=subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=timeout)
+  p=subprocess.run(cmd, stderr=subprocess.DEVNULL, timeout=timeout)
   raise SystemExit(p.returncode)
 except subprocess.TimeoutExpired:
   raise SystemExit(124)


### PR DESCRIPTION
## Problem

The python3 fallback of `run_with_timeout` (`scanner/lib/checks.sh`) ran the command with `stdout=subprocess.DEVNULL`, unlike the `timeout` / `gtimeout` branches which let stdout pass through and only suppress stderr.

Hosts without GNU `timeout` or `gtimeout` — **stock macOS** — always take this fallback. Every caller that consumes the output received an empty string, while the exit code still reported success. A silent failure: the command ran fine, the result vanished.

## Impact

| Call site | Pattern | Effect |
|---|---|---|
| `lib/checks_credentials.sh:267` `has_gcp_credentials` | pipes to `grep -q .` | returned false even with an active `gcloud auth login` → **all GCP checks skipped** |
| `checks/saas/api-checks.sh` (14 sites) | `$(run_with_timeout 15 curl ...)` | Datadog / Okta / Jenkins probes received empty responses |

Reproduction on a host without `timeout`/`gtimeout`:

```console
$ python3 -c '...fallback...' 10 gcloud auth list --filter=status:ACTIVE "--format=value(account)" > out.txt
exit=0   captured bytes=0      # command succeeded, output discarded
```

## Fix

Let stdout through; keep suppressing stderr so behavior matches the other two branches.

## Verification

- `bash scanner/tests/test_checks_lib_direct.sh` — PASS
- `bash scanner/tests/test_check_cloud_gcp_azure.sh` — PASS
- `bash scanner/tests/test_check_saas_api_checks.sh` — PASS
- `pytest scanner/` — **2753 passed, 11 skipped**
- `claudesec scan -c cloud` against a live GCP project: **9 skipped → 1 pass / 1 warning / 7 skipped** (remaining skips are AWS + Azure, no credentials configured)

## Note for reviewers

Checks that were silently inert on macOS will now actually run. Expect new findings to surface on such hosts — that is the intended behavior, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)