### PR TITLE
refactor(dashboard): delete four template keys that rendered nothing

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -471,15 +471,20 @@ running). Check with `gh issue list --state open` before trusting any entry belo
   widening (#508), `_TEMPLATE_KEYS` caller arity (#509), the zscaler `_unreachable` `reason`
   wiring (#506), and `_load_saas_sso_stats`'s reject-the-whole-list behaviour, which is
   CONFIRMED-DELIBERATE and correct (#507).
-- **Four dead template keys — the one genuinely OPEN item from that block.** `ACTIVE`,
-  `POLICY_022_TOP`, `N_INFO`, `TOTAL_ALL` are computed, passed through a 73-argument call, and
-  never substituted. They are baselined rather than deleted because removing a key means
-  removing its positional argument from that call — a behaviour change and an off-by-one
-  waiting to happen — so this is a product decision, not a guard. `CSP_NONCE` is the one
-  baselined orphan PLACEHOLDER and must STAY (nginx `sub_filter` supplies it per request).
-  Re-derive the current set with
-  `python3 -m pytest scanner/tests/test_ci_template_keys_arity.py -q`, which asserts the dead
-  set EQUAL to its baseline in both directions, rather than trusting the four names above.
+- **Four dead template keys — DONE 2026-09-02, do NOT re-propose.** `ACTIVE`,
+  `POLICY_022_TOP`, `N_INFO`, `TOTAL_ALL` were computed, passed through the call and never
+  substituted; removed together with their positional arguments AND the four locals they were
+  the only consumers of, so `KNOWN_DEAD_KEYS` is now empty. **How the off-by-one was ruled
+  out, because arity cannot see a shift** — a shifted call passes the same NUMBER of
+  arguments, just against the wrong keys: pair every key with its argument EXPRESSION by AST
+  across both files, before and after, and assert the survivors byte-identical. That is the
+  check to repeat, not a re-render (timestamps make a render diff noisy and it proves less).
+  `CSP_NONCE` stays as the one baselined orphan PLACEHOLDER (nginx `sub_filter` supplies it
+  per request). Deliberately NOT chased upstream: `overview["n_info"]` and
+  `overview["policy_022_top"]` are still produced by `dashboard_html_overview.py` with no
+  consumer left — a wider change into a dict with its own tests, reported rather than folded
+  in. Re-derive state with `python3 -m pytest scanner/tests/test_ci_template_keys_arity.py -q`
+  rather than trusting this entry.
 - **`MEMORY.md` maintenance** — this file went **~185 PRs stale** once (#470), and then the
   freshly-written `#295` entry was **false within five hours** of being written: it asserted
   `PROWLER_VERSION=5.30.1 on alpine:3.20` while #473/#479/#481 moved both the same day. The

--- a/scanner/lib/dashboard-gen.py
+++ b/scanner/lib/dashboard-gen.py
@@ -228,7 +228,6 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
     grade = sd.get("grade", "F")
     duration = sd.get("duration", 0)
     findings_list = sd.get("findings", [])
-    active = total - skipped
 
     grade_color = {"A": "#22c55e", "B": "#22c55e", "C": "#eab308", "D": "#eab308"}.get(
         grade, "#ef4444"
@@ -428,7 +427,6 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
     comp_html = _build_compliance_html(compliance_map)
 
     total_passed = passed + total_prowler_pass
-    total_all = total_prowler_fail + total_prowler_pass + failed + warnings
     total_issues = total_prowler_fail + failed + warnings
     audit_points_detected = load_audit_points_detected(scan_dir)
     # Scan scope: what data is included in this dashboard (for Overview)
@@ -595,8 +593,6 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
     n_high = overview["n_high"]
     n_med = overview["n_med"]
     n_low = overview["n_low"]
-    n_info = overview["n_info"]
-    policy_022_top = overview["policy_022_top"]
     prov_cards = overview["prov_cards"]
     bar_crit = overview["bar_crit"]
     bar_high = overview["bar_high"]
@@ -732,19 +728,15 @@ def generate_dashboard(scan_data, prowler_dir, history_dir, output_file):
         score,
         grade,
         grade_color,
-        active,
         score * 327 // 100,
         n_crit,
         n_high,
         n_med,
         n_low,
         warnings,
-        policy_022_top,
-        n_info,
         total_passed,
         total_prowler_fail,
         total_prowler_pass,
-        total_all,
         total_issues,
         env_html,
         env_connected,

--- a/scanner/lib/dashboard_html_helpers.py
+++ b/scanner/lib/dashboard_html_helpers.py
@@ -177,19 +177,15 @@ _TEMPLATE_KEYS = [
     "SCORE",
     "GRADE",
     "GRADE_COLOR",
-    "ACTIVE",
     "SCORE_DASH",
     "N_CRIT",
     "N_HIGH",
     "N_MED",
     "N_LOW",
     "N_WARN",
-    "POLICY_022_TOP",
-    "N_INFO",
     "TOTAL_PASSED",
     "TOTAL_PROWLER_FAIL",
     "TOTAL_PROWLER_PASS",
-    "TOTAL_ALL",
     "TOTAL_ISSUES",
     "ENV_HTML",
     "ENV_CONNECTED",
@@ -250,10 +246,11 @@ def _build_replacements(*values):
     # `strict=True` would change documented behaviour, not just add a check.
     #
     # WHERE THE REAL RISK LIVES, since making it explicit means naming it: the
-    # coupling is between `_TEMPLATE_KEYS` (73 entries) and its single production
-    # caller `dashboard-gen.py`, which passes exactly 73 positional values. Nothing
-    # asserts those two stay equal, so adding a 74th key without updating the caller
-    # leaves the 74th placeholder unreplaced in the rendered dashboard, silently.
-    # That is a separate change from widening the lint ruleset and is reported
-    # rather than folded in here.
+    # coupling is between `_TEMPLATE_KEYS` and its single production caller
+    # `dashboard-gen.py`, which passes one positional value per key. Add a key
+    # without updating the caller and the last placeholder is left unreplaced in
+    # the rendered dashboard, silently. `test_ci_template_keys_arity.py` is what
+    # asserts the two stay equal — from OUTSIDE, since `strict=True` is not
+    # available here — and it also pins that every key reaches a `{{KEY}}` in the
+    # template, because arity alone stays green while a key renders nothing.
     return dict(zip(_TEMPLATE_KEYS, (str(v) for v in values), strict=False))

--- a/scanner/tests/test_ci_template_keys_arity.py
+++ b/scanner/tests/test_ci_template_keys_arity.py
@@ -10,20 +10,22 @@ that helper's tested contract on purpose (`test_fewer_values_truncates_result`
 pins partial application), so `strict=True` is not available as a fix — the
 coupling has to be checked from outside.
 
-Nothing checked it. `_TEMPLATE_KEYS` has 73 entries and exactly one production
-caller, `scanner/lib/dashboard-gen.py`, which passes 73 positional values. Add a
-74th key without updating the caller and the 74th placeholder is left unreplaced
-in the rendered dashboard: no exception, no failing test, no visible diff except
-a literal `{{SOMETHING}}` on the page. The reverse — a 74th argument with no key
-— silently discards the value instead.
+Nothing checked it. `_TEMPLATE_KEYS` has exactly one production caller,
+`scanner/lib/dashboard-gen.py`, which passes one positional value per key. Add a
+key without updating the caller and the last placeholder is left unreplaced in
+the rendered dashboard: no exception, no failing test, no visible diff except a
+literal `{{SOMETHING}}` on the page. The reverse — an argument with no key —
+silently discards the value instead. Both counts are DERIVED here rather than
+written down, because a number in a comment rots on the next change.
 
 BOTH DIRECTIONS, because the guard is only half a guard otherwise:
 
 1. **Arity.** `len(_TEMPLATE_KEYS)` == the caller's positional argument count.
 2. **Placeholder reachability.** A key with no `{{KEY}}` anywhere in the template
-   is a DEAD replacement — computed, passed, stored, never substituted. Four
-   already exist (`ACTIVE`, `POLICY_022_TOP`, `N_INFO`, `TOTAL_ALL`, measured
-   2026-09-01), which is exactly why direction 1 alone would not have helped: the
+   is a DEAD replacement — computed, passed, stored, never substituted. FOUR
+   existed when this guard landed (`ACTIVE`, `POLICY_022_TOP`, `N_INFO`,
+   `TOTAL_ALL`, measured 2026-09-01; removed 2026-09-02), which is exactly why
+   direction 1 alone would not have helped: arity was already correct, and the
    common drift is adding a key plus an argument and forgetting the template.
 
 The dead set is asserted EQUAL to a baseline rather than merely non-growing, the
@@ -34,7 +36,7 @@ instead of letting it accumulate.
 
 WHY AST, NOT A LINE SCAN
 ------------------------
-The call spans 73 lines. Counting `,` characters or matching a regex over the
+The call spans dozens of lines. Counting `,` characters or matching a regex over the
 call text breaks on a nested call, a trailing comma, or a comment, and this
 repo's history is a list of guards defeated by exactly that
 (`feedback-enumerate-with-ast`). `ast.walk` reads the argument list the
@@ -67,18 +69,20 @@ sys.path.insert(0, str(LIB))
 from dashboard_html_helpers import _TEMPLATE_KEYS  # noqa: E402
 
 # Keys with no `{{KEY}}` in the template: computed, passed, stored, never
-# substituted. Baseline measured 2026-09-01 — asserted EQUAL, not as a ceiling.
+# substituted. EMPTY as of 2026-09-02, and asserted EQUAL rather than as a
+# ceiling, so a newly dead key fails here instead of joining a growing allowlist.
 #
-# Left in place rather than deleted: removing a key means removing its positional
-# argument from a 73-argument call, which is an off-by-one waiting to happen and a
-# behaviour change, not a guard. Recorded here so the next person sees the list
-# instead of rediscovering it.
-KNOWN_DEAD_KEYS = {
-    "ACTIVE",           # caller arg `active`,          index 10
-    "POLICY_022_TOP",   # caller arg `policy_022_top`,  index 17
-    "N_INFO",           # caller arg `n_info`,          index 18
-    "TOTAL_ALL",        # caller arg `total_all`,       index 22
-}
+# It was NOT empty when this guard landed. Four keys — `ACTIVE` (index 10),
+# `POLICY_022_TOP` (17), `N_INFO` (18), `TOTAL_ALL` (22) — were baselined rather
+# than deleted, because removing a key means removing its positional argument
+# from a 73-argument call and that is a behaviour change with an off-by-one in
+# it. They were removed together with their arguments and their now-orphaned
+# locals, proven shift-free by pairing every key with its argument EXPRESSION
+# (AST, both files) before and after and asserting the 69 survivors identical.
+# That pairing is the check to repeat if this list ever needs entries removed
+# again; arity alone cannot see a shift, because a shifted call still passes the
+# same NUMBER of arguments — just against the wrong keys.
+KNOWN_DEAD_KEYS = set()
 
 # `{{CSP_NONCE}}` is substituted by nginx `sub_filter` per request, not by
 # `_build_replacements`, so it is a placeholder with no key BY DESIGN. Listed
@@ -192,7 +196,7 @@ class TestEveryKeyReachesTheTemplate(unittest.TestCase):
             f"  NEWLY DEAD (add a placeholder, or drop the key AND its caller "
             f"argument): {new}\n"
             f"  NOW WIRED UP (delete it from KNOWN_DEAD_KEYS): {fixed}\n"
-            "A dead key is a value computed, passed through a 73-argument call "
+            "A dead key is a value computed, passed through the call "
             "and stored, that nothing ever substitutes.",
         )
 


### PR DESCRIPTION
Closes the one item MEMORY.md still listed as open from the #505–#511 block.

## What was dead

`ACTIVE`, `POLICY_022_TOP`, `N_INFO` and `TOTAL_ALL` were computed, passed
through the 73-argument `_build_replacements` call and stored in the replacement
map — then never substituted, because `dashboard-template.html` has no matching
`{{KEY}}`.

#509 baselined them rather than deleting them, which was right at the time:
removing a key means removing its positional argument from a 73-argument call,
and that is a behaviour change with an off-by-one in it, not a guard. This is
that change.

Removed per key: the `_TEMPLATE_KEYS` entry, its positional argument (indices
**10, 17, 18, 22**), and the local it was the only consumer of — `active`,
`policy_022_top`, `n_info`, `total_all` all go dead once the argument does, and
ruff `F841` would fail on them otherwise.

## How the off-by-one was ruled out

**Arity cannot see a shift.** A call that pairs the right *number* of values with
the *wrong* keys still has the right number of values, and
`test_caller_passes_one_value_per_key` stays green. So the check is not a count:
pair every key with its argument **source expression** by AST across both files,
before and after, and assert the survivors identical.

```text
keys=73 args=73   ->   keys=69 args=69
removed exactly {ACTIVE, POLICY_022_TOP, N_INFO, TOTAL_ALL}
every surviving key keeps its EXACT argument expression — no shift
```

Stronger than a rendered-output diff, and with no timestamp noise. It is written
into the guard as the procedure to repeat if `KNOWN_DEAD_KEYS` ever needs entries
removed again.

`KNOWN_DEAD_KEYS` is now empty and still asserted **EQUAL**, not as a ceiling, so
a newly dead key fails rather than joining a growing allowlist. `CSP_NONCE`
stays baselined as the one orphan PLACEHOLDER by design — nginx `sub_filter`
supplies it per request.

## Deliberately out of scope

`dashboard_html_overview.py` still builds `overview["n_info"]` and
`overview["policy_022_top"]`, which now have no consumer. Chasing them means
changing a shared dict with its own tests and other readers — reported, not
folded in.

## Stale counts this surfaced

`_build_replacements`'s own comment claimed *"Nothing asserts those two stay
equal"* — false since #509 — and both it and the guard docstring pinned `73`,
which is exactly the number-in-a-comment rot this repo keeps re-learning. Both
now describe the coupling without the count; the guard derives it.

## Test plan

| Check | Result |
|---|---|
| `pytest scanner/tests/` + 99% floor | **2760 passed, 11 skipped**, `scanner/lib` **99.43%** |
| `unittest discover 'test_ci_*.py'` | **Ran 1088 — OK** |
| `test_dashboard_control_liveness.sh` | **14/14 live, 2 skipped**, 0 CSP violations |
| `test_asset_dashboard_control_liveness.sh` | **20/20 live, 2 skipped**, 0 CSP violations |
| ruff / markdownlint | clean / clean |

Both liveness suites re-run because this touches `scanner/lib/dashboard_html_*`,
and both match their recorded baselines exactly.

Refs OWASP CICD-SEC-1; the "dead renderer" class recorded in this repo twice
before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)