### PR TITLE
chore(ci): delete the Codecov upload and badge — neither has ever worked

### DIFF
--- a/.claude/skills/lychee-redirect-triage/SKILL.md
+++ b/.claude/skills/lychee-redirect-triage/SKILL.md
@@ -131,8 +131,11 @@ Success criteria:
   v0.24.x nests the binary in a `lychee-<triple>/` subdir the pinned
   lychee-action installer can't find (`install: cannot stat`). #204 bumped it
   and broke CI; reverted in #209/#210.
-- **codecov badge SVG** stays on apex `codecov.io` (not `app.codecov.io`) — the
-  apex is the canonical badge host; don't "fix" its redirect.
+- ~~**codecov badge SVG** stays on apex `codecov.io`~~ — **moot since 2026-09-03**:
+  the badge was removed from `README.md` along with the upload step, so no
+  codecov URL is left for lychee to follow. Kept as a struck-through note rather
+  than deleted, because the underlying rule still applies to any badge host — an
+  apex that redirects to an `app.` subdomain is canonical, not rot.
 - **A green PR `link-check` is not proof of link health** — see the top section.
 
 ## Related

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -638,40 +638,6 @@ jobs:
           path: test-reports/*.xml
           retention-days: 14
           if-no-files-found: ignore
-      - name: Upload coverage to Codecov
-        if: always()
-        # VERDICT SUPPRESSED — WHAT IT HIDES: `continue-on-error` +
-        # `fail_ci_if_error: false` mean an upload failure (Codecov outage, missing
-        # or expired CODECOV_TOKEN, rate-limit) is invisible. What is lost is only
-        # REPORTING: the badge and the Codecov diff go stale silently. No gate is
-        # lost — the 99% floor is enforced locally by `--cov-fail-under=99` above,
-        # not by Codecov. Deliberate: a third-party outage must not block merges.
-        #
-        # THIS IS NOT HYPOTHETICAL — IT IS THE CURRENT STATE. Measured 2026-09-02,
-        # every retained run rejects the upload:
-        #   error -- Upload queued for processing failed:
-        #            {"message":"Token required - not valid tokenless upload"}
-        # Seen on runs 33596066956, 33578709890, 32085492644 (08-18) and
-        # 31363093761 (08-10, the OLDEST retained run — so >= 23 days, start
-        # unknown). Confirmed outside the logs: the badge URL in README.md renders
-        # `>unknown<`, i.e. Codecov holds no data for this repo at all.
-        # `CODECOV_TOKEN` is passed below but is empty or invalid, so the CLI falls
-        # through to a tokenless upload and is refused.
-        # The paragraph above still holds — no GATE is lost — but "goes stale
-        # silently" understates it: there is nothing to go stale.
-        # NEEDS A DECISION, not a code tweak: set a valid `CODECOV_TOKEN` secret,
-        # or delete this step AND the README badge. A third option, if the signal
-        # is wanted without the third-party coupling, is `fail_ci_if_error: true`
-        # limited to `push` on `main` so a token expiry is loud without blocking
-        # PRs on an outage.
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
-        continue-on-error: true
-        with:
-          files: test-reports/coverage.xml
-          flags: scanner-lib
-          fail_ci_if_error: false
-          verbose: true
-          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Fail workflow on scanner unittest / coverage failure
         if: always() && steps.scanner_tests.outputs.test_exit_code != '0'
         run: |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 > AI Security Best Practices toolkit for secure development with Claude Code
 
 [![npm version](https://img.shields.io/npm/v/claudesec?color=cb3837&logo=npm)](https://www.npmjs.com/package/claudesec)
-[![codecov](https://codecov.io/gh/Twodragon0/claudesec/branch/main/graph/badge.svg?flag=scanner-lib)](https://app.codecov.io/gh/Twodragon0/claudesec)
 [![GitHub stars](https://img.shields.io/github/stars/Twodragon0/claudesec?style=flat&color=yellow)](https://github.com/Twodragon0/claudesec)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)

--- a/scanner/tests/test_ci_required_graph_not_disabled.py
+++ b/scanner/tests/test_ci_required_graph_not_disabled.py
@@ -154,18 +154,20 @@ REDIRECT_KEYS_NOTE = (
 ALLOWED_STEP_REDIRECT: frozenset = frozenset()
 
 # Reviewed exceptions, `(workflow file, job key, step name)`. Each one is a step
-# whose failure genuinely must not fail the build.
+# whose failure genuinely must not fail the build. Empty: no step in the required
+# graph carries `continue-on-error` today.
 #
-# Codecov upload: a third-party artifact upload, not an enforcement step. The
-# coverage FLOOR is enforced separately and blockingly by the
+# It held one entry until 2026-09-03 — the Codecov upload, excused as "a
+# third-party artifact upload, not an enforcement step". That reasoning was
+# sound and the step is now GONE, not re-excused: measured 2026-09-02, the repo
+# has zero Actions secrets (`total_count: 0`), so `CODECOV_TOKEN` was never set,
+# every upload since at least 2026-08-10 was refused with
+# `Token required - not valid tokenless upload`, and the README badge rendered
+# `unknown`. Nothing was lost by deleting it — the coverage FLOOR is enforced
+# blockingly by `--cov-fail-under=99` and the
 # `Fail workflow on scanner unittest / coverage failure` step in the same job
-# (and pinned by test_ci_coverage_thresholds.py), so a flaky upload cannot hide a
-# coverage regression.
-ALLOWED_STEP_EXCEPTIONS = frozenset(
-    {
-        ("lint.yml", "scanner-unit-tests", "Upload coverage to Codecov"),
-    }
-)
+# (pinned by test_ci_coverage_thresholds.py).
+ALLOWED_STEP_EXCEPTIONS: frozenset = frozenset()
 
 # `if:` on a step in the required graph.
 #


### PR DESCRIPTION
The upload has been refused on **every retained run** and the README badge
renders `unknown`.

## Root cause

Measured 2026-09-02, with admin permissions so the empty result is real:

```console
$ gh api repos/Twodragon0/claudesec/actions/secrets
{"total_count":0,"secrets":[]}
```

The repo has **no Actions secrets at all**, so `secrets.CODECOV_TOKEN` has always
resolved to the empty string, the CLI fell through to a tokenless upload, and
Codecov refused it:

```text
error -- Upload queued for processing failed:
         {"message":"Token required - not valid tokenless upload"}
```

Runs `33596066956`, `33578709890`, `32085492644` (08-18), `31363093761` (08-10 —
the oldest *retained* run, so the real start date is unknown). Independently
confirmed outside the logs: the badge URL renders `>unknown<`, and
`api.codecov.io` returns 500 for this repo. **Codecov holds no data for it.**

#519 recorded the measurement and left the decision open. The decision is to
remove: a badge on the front page reading `unknown` is a broken promise, and an
upload step that cannot succeed is the same green-while-dead shape as the rest of
this week's work — it just costs reporting rather than a gate.

## Nothing is lost

The coverage floor is enforced **blockingly**, in the same job, by
`--cov-fail-under=99` plus the `Fail workflow on scanner unittest / coverage
failure` re-raise step. Both still present, both pinned by
`test_ci_coverage_thresholds.py`. The coverage XML is still produced and still
uploaded by `Upload scanner unittest + coverage artifacts`.

## Removed together

A partial removal is what leaves the next reader guessing:

| What | Why it had to go too |
|---|---|
| the `Upload coverage to Codecov` step + comment block | the defect itself |
| the README badge | the user-visible `unknown` |
| `ALLOWED_STEP_EXCEPTIONS` in `test_ci_required_graph_not_disabled.py` | existed **only** to excuse that step's `continue-on-error` |
| the codecov note in the `lychee-redirect-triage` skill | no codecov URL is left for lychee to follow |

The guard caught its own stale entry — `stale allowlist entries (step fixed or
moved)` — which is the allowlist-**equality** discipline working exactly as
designed. It is now empty, matching the sibling `ALLOWED_STEP_REDIRECT`.

The skill note is **struck through rather than deleted**: the underlying rule (an
apex that redirects to an `app.` subdomain is canonical, not rot) still applies
to any badge host.

## Deliberately not touched

`docs/guides/ci-coverage-journey.md` and the 2026-05-21 session report. Both are
**retrospectives**, and "#113 added a Codecov upload step" remains true as
history. Rewriting history to match the present is how a retrospective stops
being evidence.

## Test plan

| Check | Result |
|---|---|
| `pytest scanner/tests/` + 99% floor | **2776 passed, 11 skipped**; `scanner/lib` **99.43%** |
| `unittest discover 'test_ci_*.py'` | **Ran 1105 — OK** |
| `lint.yml` PyYAML parse | OK; floor + re-raise step confirmed still present |
| markdownlint | clean |
| remaining `codecov` refs in `lint.yml` / `README.md` | **0** |

Refs OWASP CICD-SEC-1 (Insufficient Flow Control).

🤖 Generated with [Claude Code](https://claude.com/claude-code)