### PR TITLE
fix(protection): require code-owner review again, now that the hard-excludes were shown to fail open

### DIFF
--- a/scanner/tests/test_ci_branch_protection_codified.py
+++ b/scanner/tests/test_ci_branch_protection_codified.py
@@ -31,15 +31,18 @@ Configuration; NIST SSDF SP 800-218 PO.3/PW.4):
   2. **enforce_admins=true** — admins (including the owner) are NOT exempt from
      branch protection. Flipping to false would let an admin force-push to main.
   3. **strict=true** — PRs must be up to date with main before merge.
-  4. **require_code_owner_reviews=false** — pinned to FALSE deliberately, and
-     pinned exactly so a change in EITHER direction is a reviewable diff. With
-     `required_approving_review_count=0` the setting's only effect was to block
-     PRs not authored by the sole code owner — measured across all 16 Dependabot
-     PRs, every merged one carries a manual `Twodragon0` approval and #388 sat
-     `BLOCKED` at 22/22 green until it was closed and reapplied by hand as #400,
-     while the owner's own PRs merge unreviewed. Re-enabling it is the right move
-     the moment a second person gets write access; until then it gates nothing a
-     human actually reads. The real controls are invariants 1-3 below.
+  4. **require_code_owner_reviews=true** — flipped from FALSE on 2026-09-04,
+     reversing #403, and pinned exactly so a change in EITHER direction is a
+     reviewable diff. With `required_approving_review_count=0` the setting's only
+     effect is to require an approval on PRs NOT authored by the sole code owner
+     — i.e. Dependabot's. #403 set it false reading that as overhead; #522 then
+     measured the auto-arm's path hard-excludes FAILING OPEN, which made those
+     Dependabot PRs the one place a human gate still mattered. Verified live
+     before flipping, not inferred: owner-authored PR #525 stayed
+     `MERGEABLE`/`CLEAN` with the flag on and the count still 0 (re-read 65s
+     apart), so this does NOT reproduce the merge outage that makes raising
+     `required_approving_review_count` non-viable for a solo maintainer. See the
+     comment block in the script for both decisions and the measured cost.
   5. **Safe-by-default dry-run** — the script must `set -euo pipefail` and the
      no-flag / `--dry-run` invocation must NOT write (only `--apply` mutates).
   6. **Drift marker contract** — the script emits the literal `DRIFT DETECTED`
@@ -106,8 +109,8 @@ REQUIRED_SCRIPT_TOKENS = {
     "enforce_admins_true": 'DESIRED_ENFORCE_ADMINS="true"',
     # 3. Up-to-date-before-merge.
     "strict_true": 'DESIRED_STRICT="true"',
-    # 4. CODEOWNERS review required.
-    "code_owner_reviews_false": 'DESIRED_CODE_OWNER_REVIEWS="false"',
+    # 4. CODEOWNERS review required on non-owner-authored PRs.
+    "code_owner_reviews_true": 'DESIRED_CODE_OWNER_REVIEWS="true"',
     # 5. Safe-by-default: strict bash mode + default dry-run arm.
     "strict_bash_mode": "set -euo pipefail",
     "default_is_dry_run": '--dry-run|"") MODE="dry-run"',
@@ -131,7 +134,7 @@ REQUIRED_WATCH_TOKENS = {
 BOOLEAN_DESIRED = {
     "DESIRED_ENFORCE_ADMINS": "true",
     "DESIRED_STRICT": "true",
-    "DESIRED_CODE_OWNER_REVIEWS": "false",
+    "DESIRED_CODE_OWNER_REVIEWS": "true",
 }
 _ASSIGN_RE = re.compile(r'^\s*(DESIRED_\w+)=["\']?([^"\'\s#]+)')
 
@@ -297,7 +300,7 @@ class TestBranchProtectionCodifiedMutation(unittest.TestCase):
             "set -euo pipefail",
             'DESIRED_STRICT="true"',
             'DESIRED_CONTEXTS=\'["Lint","Security Scan Gate"]\'',
-            'DESIRED_CODE_OWNER_REVIEWS="false"',
+            'DESIRED_CODE_OWNER_REVIEWS="true"',
             'DESIRED_ENFORCE_ADMINS="true"',
             '  --dry-run|"") MODE="dry-run" ;;',
             '    lines.append(f"  DRIFT DETECTED in: {x}")',

--- a/scripts/sync-repo-protection.sh
+++ b/scripts/sync-repo-protection.sh
@@ -43,36 +43,59 @@ DESIRED_STRICT="true"
 DESIRED_CONTEXTS='["Lint","Security Scan Gate"]'
 
 # Required pull-request reviews ──────────────────────────────────────────────
-# require_code_owner_reviews=FALSE, and this is the deliberate value.
+# require_code_owner_reviews=TRUE as of 2026-09-04. This REVERSES #403, which set
+# it to false, and both decisions are recorded because the second only makes
+# sense against the first.
 #
-# With required_approving_review_count=0, the ONLY thing code-owner review
-# enforced was a manual approval on PRs not authored by the sole code owner —
-# i.e. Dependabot's. Measured across all 16 Dependabot PRs: every merged one
-# carries a `Twodragon0` APPROVED review, and #388 (the one without) sat
-# `BLOCKED` with 22/22 checks green, zero conflicts and `mergeable: MERGEABLE`
-# until it was closed and reapplied by hand as #400. Meanwhile the owner's own
-# PRs merge with no review at all (#398, #400 — `reviewDecision` is empty on
-# both, because the count is 0), so the setting bought no review that was not
-# already optional.
+# WHAT #403 DECIDED, AND WHY IT WAS REASONABLE. With
+# required_approving_review_count=0, the only thing code-owner review enforces is
+# a manual approval on PRs NOT authored by the sole code owner — i.e.
+# Dependabot's. Measured across all 16 Dependabot PRs: every merged one carried a
+# `Twodragon0` APPROVED review, and #388 (the one without) sat `BLOCKED` with
+# 22/22 checks green until it was closed and reapplied by hand as #400. #403 read
+# that as a cost with no benefit: "it gates nothing a human actually reads."
 #
-# What still gates a merge, unchanged: the two required contexts below (Lint,
-# Security Scan Gate), strict up-to-date-branch, enforce_admins, and the
-# `test_ci_*` config-regression guard suite.
+# WHAT CHANGED. #522 measured the auto-arm's path hard-excludes FAILING OPEN: an
+# empty `gh pr diff` result walked the exclusion loop and armed auto-merge on a
+# `Dockerfile` PR, while the workflow's own comment called that path fail-closed.
+# Those hard-excludes were the only thing keeping sensitive Dependabot changes on
+# human review, so "gates nothing" stopped being true — #388 was the control
+# WORKING, not overhead.
+#
+# WHY THIS IS SAFE FOR A SOLO MAINTAINER, MEASURED NOT ASSUMED. Raising
+# required_approving_review_count is NOT viable here (one collaborator with push,
+# enforce_admins=true, and GitHub forbids approving your own PR — every
+# owner-authored PR would become permanently unmergeable). Code-owner review is
+# different, and that difference was verified live on 2026-09-04 rather than
+# inferred: with require_code_owner_reviews flipped to true and the count still 0,
+# owner-authored PR #525 stayed `MERGEABLE` / `CLEAN` / `reviewDecision` empty,
+# re-read 65s apart to rule out cached mergeability, then reverted to a byte-equal
+# baseline. Owner PRs are unaffected; only non-owner-authored PRs gain the gate.
+#
+# STILL UNVERIFIED, stated rather than glossed: that a Dependabot PR now reports
+# REVIEW_REQUIRED. No Dependabot PR was open during the experiment, so the
+# evidence for that half remains #388's observed BLOCKED state. Confirm on the
+# next bump.
+#
+# THE COST, measured: the last 8 merged Dependabot PRs (#510, #477, #476, #354,
+# #353, #322, #321, #294) all carry an empty `reviewDecision`. Each would now need
+# an approval click before its armed auto-merge fires. Auto-merge becomes
+# "auto-merge after approval". Revisit trigger in THIS direction: if that queue is
+# routinely rubber-stamped or ignored, the gate is theatre again and should come
+# back off — say so with the numbers, as #403 did.
 #
 # What this does NOT open up: an outside contributor's PR comes from a fork and
 # nobody but a write-holder can merge it, and `dependabot-auto-merge.yml`'s fork
 # guard (`head.repo.full_name == github.repository`) keeps a fork PR from ever
-# being auto-armed. CODEOWNERS itself stays in place and still auto-requests the
-# owner as a reviewer — it just no longer BLOCKS.
+# being auto-armed.
 #
-# Revisit trigger: the moment a second person gets write access, this should go
-# back to "true" with a non-zero approving count. A lone maintainer approving
-# their own work is theatre; two people reviewing each other is not.
-#
-# required_approving_review_count=0: no numeric approval requirement.
-# dismiss_stale_reviews=false: avoids blocking auto-merge on trivial rebases.
-# require_last_push_approval=false: no approval to dismiss, so the rule is moot.
-DESIRED_CODE_OWNER_REVIEWS="false"
+# required_approving_review_count=0: no NUMERIC approval requirement — see above
+#   for why raising it would be a merge outage rather than a review.
+# dismiss_stale_reviews=false: LOAD-BEARING alongside strict=true. Strict forces a
+#   rebase whenever main moves, and dismissing the approval on every rebase would
+#   make an approved Dependabot PR unmergeable in a busy week.
+# require_last_push_approval=false: same reason.
+DESIRED_CODE_OWNER_REVIEWS="true"
 DESIRED_APPROVING_COUNT="0"
 DESIRED_DISMISS_STALE="false"
 DESIRED_LAST_PUSH_APPROVAL="false"


### PR DESCRIPTION
Approved plan:
`~/.omc-state/claudesec-f9f584c30a4c0635/plans/option-c-require-code-owner-reviews.md`

Reverses #403, which set `require_code_owner_reviews=false`. **Both** decisions
are recorded in the script's comment block, because the second only makes sense
against the first.

## What #403 decided, and why it was reasonable

With `required_approving_review_count=0`, code-owner review's only effect is to
require an approval on PRs **not** authored by the sole code owner — i.e.
Dependabot's. Across all 16 Dependabot PRs at the time, every merged one carried
a `Twodragon0` approval and #388 sat `BLOCKED` at 22/22 green until it was closed
and reapplied by hand as #400. #403 read that as cost without benefit: *"it gates
nothing a human actually reads."*

## What changed

#522 measured the auto-arm's path hard-excludes **failing open** — an empty
`gh pr diff` result walked the exclusion loop and armed auto-merge on a
`Dockerfile` PR, while the workflow's own comment called that path fail-closed.
Those hard-excludes were the only thing keeping sensitive Dependabot changes on
human review. So *"gates nothing"* stopped being true: **#388 was the control
working.**

## Why this is safe for a solo maintainer — measured, not inferred

Raising `required_approving_review_count` is **not** viable here: one
collaborator with push, `enforce_admins=true`, and GitHub forbids approving your
own PR — every owner-authored PR would become permanently unmergeable.

Code-owner review is a different setting, and the difference was **verified live
before this change**:

| step | result |
|---|---|
| recorded baseline | `require_code_owner_reviews=false`, count 0 |
| flipped that field only | live confirmed `true` |
| owner-authored PR #525 | `MERGEABLE` / `CLEAN` / `reviewDecision` empty |
| re-read 65 s later | identical — not cached mergeability |
| reverted | byte-equal to the recorded baseline, drift 0 |

Owner PRs are unaffected; only non-owner-authored PRs gain the gate. The
experiment reused an already-open real PR instead of a throwaway, so it added no
outward artifact.

**Still unverified, stated rather than glossed:** that a Dependabot PR now
reports `REVIEW_REQUIRED`. No Dependabot PR was open during the experiment, so
the evidence for that half remains #388's observed `BLOCKED` state. Confirm on
the next bump.

## The cost, measured

The last 8 merged Dependabot PRs (#510, #477, #476, #354, #353, #322, #321, #294)
all carry an empty `reviewDecision`. Each would now need an approval click before
its armed auto-merge fires — auto-merge becomes **"auto-merge after approval"**.

The revisit trigger *in this direction* is written down too: if that queue gets
rubber-stamped or ignored, the gate is theatre again and should come back off,
with the numbers, as #403 did.

`dismiss_stale_reviews=false` stays false and is now documented as
**load-bearing**: `strict=true` forces a rebase whenever `main` moves, and
dismissing the approval on every rebase would make an approved Dependabot PR
unmergeable in a busy week.

## The guard did its job

`test_ci_branch_protection_codified.py` pins this value in **both** directions,
so the flip had to be a reviewable diff rather than a silent one. Updated in the
same change: docstring, required-token name and value, boolean desired-state
table, and the mutation fixture's known-good script.

## Live state is NOT changed by this commit

`--dry-run` now reports exactly one row:

```text
require_code_owner              True                          False                         DRIFT
```

That is the codified change waiting for `--apply`. **Applying is a separate,
deliberate step immediately after merge**, so the drift window is minutes rather
than lasting until the next scheduled watch.

## Test plan

| Check | Result |
|---|---|
| `pytest scanner/tests/` + 99% floor | **2807 passed, 11 skipped**; `scanner/lib` **99.43%** |
| `unittest discover 'test_ci_*.py'` | **Ran 1136 — OK** |
| `shellcheck` | clean |
| `--dry-run` | drifts on exactly the one intended field |
| stale `code_owner_reviews_false` refs | none |

Refs OWASP CICD-SEC-1 (Insufficient Flow Control); NIST SSDF PO.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)