### PR TITLE
fix(ci): fire the review-precondition trigger, and shrink the auto-arm to pip

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -198,10 +198,25 @@ jobs:
           # `github_actions` is deliberately absent — see the note above. It is
           # already unreachable via the `.github/**` hard-exclude, so this is a
           # second, independent refusal rather than the only one.
+          #
+          # `docker` was removed 2026-09-03 for the same reason, but the claim is
+          # WEAKER than the `github_actions` one and the difference matters.
+          # Measured: every docker-ecosystem Dependabot PR in this repo's history
+          # touches a hard-excluded path — #476, #353, #293, #273, #235
+          # (`Dockerfile.nginx`) and #220 (`Dockerfile` + `Dockerfile.nginx`) —
+          # so on the OBSERVED population this changes nothing. It is NOT
+          # unreachable by construction: a docker-ecosystem PR touching only,
+          # say, `docker-compose.yml` would have armed before and is refused now.
+          # That tightening is intended, not incidental — auto-merge on an image
+          # bump rested entirely on a path match, and the path match was shown to
+          # fail open (#522).
+          # RE-ADD CONDITION: a docker bump that must auto-merge and provably
+          # cannot touch a `Dockerfile*`. Re-add it deliberately, with the
+          # measurement, and update `test_ci_dependabot_auto_merge_fail_closed`.
           case "$ECOSYSTEM" in
-            pip|docker) ;;
+            pip) ;;
             *)
-              echo "Ecosystem '$ECOSYSTEM' is not in the auto-arm allowlist (pip, docker) — skipping."
+              echo "Ecosystem '$ECOSYSTEM' is not in the auto-arm allowlist (pip) — skipping."
               exit 0
               ;;
           esac

--- a/scanner/tests/test_ci_dependabot_auto_merge_fail_closed.py
+++ b/scanner/tests/test_ci_dependabot_auto_merge_fail_closed.py
@@ -135,10 +135,20 @@ CASES = (
      "version-update:semver-patch", "pip", False),
     ("semver-major", "true", "requirements-ci.txt",
      "version-update:semver-major", "pip", False),
+    # `docker` left the ecosystem allowlist on 2026-09-03. Pinned as its own case
+    # because it is the ONE input whose behaviour that change altered: every
+    # docker PR in this repo's history touches a hard-excluded `Dockerfile*` and
+    # was already refused, but a docker PR touching only e.g. `README.md` armed
+    # before and must not now. The tightening is the point — an image bump's
+    # safety rested entirely on a path match, and the path match failed open.
+    ("docker touching no Dockerfile", "true", "README.md",
+     "version-update:semver-minor", "docker", False),
     # The no-regression case. Without it this guard would pass on a step that
     # refuses everything, which gates nothing usable.
     ("eligible pip patch", "true", "requirements-ci.txt",
      "version-update:semver-patch", "pip", True),
+    ("eligible pip minor", "true", "requirements-ci.txt",
+     "version-update:semver-minor", "pip", True),
 )
 
 
@@ -208,6 +218,15 @@ class TestEligibilityFailsClosed(unittest.TestCase):
                     f"--- output ---\n{out}",
                 )
 
+    # NO ecosystem-allowlist assertion here ON PURPOSE. `test_ci_dependabot_automerge.py`
+    # already pins it (`REQUIRED_TOKENS["eligible_ecosystems"]`) and has its own
+    # mutation test for a widening, so a second copy would be the weak-duplicate
+    # shape ADR-001 warns about: two guards at different strictness over one
+    # invariant, where the narrower one rots into an inert restatement. This file
+    # owns BEHAVIOUR (what the step does with a given input); that one owns the
+    # allowlist TEXT. The `docker touching no Dockerfile` case above is the
+    # behavioural half of the same change.
+
     def test_the_unknown_case_explains_itself(self):
         """Fail-closed AND visible. Silence here is the class, one step over."""
         _, out = arms_auto_merge(
@@ -234,9 +253,17 @@ class TestGuardIsNonVacuous(unittest.TestCase):
     )
     EMPTY_LIST_GATE = r'(?m)^if \[ "\$path_count" -eq 0 \]; then$.*?^fi$\n'
 
+    # `pip`, not `docker`. The shipped defect was observed on a docker PR, but
+    # `docker` left the ecosystem allowlist on 2026-09-03, so a docker input is
+    # now refused at the ecosystem arm BEFORE either path gate is reached — the
+    # mutation would look "caught" while proving nothing about the gates. The
+    # guard caught that stale fixture itself ("stripping both gates did NOT
+    # re-open the hole. Check that FIRST"), which is the same lesson one turn
+    # later: a fix moves the terrain, so re-attack the new version on its own
+    # terms rather than replaying the old input.
     UNKNOWN_INPUT = dict(
         paths_known="false", changed_paths="",
-        update_type="version-update:semver-patch", ecosystem="docker",
+        update_type="version-update:semver-patch", ecosystem="pip",
     )
 
     @classmethod

--- a/scanner/tests/test_ci_dependabot_automerge.py
+++ b/scanner/tests/test_ci_dependabot_automerge.py
@@ -23,8 +23,13 @@ Control / CICD-SEC-4 Poisoned Pipeline Execution; NIST SSDF PW.4/PO.3):
   3. **Update-type allowlist** — only `version-update:semver-patch` /
      `semver-minor` may auto-arm; `semver-major` is hard-excluded. Broadening
      this would auto-merge breaking bumps.
-  4. **Ecosystem allowlist** — only `pip|docker`. Adding e.g.
-     `npm` here is a policy change that must be reviewed, not slipped in.
+  4. **Ecosystem allowlist** — only `pip`. `docker` was removed 2026-09-03:
+     every docker-ecosystem PR in this repo's history touches a hard-excluded
+     `Dockerfile*` (#476/#353/#293/#273/#235/#220), so the arm was reachable
+     only for a docker PR that touched none — which would have rested
+     entirely on the path match that #522 showed can fail open. Adding e.g.
+     `npm` or re-adding `docker` is a policy change that must be reviewed,
+     not slipped in.
   5. **No bypass** — the arm must stay `gh pr merge --auto` (server-side, still
      gated by branch protection + the human code-owner review). `--admin` must
      never appear (an admin bypass of branch protection is wrong regardless; `require_code_owner_reviews` is now false, but `enforce_admins` and the two required contexts still gate every merge), and the broken
@@ -84,7 +89,7 @@ REQUIRED_TOKENS = {
     # 4. Ecosystem allowlist. `github-actions` was REMOVED, not narrowed — it
     #    was unreachable twice over (see
     #    `test_actions_ecosystem_stays_out_of_the_allowlist`).
-    "eligible_ecosystems": "pip|docker)",
+    "eligible_ecosystems": "pip)",
     # 5. The arm must be server-side auto-merge (gated by branch protection)
     "arm_is_auto_merge": "gh pr merge --auto",
     # Sanity: this is the pull_request_target workflow we think it is
@@ -207,8 +212,9 @@ class TestDependabotAutoMergeGuard(unittest.TestCase):
         )
         self.assertIn(
             REQUIRED_TOKENS["eligible_ecosystems"], self.scan,
-            "Ecosystem allowlist changed from pip|docker — a policy "
-            "change that must be reviewed, not slipped in.",
+            "Ecosystem allowlist changed from pip — a policy change that "
+            "must be reviewed, not slipped in. Re-adding `docker` needs the "
+            "measurement in this file's docstring re-derived first.",
         )
 
     def test_actions_ecosystem_stays_out_of_the_allowlist(self):
@@ -295,7 +301,7 @@ class TestDependabotAutoMergeGuardMutation(unittest.TestCase):
             "  scripts/*|scripts)",
             'if [ "$UPDATE_TYPE" = "version-update:semver-major" ]; then',
             "  version-update:semver-patch|version-update:semver-minor) ;;",
-            "  pip|docker) ;;",
+            "  pip) ;;",
             'gh pr merge --auto --squash "$PR_URL"',
         ]
     )
@@ -392,8 +398,8 @@ class TestDependabotAutoMergeGuardMutation(unittest.TestCase):
 
     def test_broadening_ecosystems_is_detected(self):
         mutant = self._GOOD.replace(
-            "  pip|docker) ;;",
-            "  pip|docker|npm) ;;",
+            "  pip) ;;",
+            "  pip|npm) ;;",
         )
         self.assertTrue(
             any("eligible_ecosystems" in p for p in _violations(mutant)),

--- a/scripts/sync-repo-protection.sh
+++ b/scripts/sync-repo-protection.sh
@@ -115,6 +115,7 @@ esac
 
 log()  { echo "[sync-repo-protection] $*"; }
 err()  { echo "[sync-repo-protection] ERROR: $*" >&2; }
+warn() { echo "[sync-repo-protection] WARNING: $*" >&2; }
 
 check_deps() {
   local missing=0
@@ -135,6 +136,7 @@ check_deps() {
 
 PROTECTION_JSON=""
 REPO_JSON=""
+COLLABORATORS_JSON="[]"
 
 read_current_state() {
   log "Reading current branch-protection settings for ${REPO}:${BRANCH}..."
@@ -148,6 +150,17 @@ read_current_state() {
     err "Failed to read repo settings."
     exit 1
   }
+
+  # Read for the review PRECONDITION check below, not to configure anything.
+  # DESIRED_APPROVING_COUNT=0 is only defensible while there is exactly one
+  # person who could review; the comment above records that as a revisit
+  # trigger, and prose does not fire. Failing to read it is reported as
+  # "unknown" rather than assumed fine — an unread precondition is not a met one.
+  log "Reading collaborators for ${REPO} (review-precondition check)..."
+  COLLABORATORS_JSON="$(gh api "repos/${REPO}/collaborators" --paginate)" || {
+    warn "Failed to read collaborators — the review precondition cannot be checked."
+    COLLABORATORS_JSON="null"
+  }
 }
 
 # ---------------------------------------------------------------------------
@@ -160,7 +173,7 @@ DRIFT_EXIT=0
 compute_drift() {
   local pyout
   local pyexit=0
-  pyout="$(python3 - \
+  pyout="$(COLLABORATORS_JSON="${COLLABORATORS_JSON}" python3 - \
     "${PROTECTION_JSON}" \
     "${REPO_JSON}" \
     "${DESIRED_STRICT}" \
@@ -175,7 +188,7 @@ compute_drift() {
     "${DESIRED_DELETE_BRANCH}" \
     "${DESIRED_MERGE_COMMIT}" \
     "${DESIRED_REBASE_MERGE}" <<'PYEOF'
-import json, sys
+import json, os, sys
 
 protection = json.loads(sys.argv[1])
 repo       = json.loads(sys.argv[2])
@@ -235,8 +248,51 @@ if drifted:
 else:
     lines.append("  No drift detected -- settings match desired state.")
 
+# ---------------------------------------------------------------------------
+# Review PRECONDITION -- reported separately because --apply cannot fix it.
+#
+# `approving_count = 0` is deliberate and is documented above with a revisit
+# trigger: "the moment a second person gets write access, this should go back to
+# true with a non-zero approving count." That trigger lived only in prose, so
+# nothing would ever fire it. This is the mechanism.
+#
+# It is NOT folded into `drifted`: the live settings match the codified desire,
+# so calling it drift would be false, and the "Run with --apply" line would be
+# advice that cannot work. What changed is the WORLD the desire was chosen for.
+#
+# Counted by push access, not membership, so a read-only or bot collaborator
+# does not trip it.
+precondition_failed = False
+raw = os.environ.get("COLLABORATORS_JSON", "null")
+try:
+    collaborators = json.loads(raw)
+except ValueError:
+    collaborators = None
+
+if desired["approving_count"] == 0:
+    lines.append("")
+    if collaborators is None:
+        lines.append("  REVIEW PRECONDITION: UNKNOWN -- collaborator list could not be read.")
+        lines.append("  approving_count=0 assumes a single reviewer; that was not verified.")
+        precondition_failed = True
+    else:
+        pushers = sorted(
+            c.get("login", "?") for c in collaborators
+            if (c.get("permissions") or {}).get("push")
+        )
+        if len(pushers) > 1:
+            lines.append(f"  REVIEW PRECONDITION FAILED: {len(pushers)} collaborators have push: {', '.join(pushers)}")
+            lines.append("  approving_count=0 was chosen because a lone maintainer approving their")
+            lines.append("  own work is theatre. That is no longer the situation.")
+            lines.append("  DECIDE: raise DESIRED_APPROVING_COUNT (and likely DESIRED_CODE_OWNER_REVIEWS)")
+            lines.append("  in this script, or record why 0 is still right. --apply cannot fix this.")
+            precondition_failed = True
+        else:
+            who = pushers[0] if pushers else "<none>"
+            lines.append(f"  Review precondition OK: 1 collaborator with push ({who}); approving_count=0 stands.")
+
 print("\n".join(lines))
-sys.exit(1 if drifted else 0)
+sys.exit(1 if (drifted or precondition_failed) else 0)
 PYEOF
   )" || pyexit=$?
   DRIFT_REPORT="$pyout"


### PR DESCRIPTION
Approved plan:
`~/.omc-state/claudesec-f9f584c30a4c0635/plans/raise-required-approving-review-count.md`
(options A + B chosen; C deferred as its own decision).

Both changes serve one goal: the path hard-excludes in
`dependabot-auto-merge.yml` currently carry the whole weight of keeping
sensitive changes on human review, and #522 showed they can fail open.

## Not done — raising `required_approving_review_count`, and why

| fact | value |
|---|---|
| collaborators with push | **1** — `Twodragon0` |
| `enforce_admins` | **true** (admins not exempt) |
| GitHub | an author cannot approve their own PR |

So `count >= 1` is **asymmetric**: a Dependabot PR stays mergeable (the owner can
approve it) while **every PR the owner authors becomes permanently unmergeable**.
That is a merge outage, not a review requirement.

`sync-repo-protection.sh` already codified `0` as deliberate *with* a revisit
trigger — *"the moment a second person gets write access"* — and that trigger has
not fired.

## A. The revisit trigger now fires by itself

It lived in a comment, so nothing could ever fire it. The script now reads the
collaborator list and, while `DESIRED_APPROVING_COUNT` is 0, reports a **REVIEW
PRECONDITION** result. Counted by **push** access, not membership, so a read-only
or bot collaborator does not trip it.

**Reported separately from `drifted` on purpose.** The live settings *do* match
the codified desire, so calling it drift would be false and the report's *"Run
with `--apply` to remediate"* line would be advice that cannot work. What changed
is the world the desire was chosen for, and only a human can re-decide it. It
exits non-zero so `protection-drift-watch.yml`'s existing `result == 'drift'` arm
opens an issue — the same *"the issue IS the alert"* shape as #405.

**Fails closed on an unreadable list**: an unchecked precondition is not a met one.

Measured, all four paths:

```text
live (1 pusher)        -> "Review precondition OK ... approving_count=0 stands."  exit 0
2 pushers              -> "REVIEW PRECONDITION FAILED: 2 collaborators ..."       exit 1
read fails             -> "REVIEW PRECONDITION: UNKNOWN ..."                      exit 1
1 pusher + 1 read-only -> OK, no false alarm                                      exit 0
```

Passed by **env**, not as a 15th positional argument — that call already carries
14, and `sys.argv[N]` indexing is exactly the arity coupling #509 was about.

## B. `docker` leaves the ecosystem allowlist

Every docker-ecosystem Dependabot PR in this repo's history touches a
hard-excluded path — #476, #353, #293, #273, #235 (`Dockerfile.nginx`) and #220
(`Dockerfile` + `Dockerfile.nginx`) — so the arm was reachable only for a docker
PR that touched none.

**The claim is weaker than the `github_actions` one, and the difference is stated
rather than glossed.** `docker` is *not* unreachable by construction. Measured
before/after across seven inputs — six byte-identical, exactly one changes:

| input | before | after |
|---|---|---|
| `paths='README.md'` semver-minor/docker | ARMED | **refused** |

That tightening is intended, not incidental: auto-merge on an image bump rested
entirely on a path match. The **re-add condition** is written next to the `case`
arm — a docker bump that must auto-merge and provably cannot touch a
`Dockerfile*`.

## No duplicate guard

`test_ci_dependabot_automerge.py` already pins the allowlist **text** and has its
own widening mutation test, so its token moved `pip|docker)` → `pip)` and its
docstring carries the measurement.

The first draft of this change added a second, structurally stronger allowlist
assertion in the fail-closed guard. That is the **weak-duplicate** shape ADR-001
warns about — two guards at different strictness over one invariant, the narrower
rotting into an inert restatement — so it was removed with a note saying which
file owns what. `test_ci_dependabot_auto_merge_fail_closed.py` owns **behaviour**
and gained a `docker touching no Dockerfile` case plus an `eligible pip minor`
no-regression case.

**The guard caught its own fixture going stale.** With `docker` out of the
allowlist, the non-vacuity reconstruction's docker input is refused at the
ecosystem arm *before* either path gate — so it looked "caught" while proving
nothing. Switched to `pip`: a fix moves the terrain, so the new version gets
attacked on its own terms.

## Test plan

| Check | Result |
|---|---|
| `pytest scanner/tests/` + 99% floor | **2797 passed, 11 skipped**; `scanner/lib` **99.43%** |
| `unittest discover 'test_ci_*.py'` | **Ran 1126 — OK** |
| `sync-repo-protection.sh --dry-run` (live repo) | no drift, precondition OK |
| shellcheck / actionlint / ruff | clean / clean / clean |

Refs OWASP CICD-SEC-1 (Insufficient Flow Control), CICD-SEC-4; NIST SSDF PO.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)