### PR TITLE
refactor(dashboard): remove two severity counters nothing ever rendered

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -480,11 +480,17 @@ running). Check with `gh issue list --state open` before trusting any entry belo
   across both files, before and after, and assert the survivors byte-identical. That is the
   check to repeat, not a re-render (timestamps make a render diff noisy and it proves less).
   `CSP_NONCE` stays as the one baselined orphan PLACEHOLDER (nginx `sub_filter` supplies it
-  per request). Deliberately NOT chased upstream: `overview["n_info"]` and
-  `overview["policy_022_top"]` are still produced by `dashboard_html_overview.py` with no
-  consumer left — a wider change into a dict with its own tests, reported rather than folded
-  in. Re-derive state with `python3 -m pytest scanner/tests/test_ci_template_keys_arity.py -q`
-  rather than trusting this entry.
+  per request). The upstream half followed in a second pass: `n_info` and `policy_022_top`
+  were computed in `_compute_severity_counts`, re-exported through `build_overview_blocks`,
+  and consumed by nothing. **`git log -S"POLICY_022_TOP" -- scanner/lib/dashboard-template.html`
+  returns EMPTY — neither placeholder ever existed**, so these were born dead and survived
+  three refactors. Removed with their tests; `_compute_severity_counts` now returns exactly
+  the four bar severities and a test asserts the KEY SET by equality, because `assertIn` on
+  four keys would not notice a fifth being recomputed and going unrendered again.
+  `SAAS-API-022` itself is a LIVE Okta scope check — only its counter was dead, so re-adding
+  the metric is three lines if anyone ever wants it on screen. Re-derive state with
+  `python3 -m pytest scanner/tests/test_ci_template_keys_arity.py -q` rather than trusting
+  this entry.
 - **`MEMORY.md` maintenance** — this file went **~185 PRs stale** once (#470), and then the
   freshly-written `#295` entry was **false within five hours** of being written: it asserted
   `PROWLER_VERSION=5.30.1 on alpine:3.20` while #473/#479/#481 moved both the same day. The

--- a/scanner/lib/dashboard_html_helpers.py
+++ b/scanner/lib/dashboard_html_helpers.py
@@ -126,14 +126,9 @@ def _compute_severity_counts(prov_summary, findings_list):
     n_high = sum(v["high"] for v in prov_summary.values())
     n_med = sum(v["medium"] for v in prov_summary.values())
     n_low = sum(v["low"] for v in prov_summary.values())
-    n_info = sum(v.get("informational", 0) for v in prov_summary.values())
     # Merge scanner findings into severity counts for unified bar
-    policy_022_top = 0
     for f in findings_list:
         sev = (f.get("severity") or "").lower()
-        fid = str(f.get("id") or "").upper()
-        if "SAAS-API-022" in fid:
-            policy_022_top += 1
         if sev == "critical":
             n_crit += 1
         elif sev == "high":
@@ -147,8 +142,6 @@ def _compute_severity_counts(prov_summary, findings_list):
         "n_high": n_high,
         "n_med": n_med,
         "n_low": n_low,
-        "n_info": n_info,
-        "policy_022_top": policy_022_top,
     }
 
 

--- a/scanner/lib/dashboard_html_overview.py
+++ b/scanner/lib/dashboard_html_overview.py
@@ -434,8 +434,6 @@ def build_overview_blocks(
     n_high = sev["n_high"]
     n_med = sev["n_med"]
     n_low = sev["n_low"]
-    n_info = sev["n_info"]
-    policy_022_top = sev["policy_022_top"]
 
     prov_cards = _build_provider_cards(prov_summary)
 
@@ -503,8 +501,6 @@ def build_overview_blocks(
         "n_high": n_high,
         "n_med": n_med,
         "n_low": n_low,
-        "n_info": n_info,
-        "policy_022_top": policy_022_top,
         "prov_cards": prov_cards,
         "bar_crit": bars["bar_crit"],
         "bar_high": bars["bar_high"],

--- a/scanner/tests/test_dashboard_html_helpers_pure.py
+++ b/scanner/tests/test_dashboard_html_helpers_pure.py
@@ -251,13 +251,15 @@ class TestComputeSeverityCounts(unittest.TestCase):
             "aws": {"critical": 1, "high": 2, "medium": 3, "low": 4, "informational": 5},
             "gcp": {"critical": 0, "high": 1, "medium": 0, "low": 0, "informational": 2},
         }
+        # `informational` stays in the fixture on purpose: it is a real key in
+        # prowler's provider summary, and this asserts the sum IGNORES it rather
+        # than folding it into another severity.
         result = helpers._compute_severity_counts(prov_summary, [])
         self.assertEqual(result["n_crit"], 1)
         self.assertEqual(result["n_high"], 3)
         self.assertEqual(result["n_med"], 3)
         self.assertEqual(result["n_low"], 4)
-        self.assertEqual(result["n_info"], 7)
-        self.assertEqual(result["policy_022_top"], 0)
+        self.assertNotIn("n_info", result)
 
     def test_findings_severity_merged_into_counts(self):
         findings = [
@@ -276,21 +278,18 @@ class TestComputeSeverityCounts(unittest.TestCase):
         self.assertEqual(result["n_med"], 1)
         self.assertEqual(result["n_low"], 1)
 
-    def test_policy_022_counted_case_insensitive(self):
-        findings = [
-            {"severity": "high", "id": "saas-api-022"},
-            {"severity": "high", "id": "SAAS-API-022-X"},
-            {"severity": "high", "id": "OTHER"},
-        ]
-        result = helpers._compute_severity_counts({}, findings)
-        self.assertEqual(result["policy_022_top"], 2)
+    def test_returns_only_the_four_bar_severities(self):
+        """The returned keys ARE the contract — pin them, not just their values.
 
-    def test_missing_informational_key_defaults_to_zero(self):
-        prov_summary = {
-            "aws": {"critical": 0, "high": 0, "medium": 0, "low": 0},
-        }
-        result = helpers._compute_severity_counts(prov_summary, [])
-        self.assertEqual(result["n_info"], 0)
+        `n_info` and `policy_022_top` used to be here and were never consumed:
+        no `{{N_INFO}}` / `{{POLICY_022_TOP}}` ever existed in the template. An
+        equality assertion is what stops a value being recomputed and quietly
+        going unrendered again; `assertIn` on four keys would not.
+        """
+        result = helpers._compute_severity_counts({}, [])
+        self.assertEqual(
+            sorted(result), ["n_crit", "n_high", "n_low", "n_med"]
+        )
 
     def test_empty_inputs_return_zero_counts(self):
         result = helpers._compute_severity_counts({}, [])
@@ -298,8 +297,6 @@ class TestComputeSeverityCounts(unittest.TestCase):
         self.assertEqual(result["n_high"], 0)
         self.assertEqual(result["n_med"], 0)
         self.assertEqual(result["n_low"], 0)
-        self.assertEqual(result["n_info"], 0)
-        self.assertEqual(result["policy_022_top"], 0)
 
 
 # ===========================================================================

--- a/scanner/tests/test_dashboard_html_modules.py
+++ b/scanner/tests/test_dashboard_html_modules.py
@@ -52,7 +52,7 @@ class TestHelpersPureFunctions(unittest.TestCase):
 
     def test_compute_severity_counts_empty(self):
         counts = dashboard_html_helpers._compute_severity_counts({}, [])
-        for key in ("n_crit", "n_high", "n_med", "n_low", "n_info", "policy_022_top"):
+        for key in ("n_crit", "n_high", "n_med", "n_low"):
             self.assertIn(key, counts)
             self.assertEqual(counts[key], 0)
 

--- a/scanner/tests/test_dashboard_html_overview_unit.py
+++ b/scanner/tests/test_dashboard_html_overview_unit.py
@@ -361,8 +361,7 @@ def test_overview_blocks_returns_expected_keys():
     """build_overview_blocks returns the documented dict contract."""
     result = build_overview_blocks(**_overview_kwargs())
     expected = {
-        "n_crit", "n_high", "n_med", "n_low", "n_info",
-        "policy_022_top", "prov_cards",
+        "n_crit", "n_high", "n_med", "n_low", "prov_cards",
         "bar_crit", "bar_high", "bar_med", "bar_warn", "bar_low",
         "top_findings_html", "env_connected", "env_total",
         "service_surface_html", "priority_queue_html",


### PR DESCRIPTION
Follow-up to #514, which deleted four dead `_TEMPLATE_KEYS` entries and left the
upstream half **reported rather than fixed**. `_compute_severity_counts` was
still computing `n_info` and `policy_022_top`, and `build_overview_blocks` was
still re-exporting both, with no consumer once #514 landed.

## They were not orphaned by #514 — they were born dead

```console
$ git log -S"POLICY_022_TOP" -- scanner/lib/dashboard-template.html
$ git log -S"N_INFO"         -- scanner/lib/dashboard-template.html
(both empty)
```

Neither placeholder has **ever** existed in the template, so neither value has
ever reached a rendered dashboard. They survived three refactors (#89, the
12-helper split, the reusable-CI-actions change) because a key that is computed,
returned, passed and stored looks exactly like a key that is used.

## What was removed

| Where | What |
|---|---|
| `dashboard_html_helpers.py` | both computations, the `fid` local that existed only to feed the `SAAS-API-022` test, both dict entries |
| `dashboard_html_overview.py` | both reads from `sev`, both re-exports |
| 3 test files | the assertions that pinned them |

## `SAAS-API-022` itself is LIVE

It is the Okta required-scope-mapping check in
`scanner/checks/saas/api-checks.sh:443`, and it still fires. **Only the counter
was dead.** If that count is ever wanted on screen it is three lines plus a
placeholder — this removes an unrendered metric, not a broken feature.

## The replacement test asserts the key set by EQUALITY

```python
self.assertEqual(sorted(result), ["n_crit", "n_high", "n_low", "n_med"])
```

`assertIn` on four keys is exactly what let a fifth and sixth sit there
unrendered across three refactors. Equality is the same discipline
`KNOWN_DEAD_KEYS` uses one level up: a new key fails until someone either wires
it up or drops it.

The `informational` entry stays in the provider-summary fixture on purpose, with
a comment — it is a real prowler key, and the test now asserts the sum **ignores**
it rather than folding it into another severity.

## Test plan

| Check | Result |
|---|---|
| `pytest scanner/tests/` + 99% floor | **2759 passed, 11 skipped**; `scanner/lib` **99.43%**, `dashboard_html_helpers.py` **100%** |
| `unittest discover 'test_ci_*.py'` | **Ran 1088 — OK** |
| `test_dashboard_control_liveness.sh` | **14/14 live, 2 skipped**, 0 CSP violations |
| `test_asset_dashboard_control_liveness.sh` | **20/20 live, 2 skipped**, 0 CSP violations |
| ruff / markdownlint | clean / clean |

Both liveness suites re-run because this touches `scanner/lib/dashboard_html_*`,
and both match their recorded baselines exactly.

Refs OWASP CICD-SEC-1; the "dead renderer" class recorded in this repo before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)