### PR TITLE
docs(rules): name the branch point, because a bare `switch -c` forked from someone else's work

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -42,6 +42,33 @@ When creating PRs:
 - Use `--delete-branch` on merge to keep the remote clean. If the PR has open
   PRs stacked on it, retarget those FIRST — see [Stacked PRs](#stacked-prs-base--another-feature-branch).
 
+### Always name the branch point
+
+```bash
+git fetch origin main -q && git switch -c <branch> origin/main
+```
+
+**Never bare `git switch -c <branch>`**, and never treat a `git status` taken
+earlier in the session as evidence of where `HEAD` is now. This checkout is
+shared — concurrent agent sessions and the hourly automation both run `git
+checkout` in it.
+
+Measured 2026-09-02: a session read `## main...origin/main` clean at startup,
+and 35 seconds before it branched, another session created a branch and
+committed to it. `git pull --ff-only origin main` then ran while `HEAD` was on
+that branch — which merges `origin/main` INTO it and reports `Already up to
+date`, without moving to `main` — and bare `git switch -c` forked from its tip.
+The other session's commit rode into PR #513 and was squash-merged to `main`
+unreviewed, leaving its own PR #512 open with an empty effective diff. Neither
+command fails, so nothing signals it.
+
+Two cheap confirmations, because the failure is silent by construction:
+
+- `git log --oneline -1` right after branching must be the commit you expect.
+- `git diff --stat origin/main` before committing must list only your files, and
+  the file list `gh pr merge` prints must match. A file you never touched
+  appearing there means stop, not ship.
+
 ### Pre-PR validation (docs changes)
 
 Run locally before opening a docs PR:


### PR DESCRIPTION
Adds one rule to `.claude/rules/git-workflow.md`: **always name the start point.**

```bash
git fetch origin main -q && git switch -c <branch> origin/main
```

## Why — this already cost a mixed merge to `main`

This checkout is shared: concurrent agent sessions and the hourly automation
both run `git checkout` in it. A `git status` taken at session start is not
evidence of where `HEAD` is when you branch minutes later.

Measured 2026-09-02:

```text
10:59:13  commit: fix: stop discarding stdout in run_with_timeout ...
          (another session, on a NEW branch)
10:59:48  checkout: moving from that branch to fix/codeql-pin-and-junit-reporter
```

The session had read `## main...origin/main` clean at startup. Its
`git pull --ff-only origin main` then ran **while `HEAD` was on the other
branch** — which merges `origin/main` INTO that branch and reports `Already up
to date` without moving to `main` — and bare `git switch -c` forked from its
tip.

Result: that session's commit rode into #513 and was squash-merged to `main`
unreviewed, leaving its own PR #512 open with an empty effective diff.

**Neither command fails and nothing warns.** The only signal is the file list,
which is why the rule adds two confirmations that cost nothing:

```bash
git log --oneline -1          # right after branching
git diff --stat origin/main   # before committing; and check `gh pr merge`'s printed list
```

Naming the start point removes the class outright. #514 and #515 both used it
and both landed with exactly their intended files.

## Notes

- Docs-only, `.claude/` — **not linted by CI**: `markdown-lint`'s globs are
  `**/*.md` plus `!.claude/**`. markdownlint was run locally; the single MD032 it
  reports at line 16 is pre-existing on `main` and deliberately left alone.
- No code, no workflow, no gate changes.

Refs OWASP CICD-SEC-1 (Insufficient Flow Control) — an unreviewed commit reaching
a protected branch is a flow-control gap, not just an inconvenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)