### PR TITLE
ci(guards): make the two guard jobs prove they EXECUTED, by data dependency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -425,6 +425,18 @@ jobs:
           # Closes the OTHER direction from a real failure — a run that
           # discovered nothing and still reported OK.
           printf '%s\n' "$out" | grep -qE '^Ran [1-9][0-9]* tests? in '
+          # THE SUITE MUST HAVE PASSED, asserted from the OUTPUT and not only
+          # from the exit status above. `unittest` prints `OK` or `OK (skipped=N)`
+          # on success and `FAILED (...)` on failure, and it prints `Ran N` EITHER
+          # WAY. So weakening the `|| { ... exit 1; }` branch above to `|| true`
+          # lets a genuinely FAILING suite publish a genuine count: measured,
+          # `job_ran_proof_problems() == []` and `guard_job_problems() == []` with
+          # the suite red and the job green. That is worse than the parking class
+          # this block was written for — parking runs nothing, this SWALLOWS
+          # failures — and the exit-status branch was the only thing stopping it.
+          # Two independent readings of the same run, so neither alone is the
+          # gate.
+          printf '%s\n' "$out" | grep -qE '^OK( |$)'
           # PROOF, DERIVED FROM THE WORK'S OUTPUT — not merely placed after it.
           #
           # The first version of this block wrote a constant `ran=true` as the
@@ -576,6 +588,15 @@ jobs:
             # that compares against the renderer over real repository content.
             if ! printf '%s\n' "$out" | grep -qE "^${method} \(.*\) \.\.\. ok$"; then
               echo "::error::$cls did not run ${method} — the adjudicating test is gone, renamed, or parked"
+              exit 1
+            fi
+            # And the CLASS must have passed, not just the adjudicating method.
+            # Same reason as the sibling check in `ci-guards`: weakening the
+            # `|| { ... exit 1; }` above to `|| true` lets a red class through,
+            # and every other check here is satisfied by a run in which the
+            # named method passed while some other method in the class failed.
+            if ! printf '%s\n' "$out" | grep -qE '^OK( |$)'; then
+              echo "::error::$cls did not report OK — a failure in it was swallowed"
               exit 1
             fi
             # Reached only by a class that ran, did not skip, and whose named

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -154,7 +154,7 @@ jobs:
             #
             # Over-inclusion here is fail-safe: it costs ~20s and cannot hide a
             # regression. Pinned by scanner/tests/test_ci_guard_self_verify.py.
-            echo "ci_config=$(match '^(\.github/|templates/|scanner/tests/(test_ci_|_ci_guard_util\.py)|scripts/setup\.sh$|requirements.*\.txt|lychee\.toml$|ruff\.toml$|Dockerfile|nginx/|package\.json$|\.npmignore$|lighthouserc\.json$|bin/|\.claude/skills/|\.claude-plugin/|docs/|\.claude/|[^/]*\.md$|\.gitleaks\.toml$)')"
+            echo "ci_config=$(match '^(\.github/|templates/|scanner/tests/(test_ci_|_ci_)|scripts/setup\.sh$|requirements.*\.txt|lychee\.toml$|ruff\.toml$|Dockerfile|nginx/|package\.json$|\.npmignore$|lighthouserc\.json$|bin/|\.claude/skills/|\.claude-plugin/|docs/|\.claude/|[^/]*\.md$|\.gitleaks\.toml$)')"
             # `docs/`, `.claude/`, root `*.md` and `.gitleaks.toml` are the
             # guard-read DATA surface, derived rather than guessed:
             # `test_ci_guard_self_verify.guard_data_files()` walks every tracked
@@ -408,60 +408,50 @@ jobs:
           # executes this body can observe it, and `unittest discover` exits 0 on
           # "Ran 0 tests". A wrong or dropped value would therefore be a SILENT
           # VACUOUS PASS. `test_ci_required_graph_not_disabled` caught exactly
-          # that on the first draft of this step; the `cd` lives in the body
-          # instead, where the two checks below fail closed on it.
-          cd scanner/tests
-          shopt -s nullglob
-          files=(test_ci_*.py)
-          echo "guard files on disk: ${#files[@]}"
-          [ "${#files[@]}" -gt 0 ]
-          # Captured rather than piped to a log file: no stray artifact, and no
-          # dependence on `pipefail` semantics for the verdict.
-          out=$(python3 -m unittest discover -s . -p 'test_ci_*.py' 2>&1) || {
-            printf '%s\n' "$out"
-            exit 1
-          }
-          printf '%s\n' "$out"
-          # Closes the OTHER direction from a real failure — a run that
-          # discovered nothing and still reported OK.
-          printf '%s\n' "$out" | grep -qE '^Ran [1-9][0-9]* tests? in '
-          # THE SUITE MUST HAVE PASSED, asserted from the OUTPUT and not only
-          # from the exit status above. `unittest` prints `OK` or `OK (skipped=N)`
-          # on success and `FAILED (...)` on failure, and it prints `Ran N` EITHER
-          # WAY. So weakening the `|| { ... exit 1; }` branch above to `|| true`
-          # lets a genuinely FAILING suite publish a genuine count: measured,
-          # `job_ran_proof_problems() == []` and `guard_job_problems() == []` with
-          # the suite red and the job green. That is worse than the parking class
-          # this block was written for — parking runs nothing, this SWALLOWS
-          # failures — and the exit-status branch was the only thing stopping it.
-          # Two independent readings of the same run, so neither alone is the
-          # gate.
-          printf '%s\n' "$out" | grep -qE '^OK( |$)'
-          # PROOF, DERIVED FROM THE WORK'S OUTPUT — not merely placed after it.
+          # that on the first draft of this step.
           #
-          # The first version of this block wrote a constant `ran=true` as the
-          # last line and called that a fall-through proof. It is not. Reaching
-          # the LAST line is not the same as having run the work: close a parking
-          # construct ABOVE the marker and the shell falls straight through it.
-          # Measured — wrapping this body in `if [ "${X:-}" = 1 ]; then ... fi`
-          # with `fi` on the line above the marker gave `job_ran_proof_problems()
-          # == []`, `guard_job_problems() == []`, the whole 1255-test suite `OK`,
-          # and the step exiting 0 having written `ran=true` with ZERO tests run.
-          # Two inserted lines, in one job. `case ... esac` measures the same, so
-          # it is a class and not a spelling of `if`.
+          # NO `cd` AND NO `discover` FLAGS EITHER, which is the whole reason
+          # this step is now one line. Three adversarial passes defeated
+          # successive versions of an inline invocation, and the last one found
+          # what they had in common: the proof was derived from a blob whose
+          # SCOPE and VERDICT were both decided inside that same blob. Measured
+          # on the real body, each with every static guard returning `[]`:
           #
-          # The property a marker actually needs is DOMINATION — every path that
-          # reaches it must have executed the work — and text analysis cannot see
-          # domination. A DATA DEPENDENCY can: `$ran` is computed from `$out`, so
-          # parking the work leaves `$out` unbound and `set -u` kills this line
-          # instead of falling through it.
-          ran=$(printf '%s\n' "$out" | sed -nE 's/^Ran ([1-9][0-9]*) tests? in .*/\1/p')
-          [ -n "$ran" ]
-          # Still LAST, now as the second line of defence rather than the whole
-          # argument: a command below it could still exit before the runner reads
-          # the file back. `job_ran_proof_problems()` asserts both the derivation
-          # and this position.
-          echo "ran=$ran" >> "$GITHUB_OUTPUT"
+          #   cd /tmp/decoy (one trivial test file)  exit 0, ran=1,  0 real guards
+          #   `-k '*bucket*'` appended to discover    exit 0, ran=18, 18 of 1264
+          #   red suite w/ a column-0 `OK ` line and
+          #     the `|| { exit 1; }` branch neutered  exit 0, ran=2,  suite FAILED
+          #
+          # None of those forges a number. The counts are REAL — the `cd` target,
+          # everything after `-p`, and the presence of an `OK` line were simply
+          # never pinned, and `2>&1` lets a failing run put `OK` in its own
+          # output, which is why the `^OK` check that replaced the third one was
+          # never a second INDEPENDENT reading.
+          #
+          # The runner derives its scan root from its own `__file__`, refuses
+          # arguments, and prints a count only when `wasSuccessful()`. Scope,
+          # filter and verdict are all out of shell text now.
+          #
+          # THE RUNNER APPENDS ITS OWN `ran=<count>` LINE. There is no
+          # shell variable in between, and that is the point: while the
+          # value passed through a variable, the proof could be forged by
+          # BINDING that variable without an `=` assignment, which the
+          # guard counted. Measured — with the work parked and one line
+          # seeded above it, all ten of these published `ran=9999` at
+          # exit 0 with the guard reporting nothing:
+          #   read -r ran <<<   printf -v ran   declare   export
+          #   mapfile   let   (( ran = ))   for ran in   IFS= read
+          #   and a step-level `env: ran:`, which is zero shell lines
+          # A plain `ran=9999` WAS caught, so the pin worked only for the
+          # one spelling it enumerated — the enumeration failure mode this
+          # file has now hit four times. Removing the variable removes the
+          # whole class instead of adding a tenth pattern.
+          #
+          # Parking this line appends nothing, so `lint-gate` fails closed;
+          # a non-zero runner trips `set -e` AND prints nothing.
+          python3 scanner/tests/_ci_guard_runner.py >> "$GITHUB_OUTPUT"
+          # Still LAST, as the second line of defence rather than the argument:
+          # a command below it could exit before the runner reads the file back.
 
   # ---------------------------------------------------------------------------
   # The renderer-adjudicated guard classes, which SKIP everywhere else.
@@ -515,102 +505,40 @@ jobs:
         id: canary
         run: |
           set -euo pipefail
-          # FAIL, do not skip, when the oracle is missing. The classes below
-          # skip on ImportError — correct for the package-free job, and the exact
-          # fail-open this job exists to close, so it must not be reproduced here.
+          # ONE LINE, for the reasons written out on `ci-guards`. This step used
+          # to be a shell loop that ran each class with `python3 -c`, parsed
+          # `unittest -v` prose for `^<method> \(.*\) \.\.\. ok$`, greped for a
+          # skip, and greped `^OK( |$)` as a verdict. Text a run produces is text
+          # a FAILING run can shape: measured, a red class whose output carried a
+          # column-0 `OK ` line satisfied that verdict check once the
+          # `|| { exit 1; }` branch was weakened, and the step published a genuine
+          # count with the suite red.
           #
-          # One line on purpose: an indented heredoc keeps its leading
-          # whitespace and Python rejects it (`IndentationError: unexpected
-          # indent`, measured), and de-indenting the body to column 0 would
-          # break out of this block scalar.
-          installed=$(python3 -c 'import markdown_it; print(markdown_it.__version__)')
-          if [ "$installed" != "4.0.0" ]; then
-            echo "::error::markdown-it-py is $installed, not the adjudicated 4.0.0 — re-measure before repinning"
-            exit 1
-          fi
-          cd scanner/tests
-          # PER CLASS, not once over the combined output. A single aggregate
-          # `Ran [1-9]` was the first version and a review defeated it: renaming
-          # the test methods of ONE class — an ordinary refactor, not a
-          # weakening — left that class contributing zero tests while the other
-          # two carried the count, so the job printed "Ran 5 tests / OK" and
-          # exited 0 with the measured residual payload live in the catalog and
-          # a reader seeing 0 of 70 guard rows. Renamed and DELETED classes were
-          # caught; EMPTIED was not, and emptied is what a refactor produces.
-          # NAMED methods, not just classes. A per-class count floor was the
-          # second version and a review defeated that too: parking the ONE method
-          # in `TestTheDocAgreesWithTheRenderer` that reads the real catalog left
-          # the class at two synthetic-fixture tests, no skip, `Ran 3 tests / OK`
-          # and exit 0 — with the residual payload live and a reader seeing 0 of
-          # 70 rows. A count cannot tell which test does the adjudicating.
+          # The runner decides scope from its own `ADJUDICATORS` table, refuses
+          # arguments, treats a missing or wrong-version oracle as a hard failure
+          # rather than a skip, and counts an adjudicator only when `TestResult`
+          # says it ran exactly once, was not skipped, and passed. Nothing parses
+          # prose, which is also why `descriptions=False` is no longer needed.
+          # `test_ci_guard_self_verify` pins `CANARY_CLASSES` equal to that table
+          # so the two cannot drift.
+          # THE RUNNER APPENDS ITS OWN `ran=<count>` LINE. There is no
+          # shell variable in between, and that is the point: while the
+          # value passed through a variable, the proof could be forged by
+          # BINDING that variable without an `=` assignment, which the
+          # guard counted. Measured — with the work parked and one line
+          # seeded above it, all ten of these published `ran=9999` at
+          # exit 0 with the guard reporting nothing:
+          #   read -r ran <<<   printf -v ran   declare   export
+          #   mapfile   let   (( ran = ))   for ran in   IFS= read
+          #   and a step-level `env: ran:`, which is zero shell lines
+          # A plain `ran=9999` WAS caught, so the pin worked only for the
+          # one spelling it enumerated — the enumeration failure mode this
+          # file has now hit four times. Removing the variable removes the
+          # whole class instead of adding a tenth pattern.
           #
-          # `adjudicated` is the job's PROOF, and it is incremented inside the
-          # loop body rather than asserted after it. See the derivation comment on
-          # `ci-guards`: a constant written below `done` proves only that `done`
-          # was reached, and a parking construct that closes above it falls
-          # through — measured there, and the same two-line edit works here.
-          adjudicated=0
-          for spec in \
-            "test_ci_catalog_doc_sync.TestTheDocAgreesWithTheRenderer:test_the_reduction_and_the_renderer_agree_on_the_real_catalog" \
-            "test_ci_adr_decision_numbering.TestTheParseAgreesWithCommonMark:test_the_parse_matches_the_renderer_on_every_stripper_case" \
-            "test_ci_markdown_scan_evasion.TestTheResidualIsBounded:test_silent_passes_stay_within_the_measured_ceiling"; do
-            cls="${spec%%:*}"
-            method="${spec##*:}"
-            # `descriptions=False`, which `python3 -m unittest -v` cannot be
-            # told to do. With descriptions ON, a method that HAS a docstring
-            # prints its summary line as `name (…)` and the `... ok` lands on a
-            # SECOND line — so the by-name check below stops matching and the
-            # job goes red because someone documented a test. Measured on
-            # `test_the_canary_fires_on_the_measured_residual_payload`, which
-            # already has one. Fail-closed, but a gate that cries wolf at
-            # ordinary authoring is a gate that gets deleted.
-            out=$(python3 -c 'import sys, unittest; sys.exit(0 if unittest.TextTestRunner(verbosity=2, descriptions=False, stream=sys.stdout).run(unittest.defaultTestLoader.loadTestsFromName(sys.argv[1])).wasSuccessful() else 1)' "$cls" 2>&1) || {
-              printf '%s\n' "$out"
-              exit 1
-            }
-            printf '%s\n' "$out"
-            # `unittest` exits 0 on "Ran 0 tests", so an emptied or renamed class
-            # would otherwise pass vacuously.
-            printf '%s\n' "$out" | grep -qE '^Ran [1-9][0-9]* tests? in ' || {
-              echo "::error::$cls ran ZERO tests — it adjudicates nothing"
-              exit 1
-            }
-            # And a SKIPPED class still counts in "Ran N", so the count check
-            # above cannot see a skip. Anchored on unittest's own two spellings
-            # rather than the bare word: `-v` echoes each method's docstring, and
-            # these classes' docstrings discuss skipping constantly.
-            if printf '%s\n' "$out" | grep -qE '\.\.\. skipped |\(skipped='; then
-              echo "::error::$cls SKIPPED in the job that exists to run it"
-              exit 1
-            fi
-            # The adjudicating method must have RUN and PASSED by name. This is
-            # the check a count cannot make: it is the one method in each class
-            # that compares against the renderer over real repository content.
-            if ! printf '%s\n' "$out" | grep -qE "^${method} \(.*\) \.\.\. ok$"; then
-              echo "::error::$cls did not run ${method} — the adjudicating test is gone, renamed, or parked"
-              exit 1
-            fi
-            # And the CLASS must have passed, not just the adjudicating method.
-            # Same reason as the sibling check in `ci-guards`: weakening the
-            # `|| { ... exit 1; }` above to `|| true` lets a red class through,
-            # and every other check here is satisfied by a run in which the
-            # named method passed while some other method in the class failed.
-            if ! printf '%s\n' "$out" | grep -qE '^OK( |$)'; then
-              echo "::error::$cls did not report OK — a failure in it was swallowed"
-              exit 1
-            fi
-            # Reached only by a class that ran, did not skip, and whose named
-            # adjudicating method passed. This is what makes `$adjudicated` a
-            # proof rather than a constant.
-            adjudicated=$((adjudicated + 1))
-          done
-          # One increment per adjudicator, so a loop that never iterates — or a
-          # body parked around it — cannot satisfy this. Compared against the
-          # literal count of specs above, which `canary_job_problems()` pins
-          # against `CANARY_CLASSES`; a spec added without raising the floor is a
-          # guard failure, not a silent widening.
-          [ "$adjudicated" -eq 3 ]
-          echo "ran=$adjudicated" >> "$GITHUB_OUTPUT"
+          # Parking this line appends nothing, so `lint-gate` fails closed;
+          # a non-zero runner trips `set -e` AND prints nothing.
+          python3 scanner/tests/_ci_canary_runner.py >> "$GITHUB_OUTPUT"
 
   scanner-unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -384,12 +384,14 @@ jobs:
     timeout-minutes: 5
     needs: changes
     if: needs.changes.outputs.ci_config == 'true' || github.event_name == 'schedule'
-    # FALL-THROUGH PROOF. `ran` is set by the LAST line of the work body below,
-    # so it is reachable only by executing everything before it. A guard reading
-    # workflow TEXT cannot prove a shell body reached its end — measured, `exit
+    # EXECUTION PROOF. `ran` is the test count PARSED OUT OF the suite's own
+    # output, so it cannot be produced without the suite having run. A guard
+    # reading workflow TEXT cannot prove a shell body executed — measured, `exit
     # 0` after `set -euo pipefail` here left `guard_job_problems() == []` — and
-    # this closes that by construction rather than by enumerating ways to spell
-    # "do not run". `lint-gate` requires it whenever this job reports success.
+    # neither can a constant written on the last line, which only proves the last
+    # line was reached (also measured; see the derivation comment in the body).
+    # `lint-gate` requires a positive integer here whenever this job reports
+    # success.
     outputs:
       ran: ${{ steps.guards.outputs.ran }}
     steps:
@@ -423,11 +425,31 @@ jobs:
           # Closes the OTHER direction from a real failure — a run that
           # discovered nothing and still reported OK.
           printf '%s\n' "$out" | grep -qE '^Ran [1-9][0-9]* tests? in '
-          # MUST BE THE LAST LINE. See `outputs.ran` above; anything below it
-          # would be skippable while the proof still fires, which is why
-          # `job_ran_proof_problems()` asserts this line's position and not
-          # merely its presence.
-          echo "ran=true" >> "$GITHUB_OUTPUT"
+          # PROOF, DERIVED FROM THE WORK'S OUTPUT — not merely placed after it.
+          #
+          # The first version of this block wrote a constant `ran=true` as the
+          # last line and called that a fall-through proof. It is not. Reaching
+          # the LAST line is not the same as having run the work: close a parking
+          # construct ABOVE the marker and the shell falls straight through it.
+          # Measured — wrapping this body in `if [ "${X:-}" = 1 ]; then ... fi`
+          # with `fi` on the line above the marker gave `job_ran_proof_problems()
+          # == []`, `guard_job_problems() == []`, the whole 1255-test suite `OK`,
+          # and the step exiting 0 having written `ran=true` with ZERO tests run.
+          # Two inserted lines, in one job. `case ... esac` measures the same, so
+          # it is a class and not a spelling of `if`.
+          #
+          # The property a marker actually needs is DOMINATION — every path that
+          # reaches it must have executed the work — and text analysis cannot see
+          # domination. A DATA DEPENDENCY can: `$ran` is computed from `$out`, so
+          # parking the work leaves `$out` unbound and `set -u` kills this line
+          # instead of falling through it.
+          ran=$(printf '%s\n' "$out" | sed -nE 's/^Ran ([1-9][0-9]*) tests? in .*/\1/p')
+          [ -n "$ran" ]
+          # Still LAST, now as the second line of defence rather than the whole
+          # argument: a command below it could still exit before the runner reads
+          # the file back. `job_ran_proof_problems()` asserts both the derivation
+          # and this position.
+          echo "ran=$ran" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
   # The renderer-adjudicated guard classes, which SKIP everywhere else.
@@ -460,9 +482,11 @@ jobs:
     timeout-minutes: 5
     needs: changes
     if: needs.changes.outputs.ci_config == 'true' || github.event_name == 'schedule'
-    # FALL-THROUGH PROOF — see the identical block on `ci-guards`. Measured here
-    # too: `exit 0` after `set -euo pipefail` left `canary_job_problems() == []`
-    # with zero test output and the step exiting 0.
+    # EXECUTION PROOF — see the block on `ci-guards`. `ran` is the number of
+    # adjudicators that ran, skipped nothing, and passed BY NAME, counted inside
+    # the loop body. Measured here too: `exit 0` after `set -euo pipefail` left
+    # `canary_job_problems() == []` with zero test output and the step exiting 0,
+    # and so did closing a parking construct above a constant last line.
     outputs:
       ran: ${{ steps.canary.outputs.ran }}
     steps:
@@ -507,6 +531,13 @@ jobs:
           # the class at two synthetic-fixture tests, no skip, `Ran 3 tests / OK`
           # and exit 0 — with the residual payload live and a reader seeing 0 of
           # 70 rows. A count cannot tell which test does the adjudicating.
+          #
+          # `adjudicated` is the job's PROOF, and it is incremented inside the
+          # loop body rather than asserted after it. See the derivation comment on
+          # `ci-guards`: a constant written below `done` proves only that `done`
+          # was reached, and a parking construct that closes above it falls
+          # through — measured there, and the same two-line edit works here.
+          adjudicated=0
           for spec in \
             "test_ci_catalog_doc_sync.TestTheDocAgreesWithTheRenderer:test_the_reduction_and_the_renderer_agree_on_the_real_catalog" \
             "test_ci_adr_decision_numbering.TestTheParseAgreesWithCommonMark:test_the_parse_matches_the_renderer_on_every_stripper_case" \
@@ -547,12 +578,18 @@ jobs:
               echo "::error::$cls did not run ${method} — the adjudicating test is gone, renamed, or parked"
               exit 1
             fi
+            # Reached only by a class that ran, did not skip, and whose named
+            # adjudicating method passed. This is what makes `$adjudicated` a
+            # proof rather than a constant.
+            adjudicated=$((adjudicated + 1))
           done
-          # MUST BE THE LAST LINE — see `outputs.ran` on this job. Placed AFTER
-          # `done`, so a loop that never iterates still reaches it: the loop
-          # body's own per-class floors are what catch that, and stacking two
-          # unrelated failure modes onto one line would make the message lie.
-          echo "ran=true" >> "$GITHUB_OUTPUT"
+          # One increment per adjudicator, so a loop that never iterates — or a
+          # body parked around it — cannot satisfy this. Compared against the
+          # literal count of specs above, which `canary_job_problems()` pins
+          # against `CANARY_CLASSES`; a spec added without raising the floor is a
+          # guard failure, not a silent widening.
+          [ "$adjudicated" -eq 3 ]
+          echo "ran=$adjudicated" >> "$GITHUB_OUTPUT"
 
   scanner-unit-tests:
     runs-on: ubuntu-latest
@@ -1530,6 +1567,7 @@ jobs:
           python3 - <<'PY'
           import json
           import os
+          import re
           import sys
 
           needs = json.loads(os.environ["NEEDS_JSON"])
@@ -1542,13 +1580,19 @@ jobs:
               print(f"Lint gate failed: {bad}")
               sys.exit(1)
 
-          # FALL-THROUGH PROOF. These two jobs exist to prove that OTHER things
-          # run, so a hole in them is worse than the same hole elsewhere — and
-          # the hole was measured: `exit 0` as the first line of either work body
-          # parks it with the guard that pins the job returning no problems, zero
-          # test output, and the step exiting 0. Text analysis cannot prove a
-          # shell body reached its end, so each body's LAST line sets `ran` and
-          # this requires it.
+          # EXECUTION PROOF. These two jobs exist to prove that OTHER things run,
+          # so a hole in them is worse than the same hole elsewhere — and the hole
+          # was measured: `exit 0` as the first line of either work body parks it
+          # with the guard that pins the job returning no problems, zero test
+          # output, and the step exiting 0. Text analysis cannot prove a shell
+          # body executed, so each body PARSES A COUNT out of its own work and
+          # this requires that count to be a positive integer.
+          #
+          # A COUNT, not a boolean, because a boolean can be a constant and a
+          # constant proves only its own line. Measured on the first version: a
+          # trailing `ran=true` with the work wrapped in a never-taken `if` whose
+          # `fi` sits one line above it left every guard returning `[]`, the whole
+          # suite green, and the step exiting 0 having run nothing.
           #
           # Conditional on `success`, never unconditional: both jobs legitimately
           # skip when the `ci_config` bucket does not match, and a skipped job has
@@ -1568,14 +1612,16 @@ jobs:
               name: needs[name].get("outputs", {}).get("ran", "")
               for name in proof_required
               if needs[name]["result"] == "success"
-              and needs[name].get("outputs", {}).get("ran") != "true"
+              and not re.fullmatch(
+                  r"[1-9][0-9]*", needs[name].get("outputs", {}).get("ran", "")
+              )
           }
           if unproven:
               print(
-                  "Lint gate failed: job(s) reported success without reaching the "
-                  f"end of their work body: {unproven}. The `ran` output is set by "
-                  "the last line of the run body, so an empty value means the body "
-                  "exited, was skipped, or never executed."
+                  "Lint gate failed: job(s) reported success without executing "
+                  f"their work: {unproven}. The `ran` output is a count parsed out "
+                  "of the job's own test output, so a missing or zero value means "
+                  "the body exited, was parked, or ran nothing."
               )
               sys.exit(1)
           print("Lint gate passed.")

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -384,6 +384,14 @@ jobs:
     timeout-minutes: 5
     needs: changes
     if: needs.changes.outputs.ci_config == 'true' || github.event_name == 'schedule'
+    # FALL-THROUGH PROOF. `ran` is set by the LAST line of the work body below,
+    # so it is reachable only by executing everything before it. A guard reading
+    # workflow TEXT cannot prove a shell body reached its end — measured, `exit
+    # 0` after `set -euo pipefail` here left `guard_job_problems() == []` — and
+    # this closes that by construction rather than by enumerating ways to spell
+    # "do not run". `lint-gate` requires it whenever this job reports success.
+    outputs:
+      ran: ${{ steps.guards.outputs.ran }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Set up Python
@@ -391,6 +399,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Run CI config regression guards
+        id: guards
         run: |
           set -euo pipefail
           # NO `working-directory:` — it is RUNNER-consumed, so nothing that
@@ -414,6 +423,11 @@ jobs:
           # Closes the OTHER direction from a real failure — a run that
           # discovered nothing and still reported OK.
           printf '%s\n' "$out" | grep -qE '^Ran [1-9][0-9]* tests? in '
+          # MUST BE THE LAST LINE. See `outputs.ran` above; anything below it
+          # would be skippable while the proof still fires, which is why
+          # `job_ran_proof_problems()` asserts this line's position and not
+          # merely its presence.
+          echo "ran=true" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------------------
   # The renderer-adjudicated guard classes, which SKIP everywhere else.
@@ -446,6 +460,11 @@ jobs:
     timeout-minutes: 5
     needs: changes
     if: needs.changes.outputs.ci_config == 'true' || github.event_name == 'schedule'
+    # FALL-THROUGH PROOF — see the identical block on `ci-guards`. Measured here
+    # too: `exit 0` after `set -euo pipefail` left `canary_job_problems() == []`
+    # with zero test output and the step exiting 0.
+    outputs:
+      ran: ${{ steps.canary.outputs.ran }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
       - name: Set up Python
@@ -457,6 +476,7 @@ jobs:
         # against. A range would let a release change the oracle between runs.
         run: python3 -m pip install --disable-pip-version-check markdown-it-py==4.0.0
       - name: Run the renderer-adjudicated guard classes
+        id: canary
         run: |
           set -euo pipefail
           # FAIL, do not skip, when the oracle is missing. The classes below
@@ -528,6 +548,11 @@ jobs:
               exit 1
             fi
           done
+          # MUST BE THE LAST LINE — see `outputs.ran` on this job. Placed AFTER
+          # `done`, so a loop that never iterates still reaches it: the loop
+          # body's own per-class floors are what catch that, and stacking two
+          # unrelated failure modes onto one line would make the message lie.
+          echo "ran=true" >> "$GITHUB_OUTPUT"
 
   scanner-unit-tests:
     runs-on: ubuntu-latest
@@ -1515,6 +1540,43 @@ jobs:
           }
           if bad:
               print(f"Lint gate failed: {bad}")
+              sys.exit(1)
+
+          # FALL-THROUGH PROOF. These two jobs exist to prove that OTHER things
+          # run, so a hole in them is worse than the same hole elsewhere — and
+          # the hole was measured: `exit 0` as the first line of either work body
+          # parks it with the guard that pins the job returning no problems, zero
+          # test output, and the step exiting 0. Text analysis cannot prove a
+          # shell body reached its end, so each body's LAST line sets `ran` and
+          # this requires it.
+          #
+          # Conditional on `success`, never unconditional: both jobs legitimately
+          # skip when the `ci_config` bucket does not match, and a skipped job has
+          # no outputs. Demanding the marker there would fail every unrelated PR,
+          # which is the false-alarm direction that gets a check deleted.
+          #
+          # A missing NAME is an error rather than a pass. `needs.get(name, {})`
+          # would silently wave through a renamed job, which is the vacuity class
+          # this repo already paid for with undeclared `needs.*.outputs.*` refs
+          # resolving to the empty string.
+          proof_required = ("ci-guards", "renderer-canary")
+          missing = [n for n in proof_required if n not in needs]
+          if missing:
+              print(f"Lint gate failed: not in needs, cannot be proven: {missing}")
+              sys.exit(1)
+          unproven = {
+              name: needs[name].get("outputs", {}).get("ran", "")
+              for name in proof_required
+              if needs[name]["result"] == "success"
+              and needs[name].get("outputs", {}).get("ran") != "true"
+          }
+          if unproven:
+              print(
+                  "Lint gate failed: job(s) reported success without reaching the "
+                  f"end of their work body: {unproven}. The `ran` output is set by "
+                  "the last line of the run body, so an empty value means the body "
+                  "exited, was skipped, or never executed."
+              )
               sys.exit(1)
           print("Lint gate passed.")
           PY

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -215,7 +215,7 @@ first line of the run body — one token, cheaper than any of the three — park
 step with `canary_job_problems()` returning `[]`, zero test output and exit 0;
 `if false; then ... fi`, an uncalled function wrapper and `set -n` all measure the
 same. Proving a shell script reaches its end requires running it, so this is a
-limit of static text analysis rather than a defect in the check, and it is
+limit of static text analysis rather than a defect in the check, and it was
 PRE-EXISTING AND REPO-WIDE rather than something this job introduced — measured:
 the same `exit 0` injected into the `ci-guards` job's run block gives
 `guard_job_problems() == []`, and that sibling predates this row. Every guard that
@@ -223,12 +223,38 @@ proves a job runs by scanning executed text falls the same way. `renderer-canary
 IS inside `test_ci_required_graph_not_disabled`'s graph (one of its 23 nodes), and
 an early `exit 0` is outside that guard's stated scope rather than a gap in it:
 that guard exists as the complement of EXECUTION, forbidding runner-consumed keys
-because something else was meant to cover the shell body. For this job nothing
-does. Closing it means executing the step body in a guard and requiring three
-`^Ran [1-9]` lines — the #404 move, which closed ten shapes at once where three
-parser fixes had closed one each — and that is not free here, because the body
-needs the oracle and the only job holding it is the one being proved. Left open
-deliberately, with the shape written down. The `<<` refusal is likewise a
+because something else was meant to cover the shell body.
+
+**CLOSED for these two jobs by a FALL-THROUGH PROOF, not by patching shape
+five.** Patching would have been the third fix to an enumeration, which
+ADR-001 §5 names as the signal to invert. The last line of each work body writes
+`ran=true` to `$GITHUB_OUTPUT`, and `lint-gate` requires it whenever the job
+reports `success`; that line is reachable only by executing everything above it,
+so all four measured shapes — and a fifth nobody has thought of — fail together
+by the shell's own semantics rather than by enumeration. `job_ran_proof_problems`
+asserts POSITION, not presence, because the marker alone is one edit from
+useless: hoisting it above the work, or putting any command after it, parks the
+job with the proof already written. Both are pinned, as is a typo'd `steps.<id>`
+reference (fail-closed at runtime — an empty output can never satisfy the proof —
+but caught statically so a typo does not raise an alarm indistinguishable from a
+real parking event). `lint-gate`'s own body is now EXECUTED by a test class
+across seven directions, which nothing in this repo did before: both proven,
+both skipped, one of each, either job parked, a renamed proof job, and an
+ordinary failure elsewhere. The both-skipped direction is the load-bearing one —
+these jobs legitimately skip whenever `ci_config` does not match, which is most
+PRs, and an unconditional demand would fail every unrelated one.
+
+**What is still open, stated because a defence that reads complete and is not is
+the failure this document exists to catch:** the regress does not terminate
+inside the workflow. `lint-gate`'s comparison lives in a `run:` body and is
+parkable the same way. This raises the cost of parking a guard job from one token
+to several coordinated edits across two jobs — **defence in depth, not
+closure**. What terminates it is outside this file: branch protection requiring
+the `Lint` context, and GitHub evaluating `needs:` itself. Scoped deliberately to
+the two guard-running jobs rather than all 23 nodes: those two exist to prove
+other things run, and they are the two where the hole was measured. Twenty-three
+markers whose per-job value is unmeasured would be a bigger diff than its
+evidence. The `<<` refusal is likewise a
 substring test, not a heredoc parser: it also fires on `echo "shift: 1 << 2"` and
 `: $(( 1 << 2 ))`, which fail closed and do not belong in this step.
 

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -281,6 +281,45 @@ argument. A typo'd `steps.<id>` reference is caught statically too (fail-closed
 at runtime, but a red build for a typo is indistinguishable from a real parking
 event).
 
+**Two further shapes, both found by a SECOND adversarial pass on the fix itself,
+and neither one closed by the data dependency alone.**
+
+*Forgery.* The dependency stops a parked body only while the source variable is
+**unbound**. Seed it above the parked span and the derivation runs on a lie —
+measured, `out="Ran 1 tests in 0.0s"` inserted above an `if`-wrapped body
+published `ran=1` at exit 0, and `adjudicated=3` hoisted above the canary's loop
+published `ran=3`, both with every check returning `[]`. That is a *third* line
+for the attacker, not closure. What catches it is that a seeded value is an
+**extra assignment**, and counting assignments is something text can do: the
+guard pins `out` at exactly one assignment and `adjudicated` at exactly two
+(`=0` and the increment). Rewriting the one legitimate assignment instead
+removes the `unittest discover` invocation, which `guard_job_problems` already
+rejects.
+
+*Swallowed failures.* `unittest` prints `Ran N` on failure exactly as on success,
+so weakening the capture's `|| { ...; exit 1; }` branch to `|| true` let a
+genuinely **red** suite publish a genuine count with the job green — measured at
+`job_ran_proof_problems() == []` and `guard_job_problems() == []`. This is worse
+than the parking class the design was built for: parking runs nothing, this hides
+real failures. Closed the same way the parking class was — by data dependency,
+not by pinning the branch shape. Both jobs now require their run to report `OK`,
+which is a second independent reading of the same output:
+
+| capture in `ci-guards` | exit | published |
+| --- | --- | --- |
+| failing suite + `\|\| true` | 1 | nothing |
+| failing suite, branch intact | 1 | nothing |
+| passing suite | 0 | `ran=1253` |
+| passing suite + `\|\| true` | 0 | `ran=1253` |
+
+The last two rows are not decoration. The third is non-vacuity — without it the
+first two prove nothing — and the fourth is attribution: it shows the `|| true`
+mutation alone is not what turns the build red, the *failure* is. The first
+version of that probe was wrong in exactly this way: `\n` inside a non-raw Python
+string reached `printf` as a literal backslash-n, the synthetic output collapsed
+onto one line, and every row went red for a reason unrelated to the test. The
+non-vacuity row is what caught it.
+
 `lint-gate`'s own body is EXECUTED by a test class, which nothing in this repo
 did before: both proven, both skipped, one of each, either job parked / zero /
 non-numeric, a renamed proof job, an ordinary failure elsewhere, and that the

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -255,81 +255,99 @@ fixture that picks the weak variant of a shape reports the shape as closed.**
 
 The property a marker actually needs is DOMINATION — every path reaching it must
 have executed the work — and no amount of text analysis establishes domination.
-A **data dependency** does. Each job now publishes a count computed from its own
-work: `ci-guards` parses `ran` out of `$out`, the suite's captured stdout, and
-`renderer-canary` increments `adjudicated` once per class that ran, did not skip,
-and passed its named adjudicating method. Under `set -euo pipefail`, parking the
-work leaves the source variable unbound and the publish line **dies** instead of
-falling through. Measured after the fix, same mutations:
+A **data dependency** gets closer: compute the published value *from* the work, so
+parking the work leaves its source unbound and the publish line dies. That closed
+the parking class, and a second pass then closed two more shapes on top of it
+(a seeded source variable; a `|| true` that let a red suite publish a real count).
 
-| body | exit | published |
-| --- | --- | --- |
-| `ci-guards` parked (`if`-wrap above publish) | 1 — `ran: unbound variable` | nothing |
-| `renderer-canary` parked (same) | 1 — `adjudicated: unbound variable` | nothing |
-| `ci-guards` unparked (real suite) | 0 | `ran=1261` |
+**A third pass defeated all of it, and found what the three versions had in
+common.** Each derived its proof from a blob whose SCOPE and VERDICT were both
+decided inside that same blob. Measured on the real body, each with every static
+guard returning `[]`:
 
-A constant cannot do this; only a value the work produces can. `lint-gate`
-requires a **positive integer**, so `0` (a loop that never iterated) and `true`
-(the previous, defeated design) are both rejected — reverting to the old shape is
-now a red build rather than a silent one-line edit.
+| edit | result |
+| --- | --- |
+| `cd /tmp/decoy` before an unchanged `discover` | exit 0, published `ran=1`, **zero real guards ran** |
+| `-k '*bucket*'` appended to `discover` | exit 0, published `ran=18` of 1264 |
+| red suite whose output has a column-0 `OK` line (with a trailing space), failure branch neutered | exit 0, published `ran=2`, suite `FAILED` |
 
-`job_ran_proof_problems` asserts that the derivation exists, precedes the publish
-line, and — for the canary — sits inside the loop body; that a floor rejects the
-empty/zero value; and that the published value is the variable rather than a
-literal. Position is still checked, as defence in depth rather than as the
-argument. A typo'd `steps.<id>` reference is caught statically too (fail-closed
-at runtime, but a red build for a typo is indistinguishable from a real parking
-event).
+**None of those forges a number.** The counts are genuine — the `cd` target,
+everything after `-p`, and the presence of an `OK` line were simply never pinned,
+and `2>&1` lets a failing run put `OK` into its own output. So the `^OK` check
+added by the second pass was never a second *independent* reading; it re-read a
+blob the failing run controls. The old `_DISCOVER_RE` was a substring test that
+stopped matching at `-p`, which is why an appended argument was invisible.
 
-**Two further shapes, both found by a SECOND adversarial pass on the fix itself,
-and neither one closed by the data dependency alone.**
+**Fixed by moving the three unpinnable things out of shell text** into two
+tracked runners, `scanner/tests/_ci_guard_runner.py` and
+`scanner/tests/_ci_canary_runner.py`. Each derives its scan root from its own
+`__file__` (so the working directory cannot redirect it), refuses arguments
+outright (so there is no filter to append), and prints a count only when
+`TestResult.wasSuccessful()` (so the verdict is structural rather than grepped).
+The canary runner additionally treats a SKIP as a failure and a missing or
+wrong-version oracle as a hard error rather than a skip — the fail-open it exists
+to close. Both steps are now a single line, and `job_ran_proof_problems` matches
+that line **anchored whole**, rejecting a `cd` in front, an argument behind, a
+pipe, or a `|| echo N`. Re-measured after the change:
 
-*Forgery.* The dependency stops a parked body only while the source variable is
-**unbound**. Seed it above the parked span and the derivation runs on a lie —
-measured, `out="Ran 1 tests in 0.0s"` inserted above an `if`-wrapped body
-published `ran=1` at exit 0, and `adjudicated=3` hoisted above the canary's loop
-published `ran=3`, both with every check returning `[]`. That is a *third* line
-for the attacker, not closure. What catches it is that a seeded value is an
-**extra assignment**, and counting assignments is something text can do: the
-guard pins `out` at exactly one assignment and `adjudicated` at exactly two
-(`=0` and the increment). Rewriting the one legitimate assignment instead
-removes the `unittest discover` invocation, which `guard_job_problems` already
-rejects.
+| attack | caught by |
+| --- | --- |
+| `cd` before the invocation | static guard (and exit 2 at runtime) |
+| `-k` appended | static guard (and exit 2 at runtime) |
+| `\|\| echo N` swallowing a failure | static guard |
+| body parked around the publish line | runtime — `ran: unbound variable`, nothing published |
 
-*Swallowed failures.* `unittest` prints `Ran N` on failure exactly as on success,
-so weakening the capture's `|| { ...; exit 1; }` branch to `|| true` let a
-genuinely **red** suite publish a genuine count with the job green — measured at
-`job_ran_proof_problems() == []` and `guard_job_problems() == []`. This is worse
-than the parking class the design was built for: parking runs nothing, this hides
-real failures. Closed the same way the parking class was — by data dependency,
-not by pinning the branch shape. Both jobs now require their run to report `OK`,
-which is a second independent reading of the same output:
+The adjudicator table lives once, in the canary runner, and
+`CANARY_CLASSES` is pinned equal to it so the two copies cannot drift.
+`descriptions=False` has no successor and that is deliberate: nothing parses
+prose any more, so the false-alarm it prevented (a docstring on an adjudicating
+method moving `... ok` onto a second line and turning documentation into a red
+build) cannot happen.
 
-| capture in `ci-guards` | exit | published |
-| --- | --- | --- |
-| failing suite + `\|\| true` | 1 | nothing |
-| failing suite, branch intact | 1 | nothing |
-| passing suite | 0 | `ran=1253` |
-| passing suite + `\|\| true` | 0 | `ran=1253` |
+**A fourth pass then defeated the driver design too**, on the one thing still
+carried in shell: the published value passed through `$ran`, and the guard pinned
+that by counting `^ran=` assignments. Bash binds a variable many other ways.
+Measured — work parked, one line seeded above it — every one of these published
+`ran=9999` at exit 0 with the guard silent, while a plain `ran=9999` was caught:
 
-The last two rows are not decoration. The third is non-vacuity — without it the
-first two prove nothing — and the fourth is attribution: it shows the `|| true`
-mutation alone is not what turns the build red, the *failure* is. The first
-version of that probe was wrong in exactly this way: `\n` inside a non-raw Python
-string reached `printf` as a literal backslash-n, the synthetic output collapsed
-onto one line, and every row went red for a reason unrelated to the test. The
-non-vacuity row is what caught it.
+```text
+read -r ran <<<   printf -v ran   declare ran=   export ran=
+mapfile -t ran    let ran=        (( ran = ))    for ran in
+IFS= read -r ran < <(...)         step-level `env: ran:`  (zero shell lines)
+```
 
-`lint-gate`'s own body is EXECUTED by a test class, which nothing in this repo
-did before: both proven, both skipped, one of each, either job parked / zero /
-non-numeric, a renamed proof job, an ordinary failure elsewhere, and that the
-script reads the same env var the step writes. The both-skipped direction is the
-load-bearing one — these jobs legitimately skip whenever `ci_config` does not
-match, which is most PRs, and an unconditional demand would fail every unrelated
-one. The env-var direction is a **polarity** fix: the class originally hardcoded
-`NEEDS_JSON` in its harness, so renaming only the `env:` key (fatal in CI) passed
-all seven tests while renaming both sides consistently (harmless) failed all
-seven.
+The pin worked for exactly the spelling it enumerated — the same failure mode,
+now four times over. **So the variable was removed rather than the list
+extended.** Each runner prints its own `ran=<count>` and the step appends it:
+
+```bash
+python3 scanner/tests/_ci_guard_runner.py >> "$GITHUB_OUTPUT"
+```
+
+Nothing is left to bind. The step's executed shell is now checked EXHAUSTIVELY —
+`set -euo pipefail` plus that one anchored line, nothing else — so a `cd`, an
+appended argument, a pipe, a `|| true`, a different redirect target, a second
+`$GITHUB_OUTPUT` writer, or the `if`/`fi` a parking construct needs are all
+rejected as extra lines. Parking additionally appends nothing at runtime, so
+`lint-gate` fails closed independently of the static check.
+
+**Mutation scoring found four of its own tests worthless or dangerous before
+this shipped.** `if argv:` in the guard runner, `if result.skipped:` in the
+canary runner, and the
+canary's oracle check each scored **0 red** — nothing was holding them. The skip
+test was the instructive one: it produced a skip by withholding the oracle, which
+trips the oracle check *first* and returns before the skip logic is reached, so it
+passed for a reason unrelated to what it named. Each branch now has a synthetic
+target module that isolates it.
+
+The fourth was worse than worthless. The argument-refusal test drove the **real**
+runner, so removing `if argv:` made it fall through to discovering
+`scanner/tests` — which contains that test, which spawns the runner again.
+Unbounded recursion: the mutation row hung for 18 hours before it was killed, and
+in CI it would have burned the job timeout instead of failing. It now drives a
+copy in a temp directory, and the same mutation scores 1 red in seconds. **A test
+that drives the thing it lives inside needs an explicit bound**, and mutation
+scoring is what surfaced it — the passing suite never did.
 
 **What is still open, stated because a defence that reads complete and is not is
 the failure this document exists to catch:** the regress does not terminate

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -349,6 +349,57 @@ copy in a temp directory, and the same mutation scores 1 red in seconds. **A tes
 that drives the thing it lives inside needs an explicit bound**, and mutation
 scoring is what surfaced it — the passing suite never did.
 
+**A fifth pass found that moving the proof into Python RELOCATED the unpinned
+surface rather than closing it.** Three defeats, each measured end to end with
+the whole guard suite reporting `OK (Ran 1258 tests)`:
+
+| attack | edit size | effect |
+| --- | --- | --- |
+| short-circuit inside a runner | 4 lines | `ran=1264`, exit 0, **zero guards run** |
+| `outputs.ran` parked in a `#` comment | 1 line | the published value becomes a constant |
+| publishing step ≠ invoking step | 2 lines | every exhaustive check describes a step nobody reads |
+
+The first is the sharp one. Four lines at the top of `main` —
+
+```python
+if GUARD_DIR.name == "tests" and (GUARD_DIR.parent / "checks").is_dir():
+    print("ran=1264")
+    return 0
+```
+
+— made the runner print a positive integer and exit 0 having discovered nothing,
+which `lint-gate`'s `[1-9][0-9]*` accepts. An `os.environ["GITHUB_ACTIONS"]`
+spelling measured identically, on both runners at once. Nothing saw it, and the
+reason is structural rather than an oversight: the one test that *executes* a
+runner drives a **copy in a temp directory with a scrubbed environment**. That is
+deliberate and correct — it is what bounds the recursion described above — but it
+means the copy never sees the CI environment or the repository layout, so a
+branch keyed on either is invisible to it *by construction*. Behaviour testing
+cannot reach what the fixture cannot reproduce.
+
+`runner_publication_problems` therefore READS the runner source, with an AST, and
+pins three things: exactly one `ran=` publication site and it interpolates the
+name the run binds (`result.testsRun` / `adjudicated`); `main` returns 0 exactly
+once, as its final statement; and neither runner reads the environment. The
+middle one is what kills the branch rather than one spelling of its condition —
+with no early success exit, a body that skips the work cannot reach an exit code
+the job treats as a pass, whatever it keys on. The location-conditional spelling,
+which reads no environment at all, is caught by it; an `os.environ`-only fixture
+would not have reached that spelling.
+
+The second defeat is presence-vs-attribution for the fourth time in this repo:
+the `outputs.ran` reference was searched in the RAW job block, so the canonical
+`ran: ${{ steps.guards.outputs.ran }}` surviving in a comment satisfied it while
+the live value was the literal `9999`. The sibling `canary_job_problems` already
+carried the comment-stripped defence and says so in its docstring; this function
+had simply not been brought along. The third is two independent selections never
+tied together — `proof_steps` picked by the invocation, the published value
+picked by the step id — so the exhaustive "the step does nothing else" check
+could be applied to a step whose output nobody reads. Adding `if: false` to the
+invoking step then made it a complete fail-open, caught only by
+`test_ci_required_graph_not_disabled` in another file, which means this
+function's own guarantee did not hold.
+
 **What is still open, stated because a defence that reads complete and is not is
 the failure this document exists to catch:** the regress does not terminate
 inside the workflow. `lint-gate`'s comparison lives in a `run:` body and is
@@ -362,7 +413,13 @@ two exist to prove other things run, and they are the two where the hole was
 measured. Twenty-three proofs of unmeasured per-job value would be a bigger diff
 than its evidence. The `<<` refusal is likewise a substring test, not a heredoc
 parser: it also fires on `echo "shift: 1 << 2"` and `: $(( 1 << 2 ))`, which fail
-closed and do not belong in this step.
+closed and do not belong in this step. And the AST pin on the runners is not
+closure either: a body that reaches the real `TextTestRunner.run()` with a
+deliberately emptied suite still binds `result`, and what rejects that today is
+the runner's own `testsRun < len(files)` floor, which the pin does not assert. A
+runner that fabricates a `result` object is possible too — and would be an
+unmistakable diff rather than four innocuous-looking lines, which is the whole
+distinction the pin is buying.
 
 RESIDUAL STILL NOT ZERO. This closes the reachability gap, not the evasion class:
 `MAX_SILENT_PASS_SHAPES` remains a ceiling of 14, and `rendered_markdown` still

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -413,13 +413,50 @@ two exist to prove other things run, and they are the two where the hole was
 measured. Twenty-three proofs of unmeasured per-job value would be a bigger diff
 than its evidence. The `<<` refusal is likewise a substring test, not a heredoc
 parser: it also fires on `echo "shift: 1 << 2"` and `: $(( 1 << 2 ))`, which fail
-closed and do not belong in this step. And the AST pin on the runners is not
-closure either: a body that reaches the real `TextTestRunner.run()` with a
-deliberately emptied suite still binds `result`, and what rejects that today is
-the runner's own `testsRun < len(files)` floor, which the pin does not assert. A
-runner that fabricates a `result` object is possible too — and would be an
-unmistakable diff rather than four innocuous-looking lines, which is the whole
-distinction the pin is buying.
+closed and do not belong in this step.
+
+**A sixth pass measured what the AST pin does not cover, and corrected a claim
+this document made.** Three more defeats, each green at `OK (Ran 1261 tests)`:
+
+| attack | edit | effect |
+| --- | --- | --- |
+| `PATTERN = "test_ci_[pfmdg]*.py"` | **1 line** | `ran=406` — a genuine count over 406 of 1253 tests |
+| fabricate `result` behind a location condition | 13 lines | `ran=1264`, exit 0, **zero tests run** |
+| `adjudicated += 1; continue`, same condition | 4 lines | `ran=3`, exit 0, **zero adjudicators run** |
+
+The first is the sharp one, and it is the *pass-3* defeat — `cd /tmp/decoy`,
+`-k '*bucket*'`, where the scope is the lie and the count is genuine —
+reappearing one level down after being closed by moving scope *into* the runner.
+Moving it there removed the shell surface; it did not pin the value. Two reasons
+nothing saw it, both general shapes rather than oversights: the
+`result.testsRun < len(files)` floor derives `files` from the **same** `PATTERN`,
+so narrowing the pattern narrows both sides and the comparison stays true — a
+floor computed from the thing it bounds cannot bound it; and every
+temp-directory fixture name (`test_ci_pass`, `test_ci_fail`, `test_ci_m0`,
+`test_ci_decoy`) survives a pattern keeping `[pfmd]`, so the behaviour test
+cannot see a narrowing it happens to survive.
+
+`guard_runner_scope_problems` closes it by comparing the discovered set against
+`git ls-files` — data, not text, the idiom already used for `ADJUDICATORS` vs
+`CANARY_CLASSES`, and against git rather than the filesystem because an
+untracked local file is not what CI builds from. The canary runner needs no
+equivalent: its scope *is* `ADJUDICATORS`, already pinned. Redirecting
+`GUARD_DIR` measured the same way (`ran=1` with one decoy test) and is closed by
+the same check.
+
+The other two are one class, and they are **not closed**. This document
+previously said a fabricated `result` "would be an unmistakable diff rather than
+four innocuous-looking lines". That is withdrawn: the measured diff is thirteen
+lines and reads no more alarming than the short-circuit above it. **The runners'
+source is TRUSTED**; what the AST pins buy is that the publication site cannot
+become a constant, and what protects the binding is review. Pinning the binding
+as well would mean enumerating its shapes — one assignment, from this call, at
+this position — and ADR-001 §5 names the third patch to an enumeration as the
+signal to stop rather than add a fourth. Both runners are exposed symmetrically:
+the canary's behaviour test drives a shim copy in a temp directory too, so a
+location-conditional branch is invisible to it by the same construction. An
+unconditional version of the canary attack *was* caught by
+`test_the_canary_runner_rejects_every_non_pass`; the conditional one was not.
 
 RESIDUAL STILL NOT ZERO. This closes the reachability gap, not the evasion class:
 `MAX_SILENT_PASS_SHAPES` remains a ceiling of 14, and `rendered_markdown` still

--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -225,38 +225,87 @@ an early `exit 0` is outside that guard's stated scope rather than a gap in it:
 that guard exists as the complement of EXECUTION, forbidding runner-consumed keys
 because something else was meant to cover the shell body.
 
-**CLOSED for these two jobs by a FALL-THROUGH PROOF, not by patching shape
-five.** Patching would have been the third fix to an enumeration, which
-ADR-001 §5 names as the signal to invert. The last line of each work body writes
-`ran=true` to `$GITHUB_OUTPUT`, and `lint-gate` requires it whenever the job
-reports `success`; that line is reachable only by executing everything above it,
-so all four measured shapes — and a fifth nobody has thought of — fail together
-by the shell's own semantics rather than by enumeration. `job_ran_proof_problems`
-asserts POSITION, not presence, because the marker alone is one edit from
-useless: hoisting it above the work, or putting any command after it, parks the
-job with the proof already written. Both are pinned, as is a typo'd `steps.<id>`
-reference (fail-closed at runtime — an empty output can never satisfy the proof —
-but caught statically so a typo does not raise an alarm indistinguishable from a
-real parking event). `lint-gate`'s own body is now EXECUTED by a test class
-across seven directions, which nothing in this repo did before: both proven,
-both skipped, one of each, either job parked, a renamed proof job, and an
-ordinary failure elsewhere. The both-skipped direction is the load-bearing one —
-these jobs legitimately skip whenever `ci_config` does not match, which is most
-PRs, and an unconditional demand would fail every unrelated one.
+**CLOSED for these two jobs by an EXECUTION PROOF, not by patching shape five.**
+Patching would have been the third fix to an enumeration, which ADR-001 §5 names
+as the signal to invert.
+
+**The first attempt at that inversion was wrong, and it is recorded here because
+the way it was wrong is the reusable part.** It made the last line of each work
+body publish a constant `ran=true` and argued that the line "is reachable only by
+executing everything above it". It is not. Reaching the last line is not the same
+as having run the work — close a parking construct *above* the publish line and
+the shell falls straight through it. An adversarial pass measured the defeat end
+to end on `ci-guards`:
+
+```bash
+if [ "${CLAUDESEC_FULL_GUARDS:-}" = "1" ]; then   # inserted
+# ...the entire work body, untouched...
+fi                                                # inserted, one line above
+echo "ran=true" >> "$GITHUB_OUTPUT"               # unchanged
+```
+
+`job_ran_proof_problems() == []`, `guard_job_problems() == []`, the full
+1255-test suite `OK`, and the step exiting 0 with `ran=true` written and **zero
+tests run** — for two inserted lines in one job, against a claim that the cost
+was "several coordinated edits across two jobs". `case ... esac` measures the
+same, so it is a class and not a spelling of `if`. Worst of all, the fixture had
+listed `if false; then ... fi` among the shapes it closed, but only because it
+put the marker *inside* the `if`; the attacker moves `fi` up one line. **A
+fixture that picks the weak variant of a shape reports the shape as closed.**
+
+The property a marker actually needs is DOMINATION — every path reaching it must
+have executed the work — and no amount of text analysis establishes domination.
+A **data dependency** does. Each job now publishes a count computed from its own
+work: `ci-guards` parses `ran` out of `$out`, the suite's captured stdout, and
+`renderer-canary` increments `adjudicated` once per class that ran, did not skip,
+and passed its named adjudicating method. Under `set -euo pipefail`, parking the
+work leaves the source variable unbound and the publish line **dies** instead of
+falling through. Measured after the fix, same mutations:
+
+| body | exit | published |
+| --- | --- | --- |
+| `ci-guards` parked (`if`-wrap above publish) | 1 — `ran: unbound variable` | nothing |
+| `renderer-canary` parked (same) | 1 — `adjudicated: unbound variable` | nothing |
+| `ci-guards` unparked (real suite) | 0 | `ran=1261` |
+
+A constant cannot do this; only a value the work produces can. `lint-gate`
+requires a **positive integer**, so `0` (a loop that never iterated) and `true`
+(the previous, defeated design) are both rejected — reverting to the old shape is
+now a red build rather than a silent one-line edit.
+
+`job_ran_proof_problems` asserts that the derivation exists, precedes the publish
+line, and — for the canary — sits inside the loop body; that a floor rejects the
+empty/zero value; and that the published value is the variable rather than a
+literal. Position is still checked, as defence in depth rather than as the
+argument. A typo'd `steps.<id>` reference is caught statically too (fail-closed
+at runtime, but a red build for a typo is indistinguishable from a real parking
+event).
+
+`lint-gate`'s own body is EXECUTED by a test class, which nothing in this repo
+did before: both proven, both skipped, one of each, either job parked / zero /
+non-numeric, a renamed proof job, an ordinary failure elsewhere, and that the
+script reads the same env var the step writes. The both-skipped direction is the
+load-bearing one — these jobs legitimately skip whenever `ci_config` does not
+match, which is most PRs, and an unconditional demand would fail every unrelated
+one. The env-var direction is a **polarity** fix: the class originally hardcoded
+`NEEDS_JSON` in its harness, so renaming only the `env:` key (fatal in CI) passed
+all seven tests while renaming both sides consistently (harmless) failed all
+seven.
 
 **What is still open, stated because a defence that reads complete and is not is
 the failure this document exists to catch:** the regress does not terminate
 inside the workflow. `lint-gate`'s comparison lives in a `run:` body and is
-parkable the same way. This raises the cost of parking a guard job from one token
-to several coordinated edits across two jobs — **defence in depth, not
-closure**. What terminates it is outside this file: branch protection requiring
-the `Lint` context, and GitHub evaluating `needs:` itself. Scoped deliberately to
-the two guard-running jobs rather than all 23 nodes: those two exist to prove
-other things run, and they are the two where the hole was measured. Twenty-three
-markers whose per-job value is unmeasured would be a bigger diff than its
-evidence. The `<<` refusal is likewise a
-substring test, not a heredoc parser: it also fires on `echo "shift: 1 << 2"` and
-`: $(( 1 << 2 ))`, which fail closed and do not belong in this step.
+parkable the same way — **defence in depth, not closure**. What terminates it is
+outside this file: branch protection requiring the `Lint` context, and GitHub
+evaluating `needs:` itself. And the static guard still cannot see control flow:
+it returns `[]` on the parking mutations above, by design. What rejects those is
+the shell at runtime, pinned by tests that execute the real parked bodies.
+Scoped deliberately to the two guard-running jobs rather than all 23 nodes: those
+two exist to prove other things run, and they are the two where the hole was
+measured. Twenty-three proofs of unmeasured per-job value would be a bigger diff
+than its evidence. The `<<` refusal is likewise a substring test, not a heredoc
+parser: it also fires on `echo "shift: 1 << 2"` and `: $(( 1 << 2 ))`, which fail
+closed and do not belong in this step.
 
 RESIDUAL STILL NOT ZERO. This closes the reachability gap, not the evasion class:
 `MAX_SILENT_PASS_SHAPES` remains a ceiling of 14, and `rendered_markdown` still

--- a/scanner/tests/_ci_canary_runner.py
+++ b/scanner/tests/_ci_canary_runner.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Run the renderer-adjudicated guard classes; print how many were adjudicated.
+
+Sibling of `_ci_guard_runner.py`, for the same measured reason: the previous
+version of `renderer-canary` decided its own SCOPE and VERDICT inside a shell
+loop that parsed `unittest -v` text, and text the run produces is text a failing
+run can shape. A red class whose output happened to contain a column-0 `OK` line
+satisfied the shell's `grep -qE '^OK( |$)'` check once the `|| { exit 1; }`
+branch was weakened — measured, published a genuine count with the suite red.
+
+Here the verdict is `TestResult.wasSuccessful()` and the per-adjudicator check is
+`TestResult` bookkeeping, not a regex over `... ok` lines. That also removes the
+reason the old step had to pass `descriptions=False`: nothing parses the runner's
+prose any more.
+
+SPEC LIVES HERE, ONCE. `test_ci_guard_self_verify.CANARY_CLASSES` is pinned
+equal to `ADJUDICATORS` by a guard test, so the two cannot drift — this repo has
+already paid for a drifted second copy of a constant more than once.
+
+Takes no arguments, for the same reason the sibling does not: an appended filter
+narrows what the job proves while leaving the count it publishes genuine.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+GUARD_DIR = Path(__file__).resolve().parent
+
+#: (class dotted path, the ONE method in it that adjudicates real repository
+#: content against the renderer). A count alone cannot tell that this specific
+#: method ran: parking it left its class at two synthetic-fixture tests, "Ran 3
+#: tests / OK", exit 0, and the measured residual payload live in the catalog.
+ADJUDICATORS = (
+    (
+        "test_ci_catalog_doc_sync.TestTheDocAgreesWithTheRenderer",
+        "test_the_reduction_and_the_renderer_agree_on_the_real_catalog",
+    ),
+    (
+        "test_ci_adr_decision_numbering.TestTheParseAgreesWithCommonMark",
+        "test_the_parse_matches_the_renderer_on_every_stripper_case",
+    ),
+    (
+        "test_ci_markdown_scan_evasion.TestTheResidualIsBounded",
+        "test_silent_passes_stay_within_the_measured_ceiling",
+    ),
+)
+
+#: The renderer oracle these classes adjudicate against. They SKIP on
+#: ImportError, which is correct in the package-free job and is exactly the
+#: fail-open this runner exists to close, so a missing or wrong version is a
+#: hard failure here rather than a skip.
+ORACLE_VERSION = "4.0.0"
+
+
+def _oracle_problem() -> str | None:
+    try:
+        import markdown_it
+    except ImportError as exc:  # pragma: no cover - exercised in CI only
+        return f"markdown-it-py is not importable ({exc})"
+    got = getattr(markdown_it, "__version__", None)
+    if got != ORACLE_VERSION:
+        return (
+            f"markdown-it-py is {got}, not the adjudicated {ORACLE_VERSION} — "
+            "re-measure before repinning"
+        )
+    return None
+
+
+def main(argv: list) -> int:
+    if argv:
+        print(
+            f"{Path(__file__).name} takes no arguments, got {argv!r}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    problem = _oracle_problem()
+    if problem:
+        print(f"::error::{problem}", file=sys.stderr)
+        return 2
+
+    sys.path.insert(0, str(GUARD_DIR))
+    adjudicated = 0
+    for cls, method in ADJUDICATORS:
+        name = f"{cls}.{method}"
+        try:
+            suite = unittest.defaultTestLoader.loadTestsFromName(name)
+        except Exception as exc:
+            print(
+                f"::error::{name} could not be loaded ({exc}) — the "
+                "adjudicating test is gone or renamed",
+                file=sys.stderr,
+            )
+            return 1
+        result = unittest.TextTestRunner(stream=sys.stderr, verbosity=1).run(suite)
+        # A SKIP is not a pass. `unittest` counts a skipped test in `Ran N` and
+        # exits 0, which is why a count-based check could never see one.
+        if result.skipped:
+            print(
+                f"::error::{name} SKIPPED in the job that exists to run it: "
+                f"{result.skipped[0][1].strip()}",
+                file=sys.stderr,
+            )
+            return 1
+        if result.testsRun != 1 or not result.wasSuccessful():
+            print(
+                f"::error::{name} did not run and pass "
+                f"(ran={result.testsRun}, ok={result.wasSuccessful()})",
+                file=sys.stderr,
+            )
+            return 1
+        adjudicated += 1
+
+    if adjudicated != len(ADJUDICATORS):  # pragma: no cover - defensive
+        print(f"::error::adjudicated {adjudicated} of {len(ADJUDICATORS)}",
+              file=sys.stderr)
+        return 1
+    # `ran=<count>` — see the sibling runner.
+    print(f"ran={adjudicated}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scanner/tests/_ci_guard_runner.py
+++ b/scanner/tests/_ci_guard_runner.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Run the CI config regression guards and print the count ONLY if they passed.
+
+WHY THIS FILE EXISTS
+--------------------
+`ci-guards` used to run the suite straight from its `run:` body:
+
+    cd scanner/tests
+    out=$(python3 -m unittest discover -s . -p 'test_ci_*.py' 2>&1) || { ...; exit 1; }
+    printf '%s\\n' "$out" | grep -qE '^Ran [1-9][0-9]* tests? in '
+    printf '%s\\n' "$out" | grep -qE '^OK( |$)'
+    ran=$(... sed ... "$out" ...)
+
+Three separate adversarial passes defeated successive versions of that. The last
+one found the shape the others shared: **the proof was derived from a blob whose
+SCOPE and VERDICT are both decided inside the same blob.** Measured, each on the
+real body, each with every static guard returning `[]`:
+
+    cd /tmp/decoy (one trivial test file)   exit 0, published ran=1,  0 real guards ran
+    `-k '*bucket*'` appended to discover    exit 0, published ran=18, 18 of 1264 ran
+    red suite whose output has an `OK ` line
+      + the `|| { exit 1; }` branch neutered  exit 0, published ran=2, suite FAILED
+
+None of those forges anything. The count is REAL — the `cd` target, everything
+after `-p`, and the presence of a column-0 `OK` line were simply never pinned,
+and `2>&1` hands a failing run the ability to put `OK` in its own output.
+
+WHAT THIS FIXES, AND HOW
+------------------------
+Each of the three unpinned things moves out of shell text into code that is
+itself a tracked, reviewed, guard-covered file:
+
+  SCOPE    the discovery root is computed from `__file__`, so `cd` cannot
+           redirect it. Running this script from any directory scans the same
+           tree.
+  FILTER   it takes NO arguments and hard-fails when given any, so there is no
+           `-k` to append.
+  VERDICT  the exit status and the printed count come from
+           `TestResult.wasSuccessful()`, a structural property of the run — not
+           from grepping text the run itself produced.
+
+NOT A CLAIM OF CLOSURE. This file is editable like any other. What it buys is
+that weakening the proof now means editing a tracked Python file under
+`scanner/tests/`, which is inside the `ci_config` path bucket and inside the
+guard suite's own `git ls-files` sweeps — a reviewable diff rather than an
+argument appended to a shell line. The regress still terminates outside the
+workflow: branch protection requiring `Lint`, and GitHub evaluating `needs:`.
+"""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+#: Guard modules live beside this file. Derived from `__file__` ON PURPOSE — the
+#: whole point is that the working directory cannot redirect the scan.
+GUARD_DIR = Path(__file__).resolve().parent
+PATTERN = "test_ci_*.py"
+
+
+def main(argv: list) -> int:
+    # NO ARGUMENTS. `-k '*bucket*'` appended to the old shell invocation cut the
+    # run from 1264 tests to 18 while every check still passed, so accepting
+    # arguments at all is the hole. Refusing them is one line.
+    if argv:
+        print(
+            f"{Path(__file__).name} takes no arguments, got {argv!r}. It runs "
+            "the whole guard suite by design; a filter would narrow what the "
+            "job proves while leaving the count it publishes genuine.",
+            file=sys.stderr,
+        )
+        return 2
+
+    files = sorted(GUARD_DIR.glob(PATTERN))
+    if not files:
+        print(
+            f"no {PATTERN} under {GUARD_DIR} — the suite would pass vacuously "
+            "(`unittest` exits 0 on 'Ran 0 tests')",
+            file=sys.stderr,
+        )
+        return 2
+
+    # `discover` is given the resolved directory as BOTH start and top level, so
+    # it does not walk upward looking for a package root.
+    suite = unittest.defaultTestLoader.discover(
+        start_dir=str(GUARD_DIR), pattern=PATTERN, top_level_dir=str(GUARD_DIR)
+    )
+    # Everything human-readable goes to stderr; stdout carries the count and
+    # nothing else, so the caller's `$( )` cannot pick up stray text.
+    result = unittest.TextTestRunner(stream=sys.stderr, verbosity=1).run(suite)
+
+    if not result.wasSuccessful():
+        print(
+            f"guard suite FAILED: {len(result.failures)} failure(s), "
+            f"{len(result.errors)} error(s) out of {result.testsRun} test(s)",
+            file=sys.stderr,
+        )
+        return 1
+    if result.testsRun < len(files):
+        # A floor tied to something the shell does not choose. It cannot detect
+        # a narrowed run in general — one module can hold many tests — but it
+        # does reject the degenerate "discovered almost nothing" shapes.
+        print(
+            f"only {result.testsRun} test(s) ran across {len(files)} guard "
+            "file(s); the suite was narrowed",
+            file=sys.stderr,
+        )
+        return 1
+
+    # `ran=<count>`, not a bare count. The caller appends this straight to
+    # `$GITHUB_OUTPUT`, so no shell variable ever holds the value — see the
+    # step body for the measured reason.
+    print(f"ran={result.testsRun}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -512,6 +512,14 @@ PROOF_SPECS = {
         "derivation": re.compile(r'^ran=\$\(.*"\$out".*\)$'),
         "derivation_desc": 'a `ran=$(... "$out" ...)` parse of the suite output',
         "floor": '[ -n "$ran" ]',
+        # `$out` is what the proof is computed FROM, so seeding it forges the
+        # proof. Exactly one assignment, and `guard_job_problems` separately
+        # requires that one to be the `unittest discover` invocation.
+        "source": "out",
+        "source_assignments": 1,
+        # Two independent readings of the same run: a non-zero test count, and
+        # the suite reporting OK. `Ran N` prints on failure too.
+        "verdict": re.compile(r"^printf .*\| grep -qE '\^OK\( \|\$\)'$"),
     },
     CANARY_JOB: {
         "var": "adjudicated",
@@ -521,6 +529,11 @@ PROOF_SPECS = {
         # The increment must sit INSIDE the loop body. Hoisted above `for` it is a
         # constant again, and below `done` it counts nothing.
         "inside_loop": True,
+        # The counter is its own source: `adjudicated=0` to initialise and the
+        # increment. A third assignment is a seeded value.
+        "source": "adjudicated",
+        "source_assignments": 2,
+        "verdict": re.compile(r"^if ! printf .*\| grep -qE '\^OK\( \|\$\)'; then$"),
     },
 }
 PROOF_JOBS = tuple(PROOF_SPECS)
@@ -698,6 +711,40 @@ def job_ran_proof_problems(lint_text: str) -> list:
                     "Outside, it is incremented a fixed number of times "
                     "regardless of how many adjudicators actually ran."
                 )
+
+        # FORGERY. The data dependency stops a parked body only while the source
+        # variable is UNBOUND. Seed it above the parked span and the derivation
+        # runs on a lie: measured, `out="Ran 1 tests in 0.0s"` inserted above an
+        # `if`-wrapped body published `ran=1` at exit 0 with every check returning
+        # [], and `adjudicated=3` hoisted above the canary's loop published
+        # `ran=3` the same way. That is a THIRD line for the attacker rather than
+        # closure, and it is not domination — but a seeded value is an EXTRA
+        # assignment, and counting assignments is something text CAN do.
+        # Rewriting the one legitimate assignment instead removes the
+        # `unittest discover` invocation, which `guard_job_problems` already
+        # rejects.
+        assigns = [
+            ln for ln in lines
+            if re.match(rf"^{re.escape(spec['source'])}=", ln)
+        ]
+        if len(assigns) != spec["source_assignments"]:
+            problems.append(
+                f"job `{job}` assigns `{spec['source']}` {len(assigns)} time(s), "
+                f"expected {spec['source_assignments']}: {assigns}. An extra "
+                "assignment is how a parked body forges a plausible proof — the "
+                "derivation then reads a seeded value instead of the work."
+            )
+
+        if spec["verdict"] and not any(
+            spec["verdict"].match(ln) for ln in lines
+        ):
+            problems.append(
+                f"job `{job}` no longer requires its run to report `OK`. "
+                "`unittest` prints `Ran N` on failure too, so with the exit-status "
+                "branch weakened to `|| true` a genuinely FAILING suite publishes "
+                "a genuine count and the job reports success — measured, with "
+                "every other check in this function returning []."
+            )
 
         if spec["floor"] not in lines:
             problems.append(
@@ -1572,6 +1619,115 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
             "the harness cannot publish a derived proof even unparked — the "
             "parking subtests prove nothing",
         )
+
+    #: The `out=$(...)` capture in `ci-guards`, matched whole so a mutation
+    #: replaces the invocation AND its failure branch together.
+    _CI_GUARDS_CAPTURE = (
+        "out=$(python3 -m unittest discover -s . -p 'test_ci_*.py' 2>&1) || {\n"
+        "  printf '%s\\n' \"$out\"\n"
+        "  exit 1\n"
+        "}"
+    )
+
+    def _ci_guards_with_capture(self, replacement):
+        body = self._job_body("ci-guards")
+        lines = body.splitlines()
+        start = next(i for i, ln in enumerate(lines) if ln.startswith("out=$("))
+        end = next(i for i in range(start, len(lines)) if lines[i] == "}")
+        return "\n".join(lines[:start] + [replacement] + lines[end + 1:])
+
+    def test_a_swallowed_suite_failure_does_not_publish(self):
+        r"""A FAILING suite must not publish a count. Measured, not argued.
+
+        `unittest` prints `Ran N` on failure exactly as it does on success, so
+        weakening the capture's `|| { ...; exit 1; }` branch to `|| true` lets a
+        red suite publish a genuine count and the job report success — worse than
+        the parking class this design was built for, because parking runs nothing
+        while this SWALLOWS real failures. Measured before the `^OK` check
+        existed: `job_ran_proof_problems() == []` and `guard_job_problems() == []`
+        with the suite red and the job green.
+
+        The static guard still cannot see it (the OK check is textually present
+        either way), so this direction is pinned by EXECUTION. Four rows, because
+        the first version of this probe used `\\n` inside a non-raw Python string,
+        printf emitted a literal backslash-n, the whole synthetic output collapsed
+        onto one line, and every row went red for that reason instead of the one
+        under test — the non-vacuity row is what caught it."""
+        fail = r"""printf 'F\nRan 1253 tests in 16.8s\n\nFAILED (failures=1)\n'; exit 1"""
+        ok = r"""printf 'Ran 1253 tests in 16.8s\n\nOK\n'"""
+        cases = {
+            # The attack.
+            "failing + swallowed": (f"out=$({fail}) || true", False),
+            # Same failure, branch intact — red for the ordinary reason.
+            "failing + branch intact": (
+                f'out=$({fail}) || {{\n  printf \'%s\\n\' "$out"\n  exit 1\n}}',
+                False,
+            ),
+            # NON-VACUITY: the fixture path must be able to reach the publish
+            # line at all, or the two rows above prove nothing.
+            "passing": (f"out=$({ok})", True),
+            # ATTRIBUTION: `|| true` alone must NOT be what makes it red, or the
+            # first row is red for the wrong reason.
+            "passing + swallowed": (f"out=$({ok}) || true", True),
+        }
+        for name, (capture, should_publish) in cases.items():
+            with self.subTest(case=name):
+                code, written = self._run_body(
+                    self._ci_guards_with_capture(capture)
+                )
+                if should_publish:
+                    self.assertEqual(code, 0, f"{name}: expected success")
+                    self.assertEqual(written.strip(), "ran=1253", name)
+                else:
+                    self.assertNotEqual(code, 0, f"{name}: a red suite exited 0")
+                    self.assertEqual(
+                        written, "",
+                        f"{name}: a red suite published {written!r}",
+                    )
+
+    def test_seeding_the_source_variable_is_caught(self):
+        """FORGERY: the data dependency holds only while the source is unbound.
+
+        Seed it above a parked span and the derivation runs on a lie — measured,
+        `out="Ran 1 tests in 0.0s"` published `ran=1` at exit 0, and
+        `adjudicated=3` hoisted above the canary's loop published `ran=3`, both
+        with every check returning []. A seeded value is an EXTRA assignment, and
+        counting assignments is something text CAN do."""
+        for job, spec in PROOF_SPECS.items():
+            with self.subTest(job=job):
+                block = job_block(self.lint, job)
+                anchor = "          set -euo pipefail\n"
+                self.assertIn(anchor, block, f"{job}: anchor moved")
+                seeded = block.replace(
+                    anchor,
+                    anchor + f'          {spec["source"]}="forged"\n',
+                    1,
+                )
+                assert_disables(
+                    job_ran_proof_problems,
+                    self.lint,
+                    self.lint.replace(block, seeded, 1),
+                    f"{job}: source variable seeded with a forged value",
+                )
+
+    def test_dropping_the_ok_verdict_check_is_caught(self):
+        """Without it, `Ran N` alone is the whole verdict — and it prints on
+        failure too."""
+        for job, spec in PROOF_SPECS.items():
+            with self.subTest(job=job):
+                block = job_block(self.lint, job)
+                line = next(
+                    ln for ln in block.splitlines()
+                    if spec["verdict"].match(ln.strip())
+                )
+                assert_disables(
+                    job_ran_proof_problems,
+                    self.lint,
+                    self.lint.replace(
+                        block, block.replace(line + "\n", "", 1), 1
+                    ),
+                    f"{job}: `^OK` verdict check dropped",
+                )
 
     def test_the_same_control_parks_when_the_work_is_removed(self):
         """The control's own non-vacuity: it must fail when the work is gone.

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -510,6 +510,89 @@ GUARD_RUNNER = "scanner/tests/_ci_guard_runner.py"
 CANARY_RUNNER = "scanner/tests/_ci_canary_runner.py"
 
 
+def _import_guard_runner():
+    """The guard runner as a MODULE, so its SCOPE is compared as data.
+
+    Safe to import: the module body only binds constants, and `main` runs under
+    `if __name__ == "__main__"`, so importing it discovers and runs nothing."""
+    import importlib
+
+    return importlib.import_module("_ci_guard_runner")
+
+
+def guard_runner_scope_problems() -> list:
+    """The guard runner discovers EXACTLY the tracked guard files, no fewer.
+
+    THE DEFEAT THIS CLOSES, measured at `OK (Ran 1261 tests)`:
+
+        PATTERN = "test_ci_[pfmdg]*.py"      # one line, was "test_ci_*.py"
+
+    The runner published `ran=406` — a GENUINE count over 406 of 1253 tests, with
+    847 discarded. Redirecting `GUARD_DIR` to a sibling directory holding one
+    trivial test measured the same way, at `ran=1`.
+
+    Two reasons nothing saw it, both worth stating because each is a general
+    shape rather than an oversight:
+
+    1. **The floor is self-consistent.** `result.testsRun < len(files)` derives
+       `files` from the SAME `PATTERN`, so narrowing the pattern narrows both
+       sides and the comparison stays true. A floor computed from the thing it is
+       meant to bound cannot bound it. (It is not useless — it does reject
+       "discovered almost nothing", and `test_the_guard_runner_publishes_only_
+       when_the_suite_passed` pins that direction — but at 70 guard files it
+       permits discarding 94% of 1253 tests.)
+    2. **Every temp-directory fixture name matches a narrowed pattern.** The
+       behaviour test's modules are `test_ci_pass`, `test_ci_fail`, `test_ci_m0`
+       and `test_ci_decoy`; a pattern keeping `[pfmd]` keeps all of them green
+       while cutting the real repo in half. The fixture cannot see a narrowing it
+       happens to survive.
+
+    This is the pass-3 defeat — `cd /tmp/decoy`, `-k '*bucket*'`, where "the
+    scope is the lie, not the number" — reappearing one level down after it was
+    closed by moving scope INTO the runner. Moving it there did remove the shell
+    surface; it did not pin the value.
+
+    Compared as DATA against `git ls-files`, which is the idiom this file already
+    uses for `ADJUDICATORS` vs `CANARY_CLASSES`, and against git rather than the
+    filesystem for the reason `tracked_files()` documents: an untracked local
+    file is not what CI builds from. The canary runner needs no equivalent —
+    its scope IS `ADJUDICATORS`, already pinned.
+    """
+    problems = []
+    runner = _import_guard_runner()
+
+    expected_dir = REPO_ROOT / "scanner" / "tests"
+    if Path(runner.GUARD_DIR).resolve() != expected_dir.resolve():
+        problems.append(
+            f"`{GUARD_RUNNER}` scans `{runner.GUARD_DIR}`, not "
+            f"`{expected_dir}`. The job's whole claim is that it ran THE guards."
+        )
+        return problems
+
+    tracked = {
+        Path(rel).name for rel in tracked_files()
+        if rel.startswith("scanner/tests/")
+        and re.fullmatch(r"test_ci_.*\.py", Path(rel).name)
+    }
+    discovered = {p.name for p in Path(runner.GUARD_DIR).glob(runner.PATTERN)}
+    missed = sorted(tracked - discovered)
+    extra = sorted(discovered - tracked)
+    if missed:
+        problems.append(
+            f"`{GUARD_RUNNER}`'s `PATTERN = {runner.PATTERN!r}` does not "
+            f"discover {len(missed)} tracked guard file(s): {missed[:6]}"
+            f"{' ...' if len(missed) > 6 else ''}. The count it publishes would "
+            "be genuine and the scope would be the lie."
+        )
+    if extra:
+        problems.append(
+            f"`{GUARD_RUNNER}` discovers {len(extra)} file(s) git does not "
+            f"track: {extra}. An untracked file is not what CI builds from, so "
+            "it can only pad the count."
+        )
+    return problems
+
+
 def _import_canary_runner():
     """The canary runner as a MODULE, so its table is compared as data.
 
@@ -574,14 +657,37 @@ def runner_publication_problems(source: str, path: str, data_expr: str) -> list:
 
     (1) and (2) are the load-bearing pair; (3) is a cheap extra.
 
-    NOT CLOSED, stated because a defence that reads complete and is not is the
-    failure this file exists to catch: a body that reaches the real
-    `TextTestRunner.run()` with a DELIBERATELY EMPTIED suite still binds
-    `result`. The runner's own `testsRun < len(files)` floor rejects that today,
-    and this function does not pin that floor. Nor does it model a runner that
-    fabricates a `result` object — which is possible, and would be an
-    unmistakable diff rather than four innocuous-looking lines. As with the
-    workflow half, the regress terminates outside this file: at review.
+    NOT CLOSED, and a sixth pass measured the residual rather than leaving it
+    asserted. **This function does not pin how the published datum is BOUND**,
+    only that it is published from a name the run normally binds. Measured, each
+    at `OK (Ran 1261 tests)` with this function returning `[]`:
+
+        guard runner   a nested class with `testsRun = 1264` and
+                       `wasSuccessful()` returning True, selected by a
+                       location condition       -> ran=1264, exit 0, 0 tests
+        canary runner  `adjudicated += 1; continue` at the top of the loop,
+                       same condition           -> ran=3, exit 0, 0 adjudicators
+
+    An earlier version of this docstring called the first of those "an
+    unmistakable diff rather than four innocuous-looking lines". That claim was
+    wrong and is withdrawn: the measured diff is thirteen lines and reads no more
+    alarming than the four-line short-circuit above it. **The runner's source is
+    TRUSTED.** What the pins above buy is that the publication site itself cannot
+    become a constant, and what protects the binding is review — not this file.
+
+    Pinning the binding too would mean enumerating its shapes (one assignment,
+    from this call, at this position), and ADR-001 §5 names the third patch to an
+    enumeration as the signal to stop adding a fourth. `guard_runner_scope_
+    problems` is the part of pass 6 that WAS closable without enumerating: a set
+    compared against `git ls-files`.
+
+    Also not pinned here: a body reaching the real `TextTestRunner.run()` with a
+    deliberately emptied suite still binds `result`. The runner's own
+    `testsRun < len(files)` floor rejects that, and
+    `test_the_guard_runner_publishes_only_when_the_suite_passed` pins the floor
+    behaviourally — but that floor derives `files` from the runner's own
+    `PATTERN`, so see `guard_runner_scope_problems` for why it cannot bound a
+    narrowing.
     """
     problems = []
     try:
@@ -2108,6 +2214,44 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
                 self.assertTrue(
                     any("return 0" in p for p in problems), problems
                 )
+
+    def test_the_guard_runner_discovers_every_tracked_guard_file(self):
+        """Scope as data. One line cut the run to 406 of 1253 tests, green.
+
+        Mutated on the RUNNER's constants, driven through the same function the
+        control uses, so the fixture cannot pass for a reason the live check
+        would not."""
+        self.assertEqual(
+            guard_runner_scope_problems(), [],
+            "the runner does not discover the tracked guard set",
+        )
+
+        runner = _import_guard_runner()
+        original_pattern, original_dir = runner.PATTERN, runner.GUARD_DIR
+        try:
+            with self.subTest(direction="a narrowed pattern"):
+                # Every temp-directory fixture name (`test_ci_pass`,
+                # `test_ci_fail`, `test_ci_m0`, `test_ci_decoy`) survives this,
+                # which is exactly why the behaviour test could not see it.
+                runner.PATTERN = "test_ci_[pfmdg]*.py"
+                problems = guard_runner_scope_problems()
+                self.assertTrue(
+                    any("does not discover" in p for p in problems), problems
+                )
+            runner.PATTERN = original_pattern
+
+            with self.subTest(direction="a redirected scan root"):
+                runner.GUARD_DIR = Path(original_dir) / "fixtures_ci"
+                problems = guard_runner_scope_problems()
+                self.assertTrue(
+                    any("scans" in p for p in problems), problems
+                )
+        finally:
+            runner.PATTERN, runner.GUARD_DIR = original_pattern, original_dir
+        self.assertEqual(
+            guard_runner_scope_problems(), [],
+            "the fixture leaked — the runner module was left mutated",
+        )
 
     def test_the_canary_table_drifting_from_the_guard_is_caught(self):
         """`CANARY_CLASSES` and the runner's `ADJUDICATORS` are one spec in two

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -96,6 +96,7 @@ vacuous pass. Duplicating that rule here would be two owners for one invariant.
 MARKDOWN_SCAN_EXEMPT = (
     "does not parse Markdown: every `.md`/`.toml` path here is a PATH, never a document. `guard_data_files()` collects them by AST out of the OTHER guards and `uncovered_paths()` matches each against the bucket's `grep -E` pattern; nothing in this file opens one. The rationale used to say 'the catalog PATH' singular, from when the set was two hand-written entries — it is a derived census of 109 now, which changes the size but not the reason for the exemption"
 )
+import ast
 import re
 import sys
 import unittest
@@ -520,6 +521,170 @@ def _import_canary_runner():
 
     return importlib.import_module("_ci_canary_runner")
 
+#: Per runner: the expression its published count MUST interpolate. Both names
+#: are bound only by the run itself — `result` by `TextTestRunner.run()`,
+#: `adjudicated` by the loop that drives one adjudicator at a time — so a body
+#: that skips the work has nothing to print.
+RUNNER_PUBLICATION = {
+    GUARD_RUNNER: "result.testsRun",
+    CANARY_RUNNER: "adjudicated",
+}
+
+
+def runner_publication_problems(source: str, path: str, data_expr: str) -> list:
+    """The runner cannot publish a count it did not compute, or exit early.
+
+    WHY THIS EXISTS
+    ---------------
+    Moving SCOPE, FILTER and VERDICT out of shell text and into these two files
+    did close every shell-level defeat. It did not close the class — it RELOCATED
+    the unpinned surface, and an adversarial pass measured the new one. Four lines
+    in `_ci_guard_runner.py`:
+
+        if GUARD_DIR.name == "tests" and (GUARD_DIR.parent / "checks").is_dir():
+            print("ran=1264")
+            return 0
+
+    Result: `python3 scanner/tests/_ci_guard_runner.py` printed `ran=1264` and
+    exited 0 having run ZERO guards, `lint-gate`'s `[1-9][0-9]*` accepted it, and
+    the whole guard suite reported `OK (Ran 1258 tests)`. An `os.environ
+    ["GITHUB_ACTIONS"]` spelling measured identically, on both runners at once.
+
+    Nothing saw it, and the reason is structural rather than an oversight: the
+    ONE test that EXECUTES a runner (`test_the_guard_runner_publishes_only_when_
+    the_suite_passed`) drives a COPY in a temp directory with `env={"PATH": ...}`.
+    That is deliberate and correct — driving the real file in place recurses,
+    which once hung for 18 hours — but it means the copy never sees the CI
+    environment or the repository layout, so any branch keyed on either is
+    invisible to it BY CONSTRUCTION. Behaviour testing cannot reach what the
+    fixture cannot reproduce; this reads the file instead.
+
+    WHAT IS PINNED, AND WHY THESE THREE
+    -----------------------------------
+    1. ONE publication site, and it is an f-string interpolating `data_expr`.
+       A short-circuit has to print something, and a literal `ran=1264` or an
+       `f"ran={1264}"` both die here. To publish, it must produce the name the
+       run binds.
+    2. `main` returns 0 EXACTLY ONCE, as its final statement. This is what kills
+       the branch itself rather than one spelling of its condition: with no early
+       success exit, a body that skips the work cannot reach an exit code the job
+       treats as a pass, no matter what it keys the branch on.
+    3. No `os.environ` / `os.getenv` anywhere. Neither runner needs one, so this
+       is free, and it removes the cheapest spelling before (2) has to.
+
+    (1) and (2) are the load-bearing pair; (3) is a cheap extra.
+
+    NOT CLOSED, stated because a defence that reads complete and is not is the
+    failure this file exists to catch: a body that reaches the real
+    `TextTestRunner.run()` with a DELIBERATELY EMPTIED suite still binds
+    `result`. The runner's own `testsRun < len(files)` floor rejects that today,
+    and this function does not pin that floor. Nor does it model a runner that
+    fabricates a `result` object — which is possible, and would be an
+    unmistakable diff rather than four innocuous-looking lines. As with the
+    workflow half, the regress terminates outside this file: at review.
+    """
+    problems = []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        return [f"`{path}` does not parse ({exc})"]
+
+    # 1. THE PUBLICATION SITE. Every string constant that opens with `ran=` is a
+    #    candidate, whether or not it interpolates — that is the point: a plain
+    #    literal is the forgery, so it must be COUNTED and rejected, never
+    #    filtered out for not being an f-string.
+    #    An f-string's own literal head is a `Constant` that `ast.walk` also
+    #    visits, so the parts of every `JoinedStr` are excluded first — counting
+    #    them made the REAL runners report two sites each.
+    inside_fstring = {
+        id(part)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.JoinedStr)
+        for part in ast.walk(node)
+        if part is not node
+    }
+    sites = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.JoinedStr):
+            head = node.values[0] if node.values else None
+            if (
+                isinstance(head, ast.Constant)
+                and isinstance(head.value, str)
+                and head.value.startswith("ran=")
+            ):
+                sites.append(("fstring", node))
+        elif (
+            isinstance(node, ast.Constant)
+            and isinstance(node.value, str)
+            and node.value.startswith("ran=")
+            and id(node) not in inside_fstring
+        ):
+            sites.append(("literal", node))
+    if len(sites) != 1:
+        return problems + [
+            f"`{path}` has {len(sites)} `ran=` publication site(s), expected "
+            "exactly 1. A second one is a second answer to the only question "
+            f"the job asks: {[ast.unparse(n) for _, n in sites]}"
+        ]
+    kind, node = sites[0]
+    if kind != "fstring":
+        problems.append(
+            f"`{path}` publishes a CONSTANT `{ast.unparse(node)}`. The count "
+            "must be interpolated from the run, or a body that ran nothing can "
+            "print it."
+        )
+    else:
+        interpolations = [
+            v for v in node.values if isinstance(v, ast.FormattedValue)
+        ]
+        got = [ast.unparse(v.value) for v in interpolations]
+        if got != [data_expr]:
+            problems.append(
+                f"`{path}` publishes `{ast.unparse(node)}`, which interpolates "
+                f"{got} rather than exactly `[{data_expr!r}]`. That name is "
+                "bound by the run; anything else can be bound without it."
+            )
+
+    # 2. ONE SUCCESS EXIT, LAST. See the docstring: this is the check that closes
+    #    the branch rather than a spelling of its condition.
+    mains = [
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "main"
+    ]
+    if len(mains) != 1:
+        problems.append(f"`{path}` defines {len(mains)} `main` functions, expected 1")
+    else:
+        main = mains[0]
+        zeros = [
+            n for n in ast.walk(main)
+            if isinstance(n, ast.Return)
+            and isinstance(n.value, ast.Constant)
+            and n.value.value == 0
+        ]
+        if len(zeros) != 1:
+            problems.append(
+                f"`{path}`'s `main` has {len(zeros)} `return 0` statements, "
+                "expected 1. Every extra one is a way to report success without "
+                "reaching the work."
+            )
+        elif main.body[-1] is not zeros[0]:
+            problems.append(
+                f"`{path}`'s `main` does not END with its `return 0` (last "
+                f"statement is `{type(main.body[-1]).__name__}`). A success exit "
+                "anywhere else can be reached without the work."
+            )
+
+    # 3. NO ENVIRONMENT READS. The cheapest measured spelling, removed for free.
+    for n in ast.walk(tree):
+        if isinstance(n, ast.Attribute) and n.attr in ("environ", "getenv"):
+            problems.append(
+                f"`{path}` reads `{ast.unparse(n)}`. Neither runner needs the "
+                "environment, and a branch on it behaves differently in CI than "
+                "in every test that drives this file."
+            )
+    return problems
+
+
 PROOF_SPECS = {
     "ci-guards": {
         "runner": GUARD_RUNNER,
@@ -634,6 +799,28 @@ def job_ran_proof_problems(lint_text: str) -> list:
             declares = any(
                 pat.match(strip_inline_comment(raw)) for raw in block.splitlines()
             )
+        # COMMENT-STRIPPED, both spellings, before anything is READ out of the
+        # block. The reference below used to be searched in the RAW block, and an
+        # adversarial pass measured what that costs: put `ran: 9999` in the real
+        # `outputs:` map and leave the canonical
+        # `ran: ${{ steps.guards.outputs.ran }}` alive in a `#` comment two lines
+        # above, and this function returned `[]` with the whole suite at
+        # `OK (Ran 1258)`. The published value is then a CONSTANT — which is
+        # exactly the property this function exists to forbid, since "parking the
+        # body appends nothing, so `lint-gate` fails closed" is only true while
+        # the value comes from the step.
+        #
+        # The sibling `canary_job_problems` already carries this defence and says
+        # so in its docstring ("EVERYTHING HERE READS EXECUTED TEXT, NOT THE
+        # BLOCK"); this function had simply not been brought along with it. That
+        # is the same not-brought-along shape the gate check two functions up was
+        # fixed for.
+        visible = "\n".join(
+            strip_inline_comment(ln)
+            for ln in strip_comment_lines(block).splitlines()
+        )
+
+        ref_id = None
         if not declares:
             problems.append(
                 f"job `{job}` declares no `outputs:`. Without it the line its "
@@ -641,7 +828,7 @@ def job_ran_proof_problems(lint_text: str) -> list:
             )
         else:
             ref = re.search(
-                r"ran:\s*\$\{\{\s*steps\.([\w-]+)\.outputs\.ran\s*\}\}", block
+                r"ran:\s*\$\{\{\s*steps\.([\w-]+)\.outputs\.ran\s*\}\}", visible
             )
             if ref is None:
                 problems.append(
@@ -651,13 +838,15 @@ def job_ran_proof_problems(lint_text: str) -> list:
                     "repo already paid for once."
                 )
             elif not re.search(
-                rf"^\s*id:\s*{re.escape(ref.group(1))}\s*$", block, re.M
+                rf"^\s*id:\s*{re.escape(ref.group(1))}\s*$", visible, re.M
             ):
                 problems.append(
                     f"job `{job}` surfaces `ran` from step id `{ref.group(1)}`, "
                     "which no step in the job declares. The output resolves to "
                     "the empty string, so the proof can never be satisfied."
                 )
+            else:
+                ref_id = ref.group(1)
 
         # THE PROOF STEP ONLY, not the whole job. `renderer-canary` has a
         # legitimate `pip install` step before it, and an exhaustive check over
@@ -678,6 +867,40 @@ def job_ran_proof_problems(lint_text: str) -> list:
                 "leaving the published count genuine."
             )
             continue
+
+        # THE STEP THAT PUBLISHES, not merely a step that invokes. These were two
+        # independent selections — `proof_steps` picked by the invocation, the
+        # published value picked by `ref_id` — and nothing tied them together.
+        # Measured, with every check below still returning `[]`:
+        #
+        #     - name: Publish the proof      <- id: guards, echoes ran=9999
+        #       id: guards
+        #       run: |
+        #         set -euo pipefail
+        #         echo "ran=9999" >> "$GITHUB_OUTPUT"
+        #     - name: Run CI config regression guards   <- carries the invocation
+        #       run: |
+        #         set -euo pipefail
+        #         python3 scanner/tests/_ci_guard_runner.py >> "$GITHUB_OUTPUT"
+        #
+        # `guard_job_problems` and `job_ran_proof_problems` both returned `[]`.
+        # Every assertion below then ran against the SECOND step while the job's
+        # `ran` came from the first, so the exhaustive "the step does nothing
+        # else" check was being applied to a step whose output nobody reads.
+        # Adding `if: false` to the second step made it a complete fail-open, and
+        # was caught only by `test_ci_required_graph_not_disabled` in another
+        # file — i.e. this function's own guarantee did not hold, and the suite
+        # went red for an unrelated reason.
+        if ref_id is not None and not re.search(
+            rf"^\s*id:\s*{re.escape(ref_id)}\s*$", proof_steps[0], re.M
+        ):
+            problems.append(
+                f"job `{job}` runs the runner in a step that is NOT the step "
+                f"(`id: {ref_id}`) whose output it publishes. The checks below "
+                "would then describe a step nobody reads, and the publishing "
+                "step would be unconstrained."
+            )
+
         lines = [
             ln.strip() for ln in executed_shell(proof_steps[0]).splitlines()
             if ln.strip()
@@ -1809,6 +2032,83 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
                 "the runner scanned the CWD instead of its own directory",
             )
 
+    def test_the_runners_cannot_publish_a_count_they_did_not_compute(self):
+        """The relocated hole: four lines in a runner, `OK (Ran 1258 tests)`.
+
+        Both runners are read, because the measured defeat applied to both at
+        once. Every mutation below was executed as well as detected — the
+        short-circuits really did print a positive integer at exit 0 with zero
+        guards run, which is what makes them the sharp case rather than a
+        hypothetical one."""
+        for rel, data_expr in RUNNER_PUBLICATION.items():
+            src = (REPO_ROOT / rel).read_text()
+            with self.subTest(runner=rel, direction="control"):
+                self.assertEqual(
+                    runner_publication_problems(src, rel, data_expr), [],
+                    "the real runner does not satisfy its own pin",
+                )
+
+            # The MEASURED defeat, in both spellings. The second reads no
+            # environment at all, so a fixture that merely sets `GITHUB_ACTIONS`
+            # would not have reached it.
+            count = "1264" if rel == GUARD_RUNNER else "3"
+            short_circuits = {
+                "env-conditional": (
+                    "    import os\n"
+                    '    if os.environ.get("GITHUB_ACTIONS") == "true":\n'
+                    f'        print("ran={count}")\n'
+                    "        return 0\n"
+                ),
+                "location-conditional": (
+                    '    if GUARD_DIR.name == "tests":\n'
+                    f'        print("ran={count}")\n'
+                    "        return 0\n"
+                ),
+            }
+            # Every mutation below asserts it CHANGED the source before asserting
+            # the detector saw it: a `.replace()` whose needle has drifted is a
+            # no-op, and a no-op mutation makes the detector look correct for the
+            # one reason that would mean it is not being exercised at all.
+            anchor = "def main(argv: list) -> int:\n"
+            for label, injected in short_circuits.items():
+                with self.subTest(runner=rel, direction=label):
+                    mutated = src.replace(anchor, anchor + injected, 1)
+                    self.assertNotEqual(mutated, src, "the mutation did not apply")
+                    self.assertNotEqual(
+                        runner_publication_problems(mutated, rel, data_expr), [],
+                        f"a {label} short-circuit was accepted",
+                    )
+
+            with self.subTest(runner=rel, direction="a constant count"):
+                mutated = src.replace(
+                    f'print(f"ran={{{data_expr}}}")', f'print("ran={count}")', 1
+                )
+                self.assertNotEqual(mutated, src, "the publication site moved")
+                problems = runner_publication_problems(mutated, rel, data_expr)
+                self.assertTrue(
+                    any("CONSTANT" in p for p in problems), problems
+                )
+
+            with self.subTest(runner=rel, direction="a count from somewhere else"):
+                mutated = src.replace(
+                    f'print(f"ran={{{data_expr}}}")', 'print(f"ran={len(sys.argv)}")', 1
+                )
+                self.assertNotEqual(mutated, src, "the publication site moved")
+                problems = runner_publication_problems(mutated, rel, data_expr)
+                self.assertTrue(
+                    any("interpolates" in p for p in problems), problems
+                )
+
+            with self.subTest(runner=rel, direction="a success exit that is not last"):
+                # No `print` at all — only the early success exit. This is the
+                # half that does not depend on enumerating what the branch reads.
+                mutated = src.replace(anchor, anchor + "    return 0\n", 1)
+                self.assertNotEqual(mutated, src, "the mutation did not apply")
+                problems = runner_publication_problems(mutated, rel, data_expr)
+                self.assertTrue(
+                    any("return 0" in p for p in problems), problems
+                )
+
     def test_the_canary_table_drifting_from_the_guard_is_caught(self):
         """`CANARY_CLASSES` and the runner's `ADJUDICATORS` are one spec in two
         files, so drift between them must be a failure rather than a silent
@@ -1942,6 +2242,83 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
                         1,
                     ),
                     f"{job}: command added after the invocation",
+                )
+
+    def test_the_output_reference_surviving_only_in_a_comment_is_caught(self):
+        """Presence vs attribution, for the fourth time in this repo.
+
+        `ref` was searched in the RAW job block. Measured: leave the canonical
+        `ran: ${{ steps.<id>.outputs.ran }}` alive in a `#` comment and give the
+        real `outputs:` map a literal, and `job_ran_proof_problems` returned `[]`
+        with the whole suite at `OK (Ran 1258 tests)`. `ran` is then a constant,
+        which is precisely what the rest of this function forbids — the
+        data-dependency argument only holds while the value comes from the step.
+
+        Both spellings of a YAML comment, because whole-line and inline are
+        stripped by different helpers and only one of them being wired would read
+        exactly as green as both."""
+        for job in PROOF_JOBS:
+            block = job_block(self.lint, job)
+            line = next(
+                ln for ln in block.splitlines()
+                if re.match(r"^\s*ran:\s*\$\{\{\s*steps\.", ln)
+            )
+            indent = " " * (len(line) - len(line.lstrip()))
+            for label, replacement in {
+                "whole-line comment": (
+                    f"{indent}# {line.strip()}\n{indent}ran: 9999"
+                ),
+                "inline comment": f"{indent}ran: 9999  # {line.strip()}",
+            }.items():
+                with self.subTest(job=job, spelling=label):
+                    assert_disables(
+                        job_ran_proof_problems,
+                        self.lint,
+                        self.lint.replace(
+                            block, block.replace(line, replacement, 1), 1
+                        ),
+                        f"{job}: output reference parked in a {label}",
+                    )
+
+    def test_publishing_from_a_step_that_is_not_the_runner_step_is_caught(self):
+        """Two independent selections that were never tied together.
+
+        `proof_steps` is picked by the invocation; the published value is picked
+        by the step id in `outputs:`. Nothing required them to be the SAME step,
+        so every exhaustive check below could be applied to a step whose output
+        nobody reads while a sibling step published a constant. Measured, both
+        `guard_job_problems` and `job_ran_proof_problems` returned `[]`; adding
+        `if: false` to the invoking step then made it a complete fail-open,
+        caught only by a guard in another file."""
+        for job in PROOF_JOBS:
+            with self.subTest(job=job):
+                block = job_block(self.lint, job)
+                ref = re.search(
+                    r"ran:\s*\$\{\{\s*steps\.([\w-]+)\.outputs\.ran\s*\}\}", block
+                )
+                id_line = next(
+                    ln for ln in block.splitlines()
+                    if re.match(rf"^\s*id:\s*{re.escape(ref.group(1))}\s*$", ln)
+                )
+                indent = " " * (len(id_line) - len(id_line.lstrip()))
+                item = indent[:-2]
+                # The id, and a step publishing a constant under it, MOVE OFF the
+                # invoking step and onto a new one in front of it.
+                decoy = (
+                    f"{item}- name: Publish the proof\n"
+                    f"{id_line}\n"
+                    f"{indent}run: |\n"
+                    f"{indent}  set -euo pipefail\n"
+                    f'{indent}  echo "ran=9999" >> "$GITHUB_OUTPUT"\n'
+                    f"{item}- name: Run the work\n"
+                )
+                assert_disables(
+                    job_ran_proof_problems,
+                    self.lint,
+                    self.lint.replace(
+                        block, block.replace(id_line + "\n", decoy, 1), 1
+                    ),
+                    f"{job}: the publishing step is not the invoking step",
                 )
 
     def test_replacing_the_runner_with_a_constant_is_caught(self):

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -1267,6 +1267,7 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         import tempfile
 
         runner_src = (REPO_ROOT / CANARY_RUNNER).read_text()
+        ORACLE = _import_canary_runner().ORACLE_VERSION
         MODULES = {
             "mod_ok.py": (
                 "import unittest\n"
@@ -1287,6 +1288,19 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         }
 
         def drive(adjudicators, block_oracle=False, argv=()):
+            # A STUB ORACLE, not the installed package. `ci-guards` installs
+            # NOTHING by design — that is what lets it run on a broad path
+            # bucket without a pip step — so a test that needs the real
+            # markdown-it-py passes locally and fails there. It did: this test
+            # was green on a machine with the package and red in CI with
+            # `markdown-it-py is not importable`.
+            #
+            # Skipping on ImportError would have been the wrong fix twice over:
+            # it is the fail-open this whole job exists to close, and it would
+            # have made the test vacuous exactly where it runs. A stub makes the
+            # oracle branch satisfiable without depending on what is installed,
+            # and the `block_oracle` row below still exercises the failure
+            # direction with a module that raises.
             with tempfile.TemporaryDirectory() as d:
                 marker = "ADJUDICATORS = ("
                 head = runner_src[:runner_src.index(marker)]
@@ -1299,21 +1313,19 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
                 )
                 for name, body in MODULES.items():
                     Path(d, name).write_text(body)
-                path = [d]
-                if block_oracle:
-                    blk = Path(d, "blocked")
-                    blk.mkdir()
-                    Path(blk, "markdown_it.py").write_text(
-                        'raise ImportError("withheld")\n'
-                    )
-                    path.insert(0, str(blk))
+                # WRITTEN INTO `d` ITSELF, not a directory earlier on
+                # PYTHONPATH. Python puts a script's own directory at
+                # `sys.path[0]`, ahead of PYTHONPATH — measured: a blocking
+                # module on PYTHONPATH lost to the stub sitting next to the
+                # shim, and the "missing oracle" row came back green.
+                Path(d, "markdown_it.py").write_text(
+                    'raise ImportError("withheld")\n' if block_oracle
+                    else f'__version__ = "{ORACLE}"\n'
+                )
                 r = subprocess.run(
                     [sys.executable, str(shim), *argv],
                     capture_output=True, text=True, cwd="/",
-                    env={
-                        "PATH": os.environ["PATH"],
-                        "PYTHONPATH": os.pathsep.join(path),
-                    },
+                    env={"PATH": os.environ["PATH"], "PYTHONPATH": d},
                 )
                 return r.returncode, r.stdout.strip(), r.stderr
 

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -98,7 +98,6 @@ MARKDOWN_SCAN_EXEMPT = (
 )
 import re
 import sys
-import textwrap
 import unittest
 from pathlib import Path
 

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -98,6 +98,7 @@ MARKDOWN_SCAN_EXEMPT = (
 )
 import re
 import sys
+import textwrap
 import unittest
 from pathlib import Path
 
@@ -250,11 +251,21 @@ def guard_job_problems(lint_text: str) -> list:
             "regression (an ungated job always runs) but it is not this design "
             "either — say so deliberately if intended."
         )
-    elif f"needs.{CHANGES_JOB}.outputs.{BUCKET_OUTPUT}" not in gate:
+    # Matched on the FULL `needs.<job>.outputs.<name> == 'true'`, not on the bare
+    # reference. The un-anchored form was the version here until a review measured
+    # it against the same three shapes that had already defeated the canary's
+    # sibling check at `canary_job_problems` — all three returned `[]`:
+    # `ci_config == 'false'` (inverted, so the job runs only when it is not
+    # needed), `ci_config == 'true' && scanner == 'true'` (fires only alongside
+    # kcov, restoring the hole this job closed), and `workflow_dispatch` ANDed in
+    # (never on a PR). The hardened spelling was already sitting one function
+    # away; this one had simply not been brought along with it.
+    elif f"needs.{CHANGES_JOB}.outputs.{BUCKET_OUTPUT} == 'true'" not in gate:
         problems.append(
             f"job `{GUARD_JOB}` is gated on `if: {gate}`, which does not read "
-            f"`needs.{CHANGES_JOB}.outputs.{BUCKET_OUTPUT}`. A correct bucket wired "
-            "to nothing is not a gate."
+            f"`needs.{CHANGES_JOB}.outputs.{BUCKET_OUTPUT} == 'true'`. A correct "
+            "bucket wired to nothing is not a gate, and neither is one inverted "
+            "or ANDed with a condition that never holds on a pull request."
         )
 
     runs = [
@@ -456,12 +467,68 @@ def canary_job_problems(lint_text: str) -> list:
     return problems
 
 
-RAN_MARKER = 'echo "ran=true" >> "$GITHUB_OUTPUT"'
-PROOF_JOBS = ("ci-guards", CANARY_JOB)
+def _marker(var: str) -> str:
+    return f'echo "ran=${var}" >> "$GITHUB_OUTPUT"'
+
+
+def block_scalar_body(block: str, key: str = "run") -> str:
+    """The body of `<key>: |` in `block`, dedented by ITS OWN indent.
+
+    `textwrap.dedent` over the remainder of a job block is wrong here and was the
+    first version: `job_block` returns raw file text, so the remainder also holds
+    whatever follows the step — the two-space `# ---` separator comment between
+    jobs, or the next job's keys. Those set the common prefix to 2 rather than
+    10, dedent strips 2, and every body line keeps eight spaces. Measured:
+    `ci-guards` came back with `'        set -euo pipefail'` while
+    `renderer-canary`, followed by different text, came back correctly — so the
+    bug reproduced on one job and not the other, which is exactly the shape that
+    gets diagnosed as "the fixture is fine, the other job is weird".
+
+    Reading the scalar's own indent and stopping at the first line that dedents
+    below it is what YAML actually specifies, and it is stable against anything
+    added after the step."""
+    marker = f"{key}: |\n"
+    rest = block[block.index(marker) + len(marker):].splitlines()
+    indent = len(rest[0]) - len(rest[0].lstrip())
+    kept = []
+    for line in rest:
+        if not line.strip():
+            kept.append("")
+            continue
+        if len(line) - len(line.lstrip()) < indent:
+            break
+        kept.append(line[indent:])
+    return "\n".join(kept)
+
+
+# Per job: the variable the marker publishes, the line that must COMPUTE that
+# variable from the work's own output, and the floor that rejects a zero/empty
+# value. The floors are derived from `CANARY_CLASSES` rather than written out, so
+# adding an adjudicator without raising the floor is a guard failure instead of a
+# silent widening.
+PROOF_SPECS = {
+    "ci-guards": {
+        "var": "ran",
+        # `$ran` parsed out of `$out`, which holds the suite's own stdout.
+        "derivation": re.compile(r'^ran=\$\(.*"\$out".*\)$'),
+        "derivation_desc": 'a `ran=$(... "$out" ...)` parse of the suite output',
+        "floor": '[ -n "$ran" ]',
+    },
+    CANARY_JOB: {
+        "var": "adjudicated",
+        "derivation": re.compile(r"^adjudicated=\$\(\(\s*adjudicated \+ 1\s*\)\)$"),
+        "derivation_desc": "an `adjudicated=$((adjudicated + 1))` increment",
+        "floor": f'[ "$adjudicated" -eq {len(CANARY_CLASSES)} ]',
+        # The increment must sit INSIDE the loop body. Hoisted above `for` it is a
+        # constant again, and below `done` it counts nothing.
+        "inside_loop": True,
+    },
+}
+PROOF_JOBS = tuple(PROOF_SPECS)
 
 
 def job_ran_proof_problems(lint_text: str) -> list:
-    """The two guard jobs prove they reached the END of their work body.
+    """The two guard jobs publish a count PARSED OUT OF their own work.
 
     WHY THIS EXISTS AND WHY IT IS NOT MORE SHAPES
     ---------------------------------------------
@@ -477,25 +544,60 @@ def job_ran_proof_problems(lint_text: str) -> list:
     the third patch to an enumeration, which ADR-001 §5 names as the signal to
     invert instead.
 
-    The inversion: the last line of each body writes `ran=true` to
-    `$GITHUB_OUTPUT`, and `lint-gate` requires it whenever the job reports
-    success. That line is reachable ONLY by executing everything above it, so the
-    property is carried by the shell's own semantics. All four shapes fall to it
-    at once, and so does shape five.
+    THE FIRST INVERSION WAS WRONG, AND THAT IS THE LESSON HERE
+    ----------------------------------------------------------
+    It made the LAST line of each body write a constant `ran=true` and argued
+    that the line "is reachable only by executing everything above it". It is
+    not. Reaching the last line is not the same as having run the work: close a
+    parking construct ABOVE the marker and the shell falls straight through it.
+    An adversarial pass measured the defeat end to end:
 
-    WHAT THIS FUNCTION ADDS ON TOP
-    ------------------------------
-    The marker alone is a one-line edit away from useless: hoist it above the
-    work, or put `exit 0` below it, and the job parks with the output set. So
-    POSITION is asserted, not presence — it must be the last executed line.
+        if [ "${X:-}" = "1" ]; then      <- inserted
+        ...the entire work body...
+        fi                               <- inserted, one line above the marker
+        echo "ran=true" >> "$GITHUB_OUTPUT"
+
+        job_ran_proof_problems -> []      guard_job_problems -> []
+        executed: exit=0, stdout='', GITHUB_OUTPUT='ran=true'
+        full suite against the mutated lint.yml: Ran 1255 tests — OK
+
+    Two inserted lines, in ONE job — against a docstring that claimed the cost
+    was "several coordinated edits across two jobs". `case ... esac` measures the
+    same, so it is a class and not a spelling of `if`. Worse, the old fixture
+    listed `if false; then ... fi` among the shapes it closed, because it put the
+    marker INSIDE the `if`; the attacker just moves `fi` up one line.
+
+    The property a marker needs is DOMINATION — every path reaching it must have
+    executed the work — and no amount of text analysis can establish domination.
+
+    THE FIX: A DATA DEPENDENCY, NOT A POSITION
+    ------------------------------------------
+    Each job now publishes a COUNT computed from its own work:
+
+        ci-guards        `ran` parsed out of `$out`, the suite's stdout
+        renderer-canary  `adjudicated`, incremented once per class that ran,
+                         did not skip, and passed its named adjudicating method
+
+    Under `set -euo pipefail`, parking the work leaves the source variable
+    unbound and the derivation line DIES rather than falling through. Measured
+    after the fix, same two mutations: `bash: out: unbound variable`, exit 1, no
+    output written. A constant cannot do this; only a value the work produces
+    can. `lint-gate` requires a positive integer, so a zero-length or `0` value
+    is rejected too.
+
+    WHAT THIS FUNCTION ASSERTS
+    --------------------------
+    That the derivation exists, precedes the marker, and — for the canary — sits
+    inside the loop body; that a floor rejects the empty/zero value; and that the
+    marker publishes the VARIABLE rather than a literal. Position is still
+    checked, but as a second line of defence, not as the argument.
 
     WHAT IS NOT CLOSED, stated because a defence that reads complete and is not
     is the failure this file exists to catch: the regress does not terminate
     inside the workflow. `lint-gate`'s own comparison lives in a `run:` body and
-    is parkable the same way. This raises the cost of parking a guard job from
-    one token to several coordinated edits across two jobs; it is defence in
-    depth, NOT closure. What terminates it is outside this file — branch
-    protection requiring the `Lint` context, and GitHub evaluating `needs:`.
+    is parkable the same way. It is defence in depth, NOT closure. What
+    terminates it is outside this file — branch protection requiring the `Lint`
+    context, and GitHub evaluating `needs:`.
 
     Scoped to the two guard-running jobs, not all 23 nodes of the required
     graph (`required_graph(workflow_texts())`, measured). Those two exist to
@@ -503,7 +605,8 @@ def job_ran_proof_problems(lint_text: str) -> list:
     Twenty-three markers whose per-job value is unproven is a bigger diff than
     its evidence."""
     problems = []
-    for job in PROOF_JOBS:
+    for job, spec in PROOF_SPECS.items():
+        marker = _marker(spec["var"])
         block = job_block(lint_text, job)
         if block is None:
             problems.append(f"job `{job}` not found in lint.yml")
@@ -548,23 +651,75 @@ def job_ran_proof_problems(lint_text: str) -> list:
                     "be satisfied."
                 )
 
-        # POSITION, not presence. `executed_shell` so a marker parked in a
-        # comment or an `env:` scalar counts for nothing — the same routing the
-        # sibling pins use, for the same two measured reasons.
+        # `executed_shell` so a marker parked in a comment or an `env:` scalar
+        # counts for nothing — the same routing the sibling pins use, for the
+        # same two measured reasons.
         lines = [ln.strip() for ln in executed_shell(block).splitlines() if ln.strip()]
-        if RAN_MARKER not in " \n".join(lines):
+        if marker not in lines:
             problems.append(
-                f"job `{job}` never writes the `ran` marker in an executed step. "
-                "The proof is the marker; without it the job's `outputs.ran` is "
+                f"job `{job}` never writes `{marker}` in an executed step. The "
+                "proof is that line; without it the job's `outputs.ran` is "
                 "permanently empty and `lint-gate` fails closed — loudly, but it "
                 "means the mechanism is gone."
             )
-        elif lines[-1] != RAN_MARKER:
+            continue
+        at_marker = lines.index(marker)
+
+        # THE DERIVATION. This is the check that survives a parking construct
+        # closing above the marker: the published value has to be COMPUTED from
+        # the work, so parking the work leaves its source unbound and `set -u`
+        # kills the derivation instead of falling through it.
+        derived = [i for i, ln in enumerate(lines) if spec["derivation"].match(ln)]
+        if not derived:
             problems.append(
-                f"job `{job}` writes the `ran` marker but NOT as its last "
-                f"executed line (last is `{lines[-1]}`). Anything below the "
-                "marker can be skipped while the proof still fires, which is "
-                "exactly the hole the marker was added to close."
+                f"job `{job}` publishes `ran` without {spec['derivation_desc']}. "
+                "A constant proves only its own line — measured, wrapping the "
+                "work in a never-taken `if` whose `fi` sits one line above the "
+                "marker left every guard returning [], the whole suite green, "
+                "and the step exiting 0 having run nothing."
+            )
+        elif min(derived) > at_marker:
+            problems.append(
+                f"job `{job}` computes its proof AFTER publishing it, so the "
+                "published value cannot depend on the work."
+            )
+        elif spec.get("inside_loop"):
+            # Hoisted above `for` the increment is a constant again; below `done`
+            # it counts nothing. Both leave the marker looking derived.
+            loop = [i for i, ln in enumerate(lines) if ln.startswith("for ")]
+            done = [i for i, ln in enumerate(lines) if ln == "done"]
+            if not loop or not done:
+                problems.append(
+                    f"job `{job}` no longer has the `for ... done` loop its "
+                    "proof counts iterations of."
+                )
+            elif not any(loop[0] < i < done[0] for i in derived):
+                problems.append(
+                    f"job `{job}` increments its proof OUTSIDE the loop body. "
+                    "Outside, it is incremented a fixed number of times "
+                    "regardless of how many adjudicators actually ran."
+                )
+
+        if spec["floor"] not in lines:
+            problems.append(
+                f"job `{job}` lost its floor `{spec['floor']}`. Without it a "
+                "derivation that produced nothing still publishes — the empty "
+                "string for `ci-guards`, and for the canary a count that a "
+                "never-iterating loop leaves at 0."
+            )
+        elif lines.index(spec["floor"]) > at_marker:
+            problems.append(
+                f"job `{job}` applies its floor after publishing, which is after "
+                "the value has already been read."
+            )
+
+        # POSITION, still asserted — but as the second line of defence now, not
+        # as the argument. A command below the marker can exit before the runner
+        # reads the file back.
+        if lines[-1] != marker:
+            problems.append(
+                f"job `{job}` writes its proof but NOT as its last executed line "
+                f"(last is `{lines[-1]}`). Anything below it can exit first."
             )
 
     gate_block = job_block(lint_text, GATE_JOB)
@@ -579,11 +734,13 @@ def job_ran_proof_problems(lint_text: str) -> list:
                 "nobody — decoration, and the most expensive kind, because it "
                 "looks like a defence."
             )
-    if not re.search(r'\.get\(\s*"ran"\s*,?[^)]*\)\s*!=\s*"true"', gate_block):
+    if not re.search(r'fullmatch\(\s*r?"\[1-9\]\[0-9\]\*"', gate_block):
         problems.append(
-            f"`{GATE_JOB}` no longer COMPARES the `ran` output against `true`. "
-            "Listing the jobs without checking their marker passes on an empty "
-            "string, which is what a parked body produces."
+            f"`{GATE_JOB}` no longer requires `ran` to be a POSITIVE INTEGER. "
+            "Listing the jobs without checking the value passes on the empty "
+            "string, which is what a parked body produces; accepting any "
+            "non-empty value passes on `0`, which is what a loop that never "
+            "iterates produces."
         )
     return problems
 
@@ -1269,63 +1426,104 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         )
 
     # ------------------------------------------------------------------
-    # THE FALL-THROUGH PROOF. These pin `job_ran_proof_problems`, which
-    # replaces an enumeration of parking shapes with one that closes them by
-    # construction. The four shapes below are the measured ones; the point of
-    # the marker is that a fifth would fall to it too, so they are asserted
-    # against the SHELL (does the marker execute?) rather than against the
-    # static guard, which cannot see control flow and never will.
+    # THE EXECUTION PROOF. The static half of this is `job_ran_proof_problems`,
+    # pinned by the mutations further down. The half below is the one that
+    # actually carries the design, and it is NOT static: text cannot see control
+    # flow, so parking the work with a construct that closes above the publish
+    # line leaves every static check returning []. What stops it is that the
+    # published value is COMPUTED from the work, so parking the work leaves its
+    # source unbound and `set -u` kills the derivation.
+    #
+    # These run the REAL job bodies, parked. That is affordable precisely
+    # because a parked body does no work: it dies on the unbound variable in
+    # milliseconds. The unparked direction is the one that cannot be run here
+    # (`ci-guards` would invoke the whole suite, and `renderer-canary` needs the
+    # pinned oracle), so its non-vacuity is carried by the synthetic control.
     # ------------------------------------------------------------------
 
-    def test_every_measured_parking_shape_stops_a_trailing_marker(self):
-        """The inversion, tested as the shell property it actually is.
+    #: Constructs that swallow a span of shell without executing it. Not an
+    #: enumeration this design depends on — the data dependency does not care
+    #: which one is used — but each was measured to DEFEAT the previous
+    #: constant-marker design, so each is pinned as a regression.
+    PARKING_WRAPS = {
+        "if": ('if [ "${__PARK:-}" = "1" ]; then', "fi"),
+        "case": ('case "${__PARK:-}" in Plan9)', ";; esac"),
+        "uncalled function": ("__park() {", "}"),
+    }
 
-        Deliberately NOT run against the real body. A first version neutered the
-        real body line-by-line so it could be wrapped, and the heuristic kept the
-        `}` that closes `ci-guards`' `|| { ... }` block — which closed the
-        wrapping function early, so the marker ran and the test reported the
-        inversion broken. The fixture lied; the mechanism was fine. Running the
-        real body verbatim is not an option either: unparked it invokes the whole
-        guard suite, and `renderer-canary`'s body exits 1 without the oracle and
-        never reaches its last line, so the non-vacuity half could not pass.
+    def _job_body(self, job):
+        block = job_block(self.lint, job)
+        self.assertIsNotNone(block, f"job `{job}` not found")
+        return block_scalar_body(block)
 
-        What the real body contributes is the POSITION of the marker, and that is
-        pinned statically by `job_ran_proof_problems` plus the two relocation
-        mutations below. What is left to prove is the bash fact those two rest
-        on: a construct that prevents fall-through prevents the LAST line. Four
-        measured shapes, one assertion — which is the point of inverting rather
-        than patching shape five."""
-        import os
-        import subprocess
-        import tempfile
+    def test_parking_the_work_kills_the_publish_line_in_both_real_bodies(self):
+        """The property the whole design rests on, measured on the real bodies.
 
-        bodies = {
-            "exit 0": "exit 0\nwork\n" + RAN_MARKER,
-            "if false": "if false; then\nwork\n" + RAN_MARKER + "\nfi",
-            "uncalled function": "park() {\nwork\n" + RAN_MARKER + "\n}",
-            "set -n": "set -n\nwork\n" + RAN_MARKER,
-        }
-        for name, script in bodies.items():
-            with self.subTest(shape=name):
-                with tempfile.TemporaryDirectory() as d:
-                    out = Path(d, "gh_output")
-                    out.write_text("")
-                    subprocess.run(
-                        ["bash", "-c", "work() { :; }\n" + script],
-                        env={"GITHUB_OUTPUT": str(out), "PATH": os.environ["PATH"]},
-                        capture_output=True,
+        The previous design published a constant `ran=true` as the last line and
+        argued that reaching the last line proved the body ran. It does not. An
+        adversarial pass inserted two lines into `ci-guards` — a never-taken `if`
+        opened after `set -euo pipefail` and its `fi` one line above the marker —
+        and measured `job_ran_proof_problems() == []`, `guard_job_problems() ==
+        []`, the full 1255-test suite `OK`, and the step exiting 0 with
+        `ran=true` written and ZERO tests run. The old fixture had listed `if
+        false; then ... fi` among the shapes it closed, but only because it put
+        the marker INSIDE the `if`; moving `fi` up one line falls through it.
+
+        The fix is a data dependency: `$ran` is parsed out of `$out`, and
+        `$adjudicated` is incremented inside the loop. Park the work by ANY
+        construct and the source variable is unbound at the publish line, so
+        `set -u` ends the step instead of letting it fall through.
+
+        Parked from just after `set -euo pipefail` to just before the publish
+        line — the most that can be swallowed while leaving the proof intact,
+        which is the strongest form of the attack."""
+        for job, spec in PROOF_SPECS.items():
+            body = self._job_body(job)
+            lines = body.splitlines()
+            start = lines.index("set -euo pipefail") + 1
+            end = lines.index(_marker(spec["var"]))
+            for name, (open_, close_) in self.PARKING_WRAPS.items():
+                with self.subTest(job=job, shape=name):
+                    parked = "\n".join(
+                        lines[:start] + [open_] + lines[start:end] + [close_]
+                        + lines[end:]
+                    )
+                    code, written = self._run_body(parked)
+                    self.assertNotEqual(
+                        code, 0,
+                        f"{job}/{name}: the parked body EXITED 0 — the work never "
+                        "ran and the step reported success",
                     )
                     self.assertNotIn(
-                        "ran=true", out.read_text(),
-                        f"`{name}` parked the body and the trailing marker STILL "
-                        "wrote its proof — the inversion does not hold",
+                        "ran=", written,
+                        f"{job}/{name}: the parked body still published a proof "
+                        f"({written!r}) — the data dependency does not hold",
                     )
 
-    def test_an_unparked_body_does_write_the_marker(self):
-        """Non-vacuity for the four subtests above: same harness, no parking.
+    def test_the_publish_line_is_the_thing_that_dies(self):
+        """Attribution, not just failure.
 
-        Without it, a harness that could never write the marker would make every
-        shape pass for free — the mistake this file has now recorded twice."""
+        A parked body could exit non-zero for an unrelated reason and every
+        subtest above would pass for the wrong reason. This pins the actual
+        cause: bash naming the derivation's source variable as unbound."""
+        for job, spec in PROOF_SPECS.items():
+            body = self._job_body(job)
+            lines = body.splitlines()
+            start = lines.index("set -euo pipefail") + 1
+            end = lines.index(_marker(spec["var"]))
+            open_, close_ = self.PARKING_WRAPS["if"]
+            parked = "\n".join(
+                lines[:start] + [open_] + lines[start:end] + [close_] + lines[end:]
+            )
+            with self.subTest(job=job):
+                _, _, stderr = self._run_body(parked, want_stderr=True)
+                self.assertIn(
+                    spec["var"], stderr,
+                    f"{job}: parked body failed without naming `{spec['var']}` as "
+                    f"unbound; stderr was {stderr!r}",
+                )
+
+    def _run_body(self, script, want_stderr=False):
         import os
         import subprocess
         import tempfile
@@ -1333,29 +1531,77 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         with tempfile.TemporaryDirectory() as d:
             out = Path(d, "gh_output")
             out.write_text("")
-            subprocess.run(
-                ["bash", "-c", "work() { :; }\nwork\n" + RAN_MARKER],
-                env={"GITHUB_OUTPUT": str(out), "PATH": os.environ["PATH"]},
-                capture_output=True,
+            r = subprocess.run(
+                ["bash", "-c", script],
+                cwd=str(REPO_ROOT),
+                env={
+                    "GITHUB_OUTPUT": str(out),
+                    "PATH": os.environ["PATH"],
+                    # bash reports an unbound variable in the C locale here, and
+                    # `test_the_publish_line_is_the_thing_that_dies` matches on
+                    # the variable NAME rather than the message, but a
+                    # translated message on a developer machine is still worth
+                    # not depending on.
+                    "LC_ALL": "C",
+                },
+                capture_output=True, text=True,
             )
-            self.assertIn(
-                "ran=true", out.read_text(),
-                "the harness cannot write the marker even unparked — the parking "
-                "subtests prove nothing",
-            )
+            written = out.read_text()
+        if want_stderr:
+            return r.returncode, written, r.stderr
+        return r.returncode, written
 
-    def test_hoisting_the_marker_above_the_work_is_caught(self):
-        """The evasion the marker alone does not stop.
+    def test_an_unparked_body_does_publish(self):
+        """Non-vacuity for the parking subtests: same shape, nothing parked.
 
-        Move the marker to the top and the body can be parked below it with the
-        proof already written. `job_ran_proof_problems` asserts POSITION for
-        exactly this, which is why it checks the last executed line rather than
-        containment."""
-        for job in PROOF_JOBS:
+        Synthetic rather than real, because the real unparked bodies need the
+        whole guard suite and the pinned renderer oracle. It mirrors the real
+        data dependency exactly — a value parsed out of captured work output —
+        which is the only part the subtests above rely on."""
+        script = (
+            'set -euo pipefail\n'
+            'out=$(printf "Ran 7 tests in 0.1s\\nOK\\n")\n'
+            'ran=$(printf \'%s\\n\' "$out" | sed -nE '
+            "'s/^Ran ([1-9][0-9]*) tests? in .*/\\1/p')\n"
+            '[ -n "$ran" ]\n'
+            'echo "ran=$ran" >> "$GITHUB_OUTPUT"'
+        )
+        code, written = self._run_body(script)
+        self.assertEqual(code, 0, "the control harness cannot even run")
+        self.assertEqual(
+            written.strip(), "ran=7",
+            "the harness cannot publish a derived proof even unparked — the "
+            "parking subtests prove nothing",
+        )
+
+    def test_the_same_control_parks_when_the_work_is_removed(self):
+        """The control's own non-vacuity: it must fail when the work is gone.
+
+        Without this, a control that passes for a reason unrelated to the data
+        dependency would still look like evidence."""
+        script = (
+            'set -euo pipefail\n'
+            'ran=$(printf \'%s\\n\' "$out" | sed -nE '
+            "'s/^Ran ([1-9][0-9]*) tests? in .*/\\1/p')\n"
+            '[ -n "$ran" ]\n'
+            'echo "ran=$ran" >> "$GITHUB_OUTPUT"'
+        )
+        code, written = self._run_body(script)
+        self.assertNotEqual(code, 0)
+        self.assertEqual(written, "")
+
+    def test_hoisting_the_publish_line_above_the_work_is_caught(self):
+        """Publishing before deriving.
+
+        With the value hoisted, `$ran` is unbound where it is published, so this
+        also fails closed at runtime — but statically it is the difference
+        between a proof and a decoration, and it is caught where the diff is."""
+        for job, spec in PROOF_SPECS.items():
             with self.subTest(job=job):
                 block = job_block(self.lint, job)
                 marker_line = next(
-                    ln for ln in block.splitlines() if ln.strip() == RAN_MARKER
+                    ln for ln in block.splitlines()
+                    if ln.strip() == _marker(spec["var"])
                 )
                 anchor = "          set -euo pipefail\n"
                 self.assertIn(anchor, block, f"{job}: anchor moved")
@@ -1366,21 +1612,21 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
                     job_ran_proof_problems,
                     self.lint,
                     self.lint.replace(block, hoisted, 1),
-                    f"{job}: marker hoisted above the work",
+                    f"{job}: publish line hoisted above the derivation",
                 )
 
-    def test_a_command_after_the_marker_is_caught(self):
-        """Same class from the other side: `exit 0` BELOW the marker.
+    def test_a_command_after_the_publish_line_is_caught(self):
+        """The position half, which survives as defence in depth.
 
-        The proof fires, then the step exits — so the marker must be last, not
-        merely present-and-early. Any trailing command reopens the gap, so the
-        check rejects all of them rather than trying to classify which are
-        harmless."""
-        for job in PROOF_JOBS:
+        A command below the publish line can exit before the runner reads the
+        file back. Any trailing command reopens that, so the check rejects all of
+        them rather than trying to classify which are harmless."""
+        for job, spec in PROOF_SPECS.items():
             with self.subTest(job=job):
                 block = job_block(self.lint, job)
                 marker_line = next(
-                    ln for ln in block.splitlines() if ln.strip() == RAN_MARKER
+                    ln for ln in block.splitlines()
+                    if ln.strip() == _marker(spec["var"])
                 )
                 trailing = block.replace(
                     marker_line + "\n", marker_line + "\n          echo done\n", 1
@@ -1389,8 +1635,81 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
                     job_ran_proof_problems,
                     self.lint,
                     self.lint.replace(block, trailing, 1),
-                    f"{job}: command added after the marker",
+                    f"{job}: command added after the publish line",
                 )
+
+    def test_replacing_the_derivation_with_a_constant_is_caught(self):
+        """THE regression this redesign exists for.
+
+        A constant published on the last line was the previous design, and it was
+        defeated by two inserted lines. Anything that turns the derivation back
+        into a constant must be rejected statically, because at runtime a
+        constant is indistinguishable from a real proof."""
+        for job, spec in PROOF_SPECS.items():
+            with self.subTest(job=job):
+                block = job_block(self.lint, job)
+                derivation = next(
+                    ln for ln in block.splitlines()
+                    if spec["derivation"].match(ln.strip())
+                )
+                indent = " " * (len(derivation) - len(derivation.lstrip()))
+                assert_disables(
+                    job_ran_proof_problems,
+                    self.lint,
+                    self.lint.replace(
+                        block,
+                        block.replace(
+                            derivation, f"{indent}{spec['var']}=1", 1
+                        ),
+                        1,
+                    ),
+                    f"{job}: derivation replaced with a constant",
+                )
+
+    def test_dropping_the_floor_is_caught(self):
+        """A derivation that produced nothing still publishes without a floor.
+
+        For `ci-guards` that is the empty string; for the canary it is `0`, which
+        is what a loop that never iterates leaves behind. `lint-gate` rejects both
+        as well — this is the static half of the same check."""
+        for job, spec in PROOF_SPECS.items():
+            with self.subTest(job=job):
+                block = job_block(self.lint, job)
+                floor = next(
+                    ln for ln in block.splitlines() if ln.strip() == spec["floor"]
+                )
+                assert_disables(
+                    job_ran_proof_problems,
+                    self.lint,
+                    self.lint.replace(
+                        block, block.replace(floor + "\n", "", 1), 1
+                    ),
+                    f"{job}: floor dropped",
+                )
+
+    def test_moving_the_canary_increment_out_of_the_loop_is_caught(self):
+        """Outside the loop it is incremented a fixed number of times.
+
+        Hoisted above `for` or dropped below `done`, `$adjudicated` stops
+        counting adjudicators and becomes a constant wearing a derivation's
+        shape — which the runtime data dependency cannot tell apart, because the
+        variable is still bound."""
+        spec = PROOF_SPECS[CANARY_JOB]
+        block = job_block(self.lint, CANARY_JOB)
+        inc = next(
+            ln for ln in block.splitlines() if spec["derivation"].match(ln.strip())
+        )
+        done = next(ln for ln in block.splitlines() if ln.strip() == "done")
+        moved = block.replace(inc + "\n", "", 1).replace(
+            done + "\n", done + "\n          " + inc.strip() + "\n", 1
+        )
+        self.assertNotEqual(moved, block, "fixture matched nothing")
+        assert_disables(
+            job_ran_proof_problems,
+            self.lint,
+            self.lint.replace(block, moved, 1),
+            "canary increment moved below `done`",
+        )
 
     def test_dropping_the_output_declaration_is_caught(self):
         for job in PROOF_JOBS:
@@ -1432,17 +1751,16 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
                 )
 
     def test_the_aggregator_dropping_the_comparison_is_caught(self):
-        """A gate that LISTS the jobs but stops comparing passes on an empty
-        string — which is precisely what a parked body produces."""
+        """A gate that LISTS the jobs but stops checking the VALUE passes on the
+        empty string, which is what a parked body produces, and on `0`, which is
+        what a loop that never iterates produces."""
         gate = job_block(self.lint, GATE_JOB)
-        line = next(
-            ln for ln in gate.splitlines() if '.get("ran") != "true"' in ln
-        )
+        line = next(ln for ln in gate.splitlines() if "fullmatch(" in ln)
         assert_disables(
             job_ran_proof_problems,
             self.lint,
             self.lint.replace(gate, gate.replace(line, "              and False"), 1),
-            "aggregator no longer compares `ran`",
+            "aggregator no longer checks the `ran` value",
         )
 
     def test_the_aggregator_dropping_a_proof_job_is_caught(self):
@@ -1562,10 +1880,6 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         self.assertIn("not found exactly once", problems[0])
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 class TestTheAggregatorEnforcesTheProof(unittest.TestCase):
     """EXECUTE `lint-gate`'s body. Nothing in this repo did, before this class.
 
@@ -1583,7 +1897,9 @@ class TestTheAggregatorEnforcesTheProof(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.py = cls._extract(LINT_YML.read_text(encoding="utf-8"))
+        text = LINT_YML.read_text(encoding="utf-8")
+        cls.py = cls._extract(text)
+        cls.env_key = cls._env_key(text)
 
     @staticmethod
     def _extract(lint_text: str) -> str:
@@ -1591,15 +1907,16 @@ class TestTheAggregatorEnforcesTheProof(unittest.TestCase):
 
         Two layers, both load-bearing: `job_block` returns raw file text, so the
         YAML indentation is still on it and Python would reject the body; and the
-        script itself lives in a quoted heredoc inside the shell body."""
-        import textwrap
+        script itself lives in a quoted heredoc inside the shell body.
 
+        `block_scalar_body` rather than `textwrap.dedent` over the remainder —
+        see that function for the measured reason."""
         block = job_block(lint_text, GATE_JOB)
         if block is None:
             raise AssertionError(f"job `{GATE_JOB}` not found")
-        marker = "run: |\n"
-        body = textwrap.dedent(block[block.index(marker) + len(marker):])
-        m = re.search(r"^python3 - <<'PY'\n(.*?)^PY", body, re.S | re.M)
+        m = re.search(
+            r"^python3 - <<'PY'\n(.*?)^PY", block_scalar_body(block), re.S | re.M
+        )
         if m is None:
             raise AssertionError(
                 f"`{GATE_JOB}` no longer runs a `python3 - <<'PY'` heredoc — this "
@@ -1608,20 +1925,64 @@ class TestTheAggregatorEnforcesTheProof(unittest.TestCase):
             )
         return m.group(1)
 
+    @staticmethod
+    def _env_key(lint_text: str) -> str:
+        """The env var the gate step actually passes `toJson(needs)` in.
+
+        READ, not assumed, and this is a polarity fix rather than a tidy-up. The
+        first version hardcoded `NEEDS_JSON` in `_run`, so the class could not see
+        the wiring it depends on and its polarity was INVERTED — measured: rename
+        only the `env:` key and the step `KeyError`s in real CI while all seven
+        tests pass; rename BOTH sides consistently, which is a legitimate
+        refactor that works fine, and all seven fail. A check that is blind to
+        the break and loud about the fix is worse than no check."""
+        block = job_block(lint_text, GATE_JOB)
+        keys = re.findall(r"^\s+(\w+):\s*\$\{\{\s*toJson\(needs\)\s*\}\}", block, re.M)
+        if len(keys) != 1:
+            raise AssertionError(
+                f"expected exactly one `<KEY>: ${{{{ toJson(needs) }}}}` in "
+                f"`{GATE_JOB}`, found {keys}. This class feeds the script through "
+                "that variable and cannot guess which one to use."
+            )
+        return keys[0]
+
     def _run(self, needs):
         import json
         import subprocess
 
         r = subprocess.run(
             [sys.executable, "-c", self.py],
-            env={"NEEDS_JSON": json.dumps(needs), "PATH": "/usr/bin:/bin"},
+            # The whole environment, not an extension of it: this also proves the
+            # script has no hidden env dependency.
+            env={self.env_key: json.dumps(needs), "PATH": "/usr/bin:/bin"},
             capture_output=True, text=True,
         )
         return r.returncode, (r.stdout + r.stderr)
 
-    PROVEN = {"result": "success", "outputs": {"ran": "true"}}
+    def test_the_script_reads_the_variable_the_step_writes(self):
+        """The two halves of the wiring must name the same variable.
+
+        Blind spot in the first version: `_extract` pulls only the heredoc body,
+        so a one-way rename of the `env:` key was invisible here and fatal in
+        CI."""
+        self.assertIn(
+            f'os.environ["{self.env_key}"]', self.py,
+            f"`{GATE_JOB}` passes needs in `{self.env_key}` but its script does "
+            "not read that name — the step would KeyError on its next run",
+        )
+
+    # Shapes taken from a REAL `toJson(needs)` payload (run 34298321355), not
+    # invented: every entry carries both keys, and a skipped job's `outputs` is
+    # an empty dict rather than absent. `PARKED` is the literal shape of any job
+    # in that payload with no outputs at all.
+    PROVEN = {"result": "success", "outputs": {"ran": "1255"}}
     SKIPPED = {"result": "skipped", "outputs": {}}
     PARKED = {"result": "success", "outputs": {}}
+    #: A loop that never iterates, or a parse that matched nothing, publishes a
+    #: value — it is just not a positive one. A boolean proof could not express
+    #: this direction at all, which is half the reason the proof became a count.
+    ZERO = {"result": "success", "outputs": {"ran": "0"}}
+    NON_NUMERIC = {"result": "success", "outputs": {"ran": "true"}}
 
     def test_the_script_was_extracted(self):
         # Vacuity canary: an empty script exits 0 and every direction below
@@ -1651,16 +2012,24 @@ class TestTheAggregatorEnforcesTheProof(unittest.TestCase):
         self.assertEqual(code, 0, out)
 
     def test_a_parked_guard_job_fails(self):
-        for job in ("ci-guards", "renderer-canary"):
-            with self.subTest(job=job):
-                needs = {
-                    "ci-guards": self.PROVEN, "renderer-canary": self.PROVEN
-                }
-                needs[job] = self.PARKED
-                code, out = self._run(needs)
-                self.assertEqual(code, 1, out)
-                self.assertIn("without reaching the end", out)
-                self.assertIn(job, out)
+        """Three ways a job can report success without having worked.
+
+        `PARKED` is the body dying or never publishing; `ZERO` is a loop that
+        never iterated or a parse that matched nothing; `NON_NUMERIC` is the
+        PREVIOUS design's constant `ran=true`, which must now be rejected — if it
+        were still accepted, reverting to the defeated design would be a silent
+        one-line edit rather than a red build."""
+        for shape in ("PARKED", "ZERO", "NON_NUMERIC"):
+            for job in ("ci-guards", "renderer-canary"):
+                with self.subTest(job=job, shape=shape):
+                    needs = {
+                        "ci-guards": self.PROVEN, "renderer-canary": self.PROVEN
+                    }
+                    needs[job] = getattr(self, shape)
+                    code, out = self._run(needs)
+                    self.assertEqual(code, 1, out)
+                    self.assertIn("without executing their work", out)
+                    self.assertIn(job, out)
 
     def test_a_renamed_proof_job_fails_closed(self):
         """A missing NAME must be an error, not a pass.
@@ -1681,3 +2050,7 @@ class TestTheAggregatorEnforcesTheProof(unittest.TestCase):
         })
         self.assertEqual(code, 1, out)
         self.assertIn("gitleaks", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -112,6 +112,7 @@ from _ci_guard_util import (  # noqa: E402
     step_blocks,
     strip_comment_lines,
     strip_inline_comment,
+    tracked_files,
     workflow_and_action_files,
     yaml_key_pattern,
 )
@@ -267,15 +268,26 @@ def guard_job_problems(lint_text: str) -> list:
             "or ANDed with a condition that never holds on a pull request."
         )
 
-    runs = [
-        blk for blk in step_blocks(block)
-        if _DISCOVER_RE.search(blk)
-    ]
-    if not runs:
+    # THE RUNNER, matched WHOLE. This was `_DISCOVER_RE` — a substring test for
+    # `unittest discover ... -p 'test_ci_*.py'` that ignored the `-s` value and
+    # everything after `-p`. Measured, that let two edits pass with every guard
+    # returning `[]`: `cd /tmp/decoy` before it ran a one-test decoy suite
+    # (`ran=1`, zero real guards), and an appended `-k '*bucket*'` cut the run to
+    # 18 of 1264. Both published a GENUINE count — the scope, not the number, was
+    # the lie. The invocation now takes no arguments and the runner refuses any,
+    # so the check is an anchored whole-line match.
+    if not any(
+        re.search(
+            rf'^\s*python3 {re.escape(GUARD_RUNNER)} >> "\$GITHUB_OUTPUT"\s*$',
+            blk, re.M,
+        )
+        for blk in step_blocks(block)
+    ):
         problems.append(
-            f"no step in `{GUARD_JOB}` invokes `unittest discover ... -p "
-            "'test_ci_*.py'`. The job would report success while running nothing "
-            "that guards anything."
+            f"no step in `{GUARD_JOB}` invokes exactly "
+            f'`python3 {GUARD_RUNNER} >> "$GITHUB_OUTPUT"`. Anything else — a '
+            "`cd` in front, an argument behind, a pipe — changes WHICH guards "
+            "run while leaving the count it publishes genuine."
         )
 
     gate_block = job_block(lint_text, GATE_JOB)
@@ -368,91 +380,76 @@ def canary_job_problems(lint_text: str) -> list:
             "fail-open it exists to close."
         )
 
-    if not re.search(r"grep\s+-qE\s+'\\\.\\\.\\\. skipped ", executed):
+    # THE RUNNER, matched WHOLE — same reason as the sibling on `ci-guards`.
+    if not re.search(
+        rf'^\s*python3 {re.escape(CANARY_RUNNER)} >> "\$GITHUB_OUTPUT"\s*$',
+        executed, re.M,
+    ):
         problems.append(
-            f"job `{CANARY_JOB}` lost its skip check. `unittest` counts a skipped "
-            "class in `Ran N tests` and exits 0, so without this a skip reads as "
-            "a pass."
+            f"job `{CANARY_JOB}` does not invoke exactly "
+            f'`python3 {CANARY_RUNNER} >> "$GITHUB_OUTPUT"`.'
         )
-
-    if not re.search(r"\^Ran \[1-9\]", executed):
-        problems.append(
-            f"job `{CANARY_JOB}` lost its non-zero test-count check. `unittest` "
-            "exits 0 on 'Ran 0 tests', so an emptied class would pass vacuously."
-        )
-
-    # The floors must be PER CLASS. A single aggregate check over the combined
-    # output was the first version, and emptying one class — renaming its test
-    # methods, which is what an ordinary refactor produces — left the other two
-    # carrying the count while the residual went live.
-    if "for spec in" not in executed:
-        problems.append(
-            f"job `{CANARY_JOB}` no longer loops per class. An aggregate "
-            "`Ran [1-9]` over all three lets ONE adjudicator contribute zero "
-            "tests while the others carry the count — measured, with the "
-            "residual payload live and the job exiting 0."
-        )
-
-    for cls, method in CANARY_CLASSES:
-        if cls not in executed:
-            problems.append(
-                f"job `{CANARY_JOB}` no longer RUNS `{cls}`. It skips in every "
-                "other job, so dropping it here leaves it running nowhere."
-            )
-        if method not in executed:
-            problems.append(
-                f"job `{CANARY_JOB}` no longer names `{method}`, the one test in "
-                f"`{cls}` that adjudicates real repository content against the "
-                "renderer. Without the name the job floors on a COUNT, and a "
-                "count cannot tell that the adjudicating test was parked."
-            )
 
     # NO HEREDOC IN THIS STEP. `executed_shell` does not model heredoc bodies —
-    # its own docstring says so and calls it the one limitation that CAN hide an
-    # unrun test — so a `run: |` that opens `cat <<'EOF'` and quotes the whole
-    # loop inside it reads to every check above as execution: measured,
-    # `canary_job_problems() == []` with the step exiting 0 having adjudicated
-    # nothing. Closing that in the shared extractor needs a heredoc state machine
-    # across every guard that imports it; closing it HERE needs one line, because
-    # this step has no heredoc by design (the install step's comment already
-    # explains why an indented one would not even parse). Forbidding what the
-    # extractor cannot read is the fail-closed half of the same fix.
-    #
-    # SCOPE, stated because the check is a SUBSTRING test and not a heredoc
+    # its own docstring calls that the one limitation that CAN hide an unrun test
+    # — so a `run: |` opening `cat <<'EOF'` would read as execution to every
+    # check above. Forbidding what the extractor cannot read is the fail-closed
+    # half. SCOPE, stated because it is a SUBSTRING test and not a heredoc
     # parser: it also fires on `echo "shift: 1 << 2"` and `: $(( 1 << 2 ))`
-    # (measured). Both are false alarms, both fail CLOSED, and neither shape
-    # belongs in this step — acceptable, but it is a token check, not a grammar.
-    # It does NOT close the parking class; `exit 0` as the first line parks the
-    # step with no `<<` anywhere and this function still returns `[]`. See
-    # `test_parking_the_canary_step_in_a_heredoc_is_not_execution` for the
-    # measured residual.
+    # (measured). Both are false alarms, both fail CLOSED, and neither belongs
+    # in a step that is now one invocation.
     if "<<" in executed:
         problems.append(
             f"job `{CANARY_JOB}` contains a heredoc. `executed_shell` cannot see "
-            "into heredoc bodies, so the loop could sit inside one, run nothing, "
-            "and satisfy every check in this function. If a heredoc is genuinely "
-            "needed, teach `executed_shell` to strip them FIRST."
+            "into heredoc bodies, so the invocation could sit inside one and run "
+            "nothing while satisfying every check in this function."
         )
 
-    # The runner must disable unittest's descriptions. See the step's own comment:
-    # with them on, adding a docstring to an adjudicating method moves `... ok`
-    # onto a second line and the by-name check below stops matching, turning
-    # ordinary documentation into a red build.
-    if "descriptions=False" not in executed:
+    # ---------------------------------------------------------------------
+    # THE INVARIANTS THAT USED TO BE SHELL, ASSERTED WHERE THEY NOW LIVE.
+    #
+    # This block previously scanned the step's executed text for `for spec in`,
+    # each class and method name, `descriptions=False`, a skip grep, a
+    # `^Ran [1-9]` grep and a `did not run ${method}` message. Every one of those
+    # was an assertion about a shell loop that parsed `unittest -v` PROSE, and
+    # prose a run produces is prose a FAILING run can shape: measured, a red
+    # class whose output carried a column-0 `OK ` line satisfied the verdict grep
+    # once the `|| { exit 1; }` branch was weakened, and the step published a
+    # genuine count with the suite red.
+    #
+    # The invariants did not go away — they moved into `_ci_canary_runner.py`,
+    # where they are `TestResult` bookkeeping rather than regexes, and they are
+    # asserted here against the IMPORTED module. `descriptions=False` has no
+    # successor on purpose: nothing parses prose any more, so the reason it
+    # existed (a docstring on an adjudicating method splitting `... ok` onto a
+    # second line and turning documentation into a red build) is gone.
+    # ---------------------------------------------------------------------
+    if CANARY_RUNNER not in tracked_files():
         problems.append(
-            f"job `{CANARY_JOB}` no longer runs with `descriptions=False`. Under "
-            "`unittest -v` a docstring on an adjudicating method splits its "
-            "result onto a second line and the per-method check fails on a "
-            "passing suite — a false alarm, which is how a gate stops being read."
+            f"`{CANARY_RUNNER}` is not a tracked file. It holds the adjudicator "
+            "table, the oracle pin and the pass/skip verdict for this job."
         )
-
-    # The methods must be checked BY NAME in the step, not merely listed.
-    if "did not run ${method}" not in executed:
-        problems.append(
-            f"job `{CANARY_JOB}` lost its per-method assertion. A per-class count "
-            "floor passes with the adjudicating test parked — measured, with the "
-            "residual live and a reader seeing 0 of 70 rows."
-        )
+    else:
+        runner = _import_canary_runner()
+        if tuple(runner.ADJUDICATORS) != tuple(CANARY_CLASSES):
+            problems.append(
+                f"`{CANARY_RUNNER}`'s ADJUDICATORS has drifted from "
+                "`CANARY_CLASSES`:\n"
+                f"  runner: {tuple(runner.ADJUDICATORS)}\n"
+                f"  guard : {tuple(CANARY_CLASSES)}\n"
+                "A second copy of a constant is how this repo has lost a check "
+                "before; one of the two is now wrong and nothing else would say "
+                "which."
+            )
+        pinned = re.search(r"markdown-it-py==([\d.]+)", executed)
+        if pinned and runner.ORACLE_VERSION != pinned.group(1):
+            problems.append(
+                f"`{CANARY_RUNNER}` adjudicates against oracle "
+                f"{runner.ORACLE_VERSION} but the job installs "
+                f"{pinned.group(1)}. The runner hard-fails on the mismatch, so "
+                "this is a red build rather than a silent one — but it is a red "
+                "build for a reason no one would guess from the message."
+            )
 
     gate_block = job_block(lint_text, GATE_JOB)
     if gate_block is None:
@@ -505,35 +502,42 @@ def block_scalar_body(block: str, key: str = "run") -> str:
 # value. The floors are derived from `CANARY_CLASSES` rather than written out, so
 # adding an adjudicator without raising the floor is a guard failure instead of a
 # silent widening.
+#: Runner scripts, relative to the repo root. Each owns the SCOPE, the FILTER
+#: refusal and the VERDICT for one job — the three things that were unpinnable
+#: while they lived in shell text.
+GUARD_RUNNER = "scanner/tests/_ci_guard_runner.py"
+CANARY_RUNNER = "scanner/tests/_ci_canary_runner.py"
+
+
+def _import_canary_runner():
+    """The canary runner as a MODULE, so its table is compared as data.
+
+    Imported rather than grepped: a regex over the file would re-create the
+    parse-the-text problem one level up, and this repo has already measured what
+    that costs — a hand-written source list in a guard had drifted to missing 12
+    files while reading green."""
+    import importlib
+
+    return importlib.import_module("_ci_canary_runner")
+
 PROOF_SPECS = {
     "ci-guards": {
-        "var": "ran",
-        # `$ran` parsed out of `$out`, which holds the suite's own stdout.
-        "derivation": re.compile(r'^ran=\$\(.*"\$out".*\)$'),
-        "derivation_desc": 'a `ran=$(... "$out" ...)` parse of the suite output',
-        "floor": '[ -n "$ran" ]',
-        # `$out` is what the proof is computed FROM, so seeding it forges the
-        # proof. Exactly one assignment, and `guard_job_problems` separately
-        # requires that one to be the `unittest discover` invocation.
-        "source": "out",
-        "source_assignments": 1,
-        # Two independent readings of the same run: a non-zero test count, and
-        # the suite reporting OK. `Ran N` prints on failure too.
-        "verdict": re.compile(r"^printf .*\| grep -qE '\^OK\( \|\$\)'$"),
+        "runner": GUARD_RUNNER,
+        # ANCHORED WHOLE, and the ONLY thing the body does besides `set -euo
+        # pipefail`. Not a substring test: `_DISCOVER_RE` used to match
+        # `unittest discover ... -p 'test_ci_*.py'` and ignore the rest of the
+        # line, which accepted an appended `-k '*bucket*'` (1264 tests -> 18)
+        # and a `cd /tmp/decoy` in front (0 real guards), both publishing a
+        # GENUINE count.
+        "invocation": re.compile(
+            rf'^python3 {re.escape(GUARD_RUNNER)} >> "\$GITHUB_OUTPUT"$'
+        ),
     },
     CANARY_JOB: {
-        "var": "adjudicated",
-        "derivation": re.compile(r"^adjudicated=\$\(\(\s*adjudicated \+ 1\s*\)\)$"),
-        "derivation_desc": "an `adjudicated=$((adjudicated + 1))` increment",
-        "floor": f'[ "$adjudicated" -eq {len(CANARY_CLASSES)} ]',
-        # The increment must sit INSIDE the loop body. Hoisted above `for` it is a
-        # constant again, and below `done` it counts nothing.
-        "inside_loop": True,
-        # The counter is its own source: `adjudicated=0` to initialise and the
-        # increment. A third assignment is a seeded value.
-        "source": "adjudicated",
-        "source_assignments": 2,
-        "verdict": re.compile(r"^if ! printf .*\| grep -qE '\^OK\( \|\$\)'; then$"),
+        "runner": CANARY_RUNNER,
+        "invocation": re.compile(
+            rf'^python3 {re.escape(CANARY_RUNNER)} >> "\$GITHUB_OUTPUT"$'
+        ),
     },
 }
 PROOF_JOBS = tuple(PROOF_SPECS)
@@ -618,7 +622,6 @@ def job_ran_proof_problems(lint_text: str) -> list:
     its evidence."""
     problems = []
     for job, spec in PROOF_SPECS.items():
-        marker = _marker(spec["var"])
         block = job_block(lint_text, job)
         if block is None:
             problems.append(f"job `{job}` not found in lint.yml")
@@ -633,9 +636,8 @@ def job_ran_proof_problems(lint_text: str) -> list:
             )
         if not declares:
             problems.append(
-                f"job `{job}` declares no `outputs:`. Without it the marker its "
-                "body writes is invisible to `lint-gate`, and the job is back to "
-                "being provable only by reading its text."
+                f"job `{job}` declares no `outputs:`. Without it the line its "
+                "runner appends is invisible to `lint-gate`."
             )
         else:
             ref = re.search(
@@ -643,129 +645,93 @@ def job_ran_proof_problems(lint_text: str) -> list:
             )
             if ref is None:
                 problems.append(
-                    f"job `{job}` has `outputs:` but does not surface `ran` from a "
-                    "step. An output that reads from nothing is the empty string, "
-                    "which is the undeclared-output vacuity class this repo "
-                    "already paid for once."
+                    f"job `{job}` has `outputs:` but does not surface `ran` from "
+                    "a step. An output that reads from nothing is the empty "
+                    "string, which is the undeclared-output vacuity class this "
+                    "repo already paid for once."
                 )
             elif not re.search(
                 rf"^\s*id:\s*{re.escape(ref.group(1))}\s*$", block, re.M
             ):
-                # The runtime direction of this is already fail-closed — a typo'd
-                # step id yields an empty output, `lint-gate` sees success with no
-                # proof, and the build goes red. But red-at-runtime for a typo is
-                # a wasted CI cycle and an alarm that looks like a real parking
-                # event, so it is caught here instead, where the diff is.
                 problems.append(
-                    f"job `{job}` surfaces `ran` from step id "
-                    f"`{ref.group(1)}`, which no step in the job declares. The "
-                    "output resolves to the empty string, so the proof can never "
-                    "be satisfied."
+                    f"job `{job}` surfaces `ran` from step id `{ref.group(1)}`, "
+                    "which no step in the job declares. The output resolves to "
+                    "the empty string, so the proof can never be satisfied."
                 )
 
-        # `executed_shell` so a marker parked in a comment or an `env:` scalar
-        # counts for nothing — the same routing the sibling pins use, for the
-        # same two measured reasons.
-        lines = [ln.strip() for ln in executed_shell(block).splitlines() if ln.strip()]
-        if marker not in lines:
+        # THE PROOF STEP ONLY, not the whole job. `renderer-canary` has a
+        # legitimate `pip install` step before it, and an exhaustive check over
+        # the job's combined shell would flag that as an extra command. Selected
+        # by the invocation itself so the selection cannot drift from what is
+        # being checked.
+        proof_steps = [
+            blk for blk in step_blocks(block)
+            if any(spec["invocation"].match(ln.strip())
+                   for ln in executed_shell(blk).splitlines())
+        ]
+        if len(proof_steps) != 1:
             problems.append(
-                f"job `{job}` never writes `{marker}` in an executed step. The "
-                "proof is that line; without it the job's `outputs.ran` is "
-                "permanently empty and `lint-gate` fails closed — loudly, but it "
-                "means the mechanism is gone."
+                f"job `{job}` has {len(proof_steps)} steps running an anchored "
+                f"`python3 {spec['runner']} >> \"$GITHUB_OUTPUT\"`, expected 1. "
+                "A `cd` in front, an argument behind, a pipe or a `|| true` all "
+                "change WHICH work runs — or whether its verdict counts — while "
+                "leaving the published count genuine."
             )
             continue
-        at_marker = lines.index(marker)
-
-        # THE DERIVATION. This is the check that survives a parking construct
-        # closing above the marker: the published value has to be COMPUTED from
-        # the work, so parking the work leaves its source unbound and `set -u`
-        # kills the derivation instead of falling through it.
-        derived = [i for i, ln in enumerate(lines) if spec["derivation"].match(ln)]
-        if not derived:
-            problems.append(
-                f"job `{job}` publishes `ran` without {spec['derivation_desc']}. "
-                "A constant proves only its own line — measured, wrapping the "
-                "work in a never-taken `if` whose `fi` sits one line above the "
-                "marker left every guard returning [], the whole suite green, "
-                "and the step exiting 0 having run nothing."
-            )
-        elif min(derived) > at_marker:
-            problems.append(
-                f"job `{job}` computes its proof AFTER publishing it, so the "
-                "published value cannot depend on the work."
-            )
-        elif spec.get("inside_loop"):
-            # Hoisted above `for` the increment is a constant again; below `done`
-            # it counts nothing. Both leave the marker looking derived.
-            loop = [i for i, ln in enumerate(lines) if ln.startswith("for ")]
-            done = [i for i, ln in enumerate(lines) if ln == "done"]
-            if not loop or not done:
-                problems.append(
-                    f"job `{job}` no longer has the `for ... done` loop its "
-                    "proof counts iterations of."
-                )
-            elif not any(loop[0] < i < done[0] for i in derived):
-                problems.append(
-                    f"job `{job}` increments its proof OUTSIDE the loop body. "
-                    "Outside, it is incremented a fixed number of times "
-                    "regardless of how many adjudicators actually ran."
-                )
-
-        # FORGERY. The data dependency stops a parked body only while the source
-        # variable is UNBOUND. Seed it above the parked span and the derivation
-        # runs on a lie: measured, `out="Ran 1 tests in 0.0s"` inserted above an
-        # `if`-wrapped body published `ran=1` at exit 0 with every check returning
-        # [], and `adjudicated=3` hoisted above the canary's loop published
-        # `ran=3` the same way. That is a THIRD line for the attacker rather than
-        # closure, and it is not domination — but a seeded value is an EXTRA
-        # assignment, and counting assignments is something text CAN do.
-        # Rewriting the one legitimate assignment instead removes the
-        # `unittest discover` invocation, which `guard_job_problems` already
-        # rejects.
-        assigns = [
-            ln for ln in lines
-            if re.match(rf"^{re.escape(spec['source'])}=", ln)
+        lines = [
+            ln.strip() for ln in executed_shell(proof_steps[0]).splitlines()
+            if ln.strip()
         ]
-        if len(assigns) != spec["source_assignments"]:
+
+        # THE WHOLE STEP, not just "contains". Everything the step executes is
+        # `set -euo pipefail` and the invocation, so anything else is by
+        # definition something new to explain.
+        allowed = {"set -euo pipefail"}
+        extra = [
+            ln for ln in lines
+            if ln not in allowed and not spec["invocation"].match(ln)
+        ]
+        if extra:
             problems.append(
-                f"job `{job}` assigns `{spec['source']}` {len(assigns)} time(s), "
-                f"expected {spec['source_assignments']}: {assigns}. An extra "
-                "assignment is how a parked body forges a plausible proof — the "
-                "derivation then reads a seeded value instead of the work."
+                f"job `{job}` executes lines beyond the runner invocation: "
+                f"{extra}. The proof is that the step does nothing else; a "
+                "second command can seed state, redirect the output file, or "
+                "append a forged `ran=` of its own."
             )
 
-        if spec["verdict"] and not any(
-            spec["verdict"].match(ln) for ln in lines
-        ):
+        # EXACTLY ONE WRITER to `$GITHUB_OUTPUT`. Covered by `extra` above, but
+        # asserted separately because this is the specific forgery the previous
+        # design could not stop: while a shell variable carried the value, ten
+        # different ways of BINDING it without an `=` assignment published
+        # `ran=9999` at exit 0 with the guard silent (`read`, `printf -v`,
+        # `declare`, `export`, `mapfile`, `let`, `(( ))`, `for`, process
+        # substitution, and a step-level `env:` contributing no shell lines at
+        # all). A plain `ran=9999` WAS caught — the pin worked only for the one
+        # spelling it enumerated. Removing the variable removed the class.
+        writers = [ln for ln in lines if "$GITHUB_OUTPUT" in ln]
+        if len(writers) != 1:
             problems.append(
-                f"job `{job}` no longer requires its run to report `OK`. "
-                "`unittest` prints `Ran N` on failure too, so with the exit-status "
-                "branch weakened to `|| true` a genuinely FAILING suite publishes "
-                "a genuine count and the job reports success — measured, with "
-                "every other check in this function returning []."
+                f"job `{job}` has {len(writers)} lines writing to "
+                f"`$GITHUB_OUTPUT`, expected exactly 1: {writers}."
             )
-
-        if spec["floor"] not in lines:
+        elif lines[-1] != writers[0]:
             problems.append(
-                f"job `{job}` lost its floor `{spec['floor']}`. Without it a "
-                "derivation that produced nothing still publishes — the empty "
-                "string for `ci-guards`, and for the canary a count that a "
-                "never-iterating loop leaves at 0."
-            )
-        elif lines.index(spec["floor"]) > at_marker:
-            problems.append(
-                f"job `{job}` applies its floor after publishing, which is after "
-                "the value has already been read."
-            )
-
-        # POSITION, still asserted — but as the second line of defence now, not
-        # as the argument. A command below the marker can exit before the runner
-        # reads the file back.
-        if lines[-1] != marker:
-            problems.append(
-                f"job `{job}` writes its proof but NOT as its last executed line "
+                f"job `{job}` writes its proof but NOT as the last executed line "
                 f"(last is `{lines[-1]}`). Anything below it can exit first."
+            )
+
+        if any(re.match(r"^cd\s", ln) for ln in lines):
+            problems.append(
+                f"job `{job}` contains a `cd`. The runner is named by a path "
+                "relative to the repo root, so a `cd` can only change which "
+                "file — or no file — gets executed."
+            )
+
+        if spec["runner"] not in tracked_files():
+            problems.append(
+                f"job `{job}` invokes `{spec['runner']}`, which is not a tracked "
+                "file. That script IS the job's proof — which tests ran, and "
+                "whether they passed."
             )
 
     gate_block = job_block(lint_text, GATE_JOB)
@@ -804,6 +770,23 @@ def uncovered_paths(pattern: str) -> list:
         for name in installed_workflow_templates(SETUP_SH.read_text(encoding="utf-8")):
             targets.append(f"templates/{name}")
     targets.extend(guard_data_files())
+    # THE SCRIPTS THE JOBS EXECUTE, not just the files guards READ. That
+    # distinction is why this function missed them: the target set was
+    # workflows, templates and AST-derived data files, and a runner is none of
+    # those — it is the thing the job runs.
+    #
+    # Measured when the runners were introduced: both were OUTSIDE the bucket,
+    # so a PR editing only `_ci_guard_runner.py` — the script that decides which
+    # guards run and whether they passed — would not have fired `ci-guards` or
+    # `renderer-canary` at all. The path gate would have hidden a change to the
+    # proof itself, which is this repo's already-recorded "the gate hides drift"
+    # class landing on the gate's own evidence.
+    #
+    # Sourced from `PROOF_SPECS` rather than hand-written: those values are
+    # pinned to the workflow by `job_ran_proof_problems`, which matches the
+    # invocation line anchored WHOLE, so the constant cannot drift from what the
+    # jobs actually execute without turning something red.
+    targets.extend(spec["runner"] for spec in PROOF_SPECS.values())
     return sorted(p for p in targets if not bucket.match(p))
 
 
@@ -980,6 +963,30 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         """Item 6 of the guard conventions: the harness must be able to report
         GREEN on the real file, or every RED below proves nothing."""
         self.assertEqual(uncovered_paths(bucket_pattern(self.lint)), [])
+
+    def test_a_bucket_that_stops_covering_the_runners_is_caught(self):
+        """The proof scripts must be INSIDE the gate that runs them.
+
+        Measured when they were introduced: both runners fell outside the
+        `ci_config` bucket, so a PR editing only `_ci_guard_runner.py` — the
+        script that decides which guards run and whether they passed — would not
+        have fired `ci-guards` or `renderer-canary`. The path gate would have
+        hidden a change to the evidence itself.
+
+        Mutated by NARROWING the alternation back to the exact previous
+        spelling, so the RED can come from nothing else."""
+        narrowed = apply_mutation(
+            self.lint,
+            r"scanner/tests/(test_ci_|_ci_)",
+            r"scanner/tests/(test_ci_|_ci_guard_util\.py)",
+        )
+        missed = uncovered_paths(bucket_pattern(narrowed))
+        for spec in PROOF_SPECS.values():
+            self.assertIn(
+                spec["runner"], missed,
+                f"narrowing the bucket left `{spec['runner']}` reported as "
+                "covered — the check cannot see the runners at all",
+            )
 
     def test_derived_target_set_is_populated(self):
         """The denominator must not be empty. `templates/codeql.yml` and
@@ -1238,37 +1245,128 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
             "renderer-canary no longer installs the oracle",
         )
 
-    def test_dropping_the_skip_check_is_caught(self):
-        """`unittest` counts a skipped class in `Ran N tests` and exits 0, so
-        the count check alone does not catch a skip."""
-        assert_disables(
-            canary_job_problems,
-            self.lint,
-            apply_mutation(
-                # RAW string: the workflow carries a shell-quoted ERE, so the
-                # backslashes are literal in the file. Writing them as escapes in
-                # a normal Python string produced a stale fixture twice, which
-                # `assert_disables` correctly refused to score.
-                self.lint,
-                r"grep -qE '\.\.\. skipped |\(skipped='",
-                "grep -qE '__removed__'",
-            ),
-            "renderer-canary lost its skip check",
-        )
+    def test_the_canary_runner_rejects_every_non_pass(self):
+        """The four shell-loop checks, replaced by EXECUTING their successor.
 
-    def test_dropping_a_canary_class_is_caught(self):
-        """Each class skips in every other job, so removing it here leaves it
-        running nowhere at all."""
-        assert_disables(
-            canary_job_problems,
-            self.lint,
-            apply_mutation(
-                self.lint,
-                "test_ci_markdown_scan_evasion.TestTheResidualIsBounded",
-                "test_ci_markdown_scan_evasion.__removed__",
+        This supersedes four assertions that scanned the step's text for a skip
+        grep, a `^Ran [1-9]` grep, `for spec in`, and a `did not run ${method}`
+        message. All four described a loop that parsed `unittest -v` PROSE, and
+        prose a run produces is prose a FAILING run can shape — measured, a red
+        class carrying a column-0 `OK ` line satisfied the verdict grep once the
+        failure branch was weakened.
+
+        SYNTHETIC TARGET MODULES, one per direction, because the first version
+        of this test was wrong in a way mutation scoring caught: it produced a
+        skip by withholding the oracle, which trips the runner's oracle check
+        FIRST and returns before the skip logic is ever reached. `if
+        result.skipped:` scored 0 red — the assertion passed for a reason
+        unrelated to what it named. Each branch now has a target that isolates
+        it."""
+        import os
+        import subprocess
+        import tempfile
+
+        runner_src = (REPO_ROOT / CANARY_RUNNER).read_text()
+        MODULES = {
+            "mod_ok.py": (
+                "import unittest\n"
+                "class C(unittest.TestCase):\n"
+                "    def test_it(self): pass\n"
             ),
-            "a renderer-adjudicated class dropped from the canary job",
-        )
+            "mod_skip.py": (
+                "import unittest\n"
+                "class C(unittest.TestCase):\n"
+                "    @unittest.skip('withheld dependency')\n"
+                "    def test_it(self): pass\n"
+            ),
+            "mod_fail.py": (
+                "import unittest\n"
+                "class C(unittest.TestCase):\n"
+                "    def test_it(self): self.fail('OK  a\\nOK')\n"
+            ),
+        }
+
+        def drive(adjudicators, block_oracle=False, argv=()):
+            with tempfile.TemporaryDirectory() as d:
+                marker = "ADJUDICATORS = ("
+                head = runner_src[:runner_src.index(marker)]
+                tail = runner_src[
+                    runner_src.index("\n)\n", runner_src.index(marker)) + 3:
+                ]
+                shim = Path(d, "_ci_canary_runner.py")
+                shim.write_text(
+                    head + f"ADJUDICATORS = {adjudicators!r}" + tail
+                )
+                for name, body in MODULES.items():
+                    Path(d, name).write_text(body)
+                path = [d]
+                if block_oracle:
+                    blk = Path(d, "blocked")
+                    blk.mkdir()
+                    Path(blk, "markdown_it.py").write_text(
+                        'raise ImportError("withheld")\n'
+                    )
+                    path.insert(0, str(blk))
+                r = subprocess.run(
+                    [sys.executable, str(shim), *argv],
+                    capture_output=True, text=True, cwd="/",
+                    env={
+                        "PATH": os.environ["PATH"],
+                        "PYTHONPATH": os.pathsep.join(path),
+                    },
+                )
+                return r.returncode, r.stdout.strip(), r.stderr
+
+        OK = (("mod_ok.C", "test_it"),)
+
+        # NON-VACUITY FIRST, or every negative row below passes for free.
+        code, out, err = drive(OK)
+        self.assertEqual(code, 0, err[-1200:])
+        self.assertEqual(out, "ran=1", err[-1200:])
+
+        with self.subTest(direction="a SKIPPED adjudicator is not a pass"):
+            # `unittest` counts a skip in `Ran N` and exits 0, which is why a
+            # count-based check could never see one.
+            code, out, err = drive((("mod_skip.C", "test_it"),))
+            self.assertNotEqual(code, 0)
+            self.assertEqual(out, "")
+            self.assertIn("SKIPPED in the job that exists to run it", err)
+
+        with self.subTest(direction="a FAILING adjudicator is not a pass"):
+            code, out, err = drive((("mod_fail.C", "test_it"),))
+            self.assertNotEqual(code, 0)
+            self.assertEqual(out, "")
+            self.assertIn("did not run and pass", err)
+            # Attribution: the `OK ` line the old grep-based verdict would have
+            # read really is in this output.
+            self.assertIn("OK  a", err)
+
+        with self.subTest(direction="a renamed method is not a pass"):
+            # NOTE THE MECHANISM: `loadTestsFromName` does NOT raise for a
+            # missing method — it returns a suite holding a synthetic
+            # `_FailedTest` that runs and errors. So the load-time branch never
+            # fires and `wasSuccessful()` is what rejects it. An earlier version
+            # of this assertion expected the load-time message and failed; the
+            # runner was right and the expectation was wrong.
+            code, out, err = drive((("mod_ok.C", "test_gone"),))
+            self.assertNotEqual(code, 0)
+            self.assertEqual(out, "")
+            self.assertIn("did not run and pass", err)
+
+        with self.subTest(direction="a missing oracle is a hard failure"):
+            # Asserted on the ORACLE branch's own message, not on a substring
+            # the skip branch could also produce — the two used to mask each
+            # other and both scored 0 red.
+            code, out, err = drive(OK, block_oracle=True)
+            self.assertEqual(code, 2)
+            self.assertEqual(out, "")
+            self.assertIn("markdown-it-py is not importable", err)
+
+        with self.subTest(direction="no arguments accepted"):
+            code, out, err = drive(OK, argv=("-k", "*bucket*"))
+            self.assertEqual(code, 2)
+            self.assertEqual(out, "")
+            self.assertIn("takes no arguments", err)
 
     def test_rewiring_the_canary_gate_is_caught(self):
         """The gate is asserted, not merely present.
@@ -1428,68 +1526,9 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
             "renderer-canary step parked in a heredoc body",
         )
 
-    def test_restoring_unittest_descriptions_is_caught(self):
-        """The fail-CLOSED half: a false alarm is also a defect.
-
-        `python3 -m unittest -v` cannot be told `descriptions=False`, and with
-        descriptions on, a method that HAS a docstring prints `name (…)` and puts
-        `... ok` on the NEXT line — so the by-name check stops matching and the
-        job goes red because someone documented a test. Measured on
-        `test_the_canary_fires_on_the_measured_residual_payload`, which already
-        carries one; the three adjudicating methods do not, which is the only
-        reason this is latent rather than live.
-
-        Pinned because reverting to the shorter `-m unittest -v` spelling looks
-        like a simplification and reintroduces it."""
-        start = self.lint.index(
-            "      - name: Run the renderer-adjudicated guard classes"
-        )
-        end = self.lint.index("\n  scanner-unit-tests:")
-        body = self.lint[start:end]
-        # Anchored on the RUNNER line, not on the token: the step's own comment
-        # explains `descriptions=False` and therefore contains it, and matching
-        # the token alone found two lines and would have mutated a comment —
-        # scoring the fixture rather than the check. The same over-broad-anchor
-        # slip the gate mutation already paid for once in this file.
-        runner = [
-            line for line in body.splitlines()
-            if "descriptions=False" in line and line.lstrip().startswith("out=$(")
-        ]
-        self.assertEqual(
-            len(runner),
-            1,
-            "expected exactly one runner line to mutate; the step changed shape",
-        )
-        reverted = body.replace(
-            runner[0],
-            '            out=$(python3 -m unittest -v "$cls" 2>&1) || {',
-        )
-        assert_disables(
-            canary_job_problems,
-            self.lint,
-            self.lint[:start] + reverted + self.lint[end:],
-            "renderer-canary reverted to `unittest -v` (descriptions on)",
-        )
-
-    # ------------------------------------------------------------------
-    # THE EXECUTION PROOF. The static half of this is `job_ran_proof_problems`,
-    # pinned by the mutations further down. The half below is the one that
-    # actually carries the design, and it is NOT static: text cannot see control
-    # flow, so parking the work with a construct that closes above the publish
-    # line leaves every static check returning []. What stops it is that the
-    # published value is COMPUTED from the work, so parking the work leaves its
-    # source unbound and `set -u` kills the derivation.
-    #
-    # These run the REAL job bodies, parked. That is affordable precisely
-    # because a parked body does no work: it dies on the unbound variable in
-    # milliseconds. The unparked direction is the one that cannot be run here
-    # (`ci-guards` would invoke the whole suite, and `renderer-canary` needs the
-    # pinned oracle), so its non-vacuity is carried by the synthetic control.
-    # ------------------------------------------------------------------
-
     #: Constructs that swallow a span of shell without executing it. Not an
-    #: enumeration this design depends on — the data dependency does not care
-    #: which one is used — but each was measured to DEFEAT the previous
+    #: enumeration the design depends on — the data dependency does not care
+    #: which one is used — but each was measured to DEFEAT the earlier
     #: constant-marker design, so each is pinned as a regression.
     PARKING_WRAPS = {
         "if": ('if [ "${__PARK:-}" = "1" ]; then', "fi"),
@@ -1502,72 +1541,57 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         self.assertIsNotNone(block, f"job `{job}` not found")
         return block_scalar_body(block)
 
-    def test_parking_the_work_kills_the_publish_line_in_both_real_bodies(self):
-        """The property the whole design rests on, measured on the real bodies.
+    def test_parking_the_step_is_caught_and_publishes_nothing(self):
+        """Parking, against the shape that has no shell variable left.
 
-        The previous design published a constant `ran=true` as the last line and
-        argued that reaching the last line proved the body ran. It does not. An
-        adversarial pass inserted two lines into `ci-guards` — a never-taken `if`
-        opened after `set -euo pipefail` and its `fi` one line above the marker —
-        and measured `job_ran_proof_problems() == []`, `guard_job_problems() ==
-        []`, the full 1255-test suite `OK`, and the step exiting 0 with
-        `ran=true` written and ZERO tests run. The old fixture had listed `if
-        false; then ... fi` among the shapes it closed, but only because it put
-        the marker INSIDE the `if`; moving `fi` up one line falls through it.
+        Under the previous design the publish line read `$ran`, so parking the
+        work left it unbound and `set -u` killed the step. That mechanism is
+        gone with the variable — and it is not missed, because parking now fails
+        in two independent places instead:
 
-        The fix is a data dependency: `$ran` is parsed out of `$out`, and
-        `$adjudicated` is incremented inside the loop. Park the work by ANY
-        construct and the source variable is unbound at the publish line, so
-        `set -u` ends the step instead of letting it fall through.
+          static  the step's executed shell is EXHAUSTIVELY `set -euo pipefail`
+                  plus the anchored invocation, so the `if`/`fi` a parking
+                  construct must add are extra lines and get rejected outright;
+          runtime the invocation itself is inside the parked span, so nothing is
+                  appended, `outputs.ran` is empty, and `lint-gate` rejects it as
+                  not a positive integer.
 
-        Parked from just after `set -euo pipefail` to just before the publish
-        line — the most that can be swallowed while leaving the proof intact,
-        which is the strongest form of the attack."""
+        The runtime half is the one that survives someone editing this guard, so
+        both are asserted."""
         for job, spec in PROOF_SPECS.items():
             body = self._job_body(job)
             lines = body.splitlines()
             start = lines.index("set -euo pipefail") + 1
-            end = lines.index(_marker(spec["var"]))
+            invocation = next(
+                i for i, ln in enumerate(lines)
+                if spec["invocation"].match(ln.strip())
+            )
             for name, (open_, close_) in self.PARKING_WRAPS.items():
                 with self.subTest(job=job, shape=name):
-                    parked = "\n".join(
-                        lines[:start] + [open_] + lines[start:end] + [close_]
-                        + lines[end:]
+                    parked_lines = (
+                        lines[:start] + [open_] + lines[start:invocation + 1]
+                        + [close_]
                     )
-                    code, written = self._run_body(parked)
-                    self.assertNotEqual(
-                        code, 0,
-                        f"{job}/{name}: the parked body EXITED 0 — the work never "
-                        "ran and the step reported success",
+                    block = job_block(self.lint, job)
+                    mutated = self.lint.replace(
+                        block,
+                        block.replace(
+                            "\n".join(lines),
+                            "\n".join(parked_lines),
+                        ),
+                        1,
                     )
-                    self.assertNotIn(
-                        "ran=", written,
-                        f"{job}/{name}: the parked body still published a proof "
-                        f"({written!r}) — the data dependency does not hold",
+                    if mutated != self.lint:
+                        self.assertTrue(
+                            job_ran_proof_problems(mutated),
+                            f"{job}/{name}: a parked step was accepted",
+                        )
+                    code, written = self._run_body("\n".join(parked_lines))
+                    self.assertEqual(
+                        written, "",
+                        f"{job}/{name}: a parked step still published "
+                        f"{written!r}",
                     )
-
-    def test_the_publish_line_is_the_thing_that_dies(self):
-        """Attribution, not just failure.
-
-        A parked body could exit non-zero for an unrelated reason and every
-        subtest above would pass for the wrong reason. This pins the actual
-        cause: bash naming the derivation's source variable as unbound."""
-        for job, spec in PROOF_SPECS.items():
-            body = self._job_body(job)
-            lines = body.splitlines()
-            start = lines.index("set -euo pipefail") + 1
-            end = lines.index(_marker(spec["var"]))
-            open_, close_ = self.PARKING_WRAPS["if"]
-            parked = "\n".join(
-                lines[:start] + [open_] + lines[start:end] + [close_] + lines[end:]
-            )
-            with self.subTest(job=job):
-                _, _, stderr = self._run_body(parked, want_stderr=True)
-                self.assertIn(
-                    spec["var"], stderr,
-                    f"{job}: parked body failed without naming `{spec['var']}` as "
-                    f"unbound; stderr was {stderr!r}",
-                )
 
     def _run_body(self, script, want_stderr=False):
         import os
@@ -1636,97 +1660,239 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         end = next(i for i in range(start, len(lines)) if lines[i] == "}")
         return "\n".join(lines[:start] + [replacement] + lines[end + 1:])
 
-    def test_a_swallowed_suite_failure_does_not_publish(self):
-        r"""A FAILING suite must not publish a count. Measured, not argued.
+    def test_the_guard_runner_publishes_only_when_the_suite_passed(self):
+        """The verdict is `wasSuccessful()`, not a grep. Driven, not read.
 
-        `unittest` prints `Ran N` on failure exactly as it does on success, so
-        weakening the capture's `|| { ...; exit 1; }` branch to `|| true` lets a
-        red suite publish a genuine count and the job report success — worse than
-        the parking class this design was built for, because parking runs nothing
-        while this SWALLOWS real failures. Measured before the `^OK` check
-        existed: `job_ran_proof_problems() == []` and `guard_job_problems() == []`
-        with the suite red and the job green.
+        Three shell versions of this check were defeated in a row. The last one
+        greped the run's own output for `^OK( |$)`, which a failing run can
+        satisfy: `2>&1` captures the whole failure report, and this repo's
+        guards routinely build multi-line messages whose lines start at column
+        0. Measured — a red suite with an `OK ` line in it, plus the failure
+        branch weakened to `|| true`, exited 0 and published `ran=2`.
 
-        The static guard still cannot see it (the OK check is textually present
-        either way), so this direction is pinned by EXECUTION. Four rows, because
-        the first version of this probe used `\\n` inside a non-raw Python string,
-        printf emitted a literal backslash-n, the whole synthetic output collapsed
-        onto one line, and every row went red for that reason instead of the one
-        under test — the non-vacuity row is what caught it."""
-        fail = r"""printf 'F\nRan 1253 tests in 16.8s\n\nFAILED (failures=1)\n'; exit 1"""
-        ok = r"""printf 'Ran 1253 tests in 16.8s\n\nOK\n'"""
-        cases = {
-            # The attack.
-            "failing + swallowed": (f"out=$({fail}) || true", False),
-            # Same failure, branch intact — red for the ordinary reason.
-            "failing + branch intact": (
-                f'out=$({fail}) || {{\n  printf \'%s\\n\' "$out"\n  exit 1\n}}',
-                False,
-            ),
-            # NON-VACUITY: the fixture path must be able to reach the publish
-            # line at all, or the two rows above prove nothing.
-            "passing": (f"out=$({ok})", True),
-            # ATTRIBUTION: `|| true` alone must NOT be what makes it red, or the
-            # first row is red for the wrong reason.
-            "passing + swallowed": (f"out=$({ok}) || true", True),
-        }
-        for name, (capture, should_publish) in cases.items():
-            with self.subTest(case=name):
-                code, written = self._run_body(
-                    self._ci_guards_with_capture(capture)
+        Driven in a temp directory rather than against `scanner/tests`, because
+        the runner scans ITS OWN parent: dropping the shim next to synthetic
+        fixtures gives exact control over pass/fail without touching the repo."""
+        import os
+        import subprocess
+        import tempfile
+
+        PASSING = (
+            "import unittest\n"
+            "class T(unittest.TestCase):\n"
+            "    def test_a(self): pass\n"
+            "    def test_b(self): pass\n"
+        )
+        FAILING = (
+            "import unittest\n"
+            "class U(unittest.TestCase):\n"
+            # A failure message whose line starts at column 0 with `OK `, which
+            # is exactly what defeated the grep-based verdict.
+            "    def test_c(self): self.fail('OK  docs/a.md\\nOK')\n"
+        )
+
+        def drive(files, argv=()):
+            with tempfile.TemporaryDirectory() as d:
+                Path(d, "_ci_guard_runner.py").write_text(
+                    (REPO_ROOT / GUARD_RUNNER).read_text()
                 )
-                if should_publish:
-                    self.assertEqual(code, 0, f"{name}: expected success")
-                    self.assertEqual(written.strip(), "ran=1253", name)
-                else:
-                    self.assertNotEqual(code, 0, f"{name}: a red suite exited 0")
-                    self.assertEqual(
-                        written, "",
-                        f"{name}: a red suite published {written!r}",
+                for name, body in files.items():
+                    Path(d, name).write_text(body)
+                r = subprocess.run(
+                    [sys.executable, str(Path(d, "_ci_guard_runner.py")), *argv],
+                    capture_output=True, text=True, cwd="/",
+                    env={"PATH": os.environ["PATH"]},
+                )
+                return r.returncode, r.stdout.strip(), r.stderr
+
+        # NON-VACUITY: the harness must be able to publish at all.
+        code, out, err = drive({"test_ci_pass.py": PASSING})
+        self.assertEqual(code, 0, err[-800:])
+        self.assertEqual(out, "ran=2", err[-800:])
+
+        with self.subTest(direction="a failing test blocks the count"):
+            code, out, err = drive(
+                {"test_ci_pass.py": PASSING, "test_ci_fail.py": FAILING}
+            )
+            self.assertNotEqual(code, 0)
+            self.assertEqual(
+                out, "",
+                "a red suite published a count — the verdict is not structural",
+            )
+            self.assertIn("FAILED", err)
+            # Attribution: the `OK ` line really is present in the output that
+            # the old grep-based verdict would have read.
+            self.assertIn("OK  docs/a.md", err)
+
+        with self.subTest(direction="an empty tree is not a vacuous pass"):
+            code, out, err = drive({})
+            self.assertEqual(code, 2)
+            self.assertEqual(out, "")
+
+        with self.subTest(direction="no arguments accepted"):
+            # Pinned separately from the canary runner's identical refusal:
+            # mutation scoring showed `if argv:` in THIS runner at 0 red, i.e.
+            # nothing was holding it. An appended `-k '*bucket*'` is what cut a
+            # real run from 1264 tests to 18.
+            #
+            # DRIVEN AGAINST A COPY, never `REPO_ROOT / GUARD_RUNNER`. The first
+            # version ran the real runner, and mutation scoring found what that
+            # costs: with the refusal removed, the runner falls through to
+            # discovering `scanner/tests` — which contains THIS test, which
+            # spawns the runner again. Unbounded recursion. It hung for 18 hours
+            # before it was killed, and in CI it would burn the job timeout
+            # instead of failing. A copy scans only its own temp directory, so
+            # the same mutation now fails fast.
+            code, out, err = drive({"test_ci_pass.py": PASSING}, argv=("-k", "*x*"))
+            self.assertEqual(code, 2)
+            self.assertEqual(out, "")
+            self.assertIn("takes no arguments", err)
+
+        with self.subTest(direction="a narrowed run is rejected"):
+            # The floor tied to something the shell does not choose: more guard
+            # FILES than tests that ran means discovery was cut short.
+            with tempfile.TemporaryDirectory() as d:
+                Path(d, "_ci_guard_runner.py").write_text(
+                    (REPO_ROOT / GUARD_RUNNER).read_text()
+                )
+                for n in range(3):
+                    Path(d, f"test_ci_m{n}.py").write_text(
+                        "import unittest\n"
+                        f"class C{n}(unittest.TestCase):\n"
+                        # Only ONE module contributes a test; the other two are
+                        # importable but empty, so testsRun < len(files).
+                        + ("    def test_it(self): pass\n" if n == 0 else "    pass\n")
+                    )
+                r = subprocess.run(
+                    [sys.executable, str(Path(d, "_ci_guard_runner.py"))],
+                    capture_output=True, text=True, cwd="/",
+                    env={"PATH": os.environ["PATH"]},
+                )
+            self.assertNotEqual(r.returncode, 0, r.stderr[-600:])
+            self.assertEqual(r.stdout.strip(), "")
+            self.assertIn("was narrowed", r.stderr)
+
+        with self.subTest(direction="cwd cannot redirect the scan"):
+            # Driven from `/` above already; this pins that a decoy suite in the
+            # CWD is not what gets scanned.
+            with tempfile.TemporaryDirectory() as decoy:
+                Path(decoy, "test_ci_decoy.py").write_text(
+                    "import unittest\n"
+                    "class D(unittest.TestCase):\n"
+                    "    def test_only(self): pass\n"
+                )
+                with tempfile.TemporaryDirectory() as d:
+                    Path(d, "_ci_guard_runner.py").write_text(
+                        (REPO_ROOT / GUARD_RUNNER).read_text()
+                    )
+                    Path(d, "test_ci_pass.py").write_text(PASSING)
+                    r = subprocess.run(
+                        [sys.executable, str(Path(d, "_ci_guard_runner.py"))],
+                        capture_output=True, text=True, cwd=decoy,
+                        env={"PATH": os.environ["PATH"]},
+                    )
+            self.assertEqual(r.returncode, 0, r.stderr[-800:])
+            self.assertEqual(
+                r.stdout.strip(), "ran=2",
+                "the runner scanned the CWD instead of its own directory",
+            )
+
+    def test_the_canary_table_drifting_from_the_guard_is_caught(self):
+        """`CANARY_CLASSES` and the runner's `ADJUDICATORS` are one spec in two
+        files, so drift between them must be a failure rather than a silent
+        divergence — this repo has lost a check to a drifted second copy before.
+
+        Mutated on the GUARD side, so the runner (which CI executes) stays
+        correct and only the pin moves."""
+        original = tuple(CANARY_CLASSES)
+        narrowed = original[:-1]
+        import test_ci_guard_self_verify as self_mod
+
+        self_mod.CANARY_CLASSES = narrowed
+        try:
+            problems = canary_job_problems(self.lint)
+        finally:
+            self_mod.CANARY_CLASSES = original
+        self.assertTrue(
+            any("drifted" in p for p in problems),
+            f"a narrowed CANARY_CLASSES was accepted: {problems}",
+        )
+
+    def test_binding_the_published_value_any_other_way_is_caught(self):
+        """The enumeration failure mode, closed by removing what it enumerated.
+
+        While the value passed through a shell variable, the guard counted
+        `^ran=` assignments — and that pin worked for exactly the one spelling it
+        named. Measured on that design, with the work parked and ONE line seeded
+        above it, every one of these published `ran=9999` at exit 0 with the
+        guard reporting nothing, while a plain `ran=9999` WAS caught:
+
+            read -r ran <<<        printf -v ran        declare ran=
+            export ran=            mapfile -t ran       let ran=
+            (( ran = ))            for ran in           IFS= read -r ran < <()
+            step-level `env: ran:` (zero shell lines at all)
+
+        There is no variable now — the runner appends its own `ran=<count>` — so
+        each of these is just an extra line in a step whose executed shell is
+        checked exhaustively. Pinned anyway, because the value of this design is
+        precisely that the list above stopped mattering, and a future edit that
+        reintroduces an intermediate variable should turn this red."""
+        seeds = [
+            'read -r ran <<< "9999"',
+            "printf -v ran %s 9999",
+            "declare ran=9999",
+            "export ran=9999",
+            'mapfile -t ran <<< "9999"',
+            "let ran=9999",
+            "(( ran = 9999 ))",
+            "for ran in 9999; do :; done",
+            'echo "ran=9999" >> "$GITHUB_OUTPUT"',
+        ]
+        for job in PROOF_SPECS:
+            block = job_block(self.lint, job)
+            anchor = "          set -euo pipefail\n"
+            self.assertIn(anchor, block, f"{job}: anchor moved")
+            for seed in seeds:
+                with self.subTest(job=job, seed=seed[:28]):
+                    assert_disables(
+                        job_ran_proof_problems,
+                        self.lint,
+                        self.lint.replace(
+                            block,
+                            block.replace(anchor, anchor + f"          {seed}\n", 1),
+                            1,
+                        ),
+                        f"{job}: {seed[:28]}",
                     )
 
-    def test_seeding_the_source_variable_is_caught(self):
-        """FORGERY: the data dependency holds only while the source is unbound.
+    def test_a_step_level_env_cannot_supply_the_value(self):
+        """The one seeding shape that adds NO shell line at all.
 
-        Seed it above a parked span and the derivation runs on a lie — measured,
-        `out="Ran 1 tests in 0.0s"` published `ran=1` at exit 0, and
-        `adjudicated=3` hoisted above the canary's loop published `ran=3`, both
-        with every check returning []. A seeded value is an EXTRA assignment, and
-        counting assignments is something text CAN do."""
+        `executed_shell` discards every non-`run` key, so a step-level
+        `env: ran: '9999'` was invisible to the assignment count — and under the
+        old design it published `ran=9999` from a fully parked body. It is
+        harmless now for a structural reason rather than a detected one: nothing
+        in the step reads a variable, so there is nothing for it to supply.
+        Asserted as BEHAVIOUR, since there is no text for a static check to see."""
         for job, spec in PROOF_SPECS.items():
             with self.subTest(job=job):
-                block = job_block(self.lint, job)
-                anchor = "          set -euo pipefail\n"
-                self.assertIn(anchor, block, f"{job}: anchor moved")
-                seeded = block.replace(
-                    anchor,
-                    anchor + f'          {spec["source"]}="forged"\n',
-                    1,
+                # `executed_shell`, not the raw body: the first version of this
+                # matched `$ran` inside the step's own COMMENTS explaining why
+                # the variable was removed, and went red on prose.
+                lines = [
+                    ln for ln in
+                    executed_shell(job_block(self.lint, job)).splitlines()
+                    if ln.strip()
+                ]
+                self.assertFalse(
+                    [ln for ln in lines if "$ran" in ln or "${ran" in ln],
+                    f"{job}: the step reads a shell variable again, so a "
+                    "step-level `env:` could supply it — the shape this design "
+                    "removed",
                 )
-                assert_disables(
-                    job_ran_proof_problems,
-                    self.lint,
-                    self.lint.replace(block, seeded, 1),
-                    f"{job}: source variable seeded with a forged value",
-                )
-
-    def test_dropping_the_ok_verdict_check_is_caught(self):
-        """Without it, `Ran N` alone is the whole verdict — and it prints on
-        failure too."""
-        for job, spec in PROOF_SPECS.items():
-            with self.subTest(job=job):
-                block = job_block(self.lint, job)
-                line = next(
-                    ln for ln in block.splitlines()
-                    if spec["verdict"].match(ln.strip())
-                )
-                assert_disables(
-                    job_ran_proof_problems,
-                    self.lint,
-                    self.lint.replace(
-                        block, block.replace(line + "\n", "", 1), 1
-                    ),
-                    f"{job}: `^OK` verdict check dropped",
+                self.assertTrue(
+                    any(spec["invocation"].match(ln.strip()) for ln in lines),
+                    f"{job}: invocation not found",
                 )
 
     def test_the_same_control_parks_when_the_work_is_removed(self):
@@ -1745,126 +1911,90 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         self.assertNotEqual(code, 0)
         self.assertEqual(written, "")
 
-    def test_hoisting_the_publish_line_above_the_work_is_caught(self):
-        """Publishing before deriving.
-
-        With the value hoisted, `$ran` is unbound where it is published, so this
-        also fails closed at runtime — but statically it is the difference
-        between a proof and a decoration, and it is caught where the diff is."""
-        for job, spec in PROOF_SPECS.items():
-            with self.subTest(job=job):
-                block = job_block(self.lint, job)
-                marker_line = next(
-                    ln for ln in block.splitlines()
-                    if ln.strip() == _marker(spec["var"])
-                )
-                anchor = "          set -euo pipefail\n"
-                self.assertIn(anchor, block, f"{job}: anchor moved")
-                hoisted = block.replace(marker_line + "\n", "").replace(
-                    anchor, anchor + marker_line + "\n", 1
-                )
-                assert_disables(
-                    job_ran_proof_problems,
-                    self.lint,
-                    self.lint.replace(block, hoisted, 1),
-                    f"{job}: publish line hoisted above the derivation",
-                )
-
     def test_a_command_after_the_publish_line_is_caught(self):
-        """The position half, which survives as defence in depth.
-
-        A command below the publish line can exit before the runner reads the
-        file back. Any trailing command reopens that, so the check rejects all of
-        them rather than trying to classify which are harmless."""
+        """A command below the invocation can exit before the runner reads the
+        output file back — and is an extra line besides."""
         for job, spec in PROOF_SPECS.items():
             with self.subTest(job=job):
                 block = job_block(self.lint, job)
-                marker_line = next(
+                line = next(
                     ln for ln in block.splitlines()
-                    if ln.strip() == _marker(spec["var"])
-                )
-                trailing = block.replace(
-                    marker_line + "\n", marker_line + "\n          echo done\n", 1
+                    if spec["invocation"].match(ln.strip())
                 )
                 assert_disables(
                     job_ran_proof_problems,
                     self.lint,
-                    self.lint.replace(block, trailing, 1),
-                    f"{job}: command added after the publish line",
+                    self.lint.replace(
+                        block,
+                        block.replace(line + "\n", line + "\n          echo done\n", 1),
+                        1,
+                    ),
+                    f"{job}: command added after the invocation",
                 )
 
-    def test_replacing_the_derivation_with_a_constant_is_caught(self):
-        """THE regression this redesign exists for.
+    def test_replacing_the_runner_with_a_constant_is_caught(self):
+        """THE regression this whole series exists for.
 
-        A constant published on the last line was the previous design, and it was
-        defeated by two inserted lines. Anything that turns the derivation back
-        into a constant must be rejected statically, because at runtime a
-        constant is indistinguishable from a real proof."""
+        A constant published as the last line was the FIRST design, and it was
+        defeated by two inserted lines. Anything that turns the proof back into a
+        constant must be rejected statically, because at runtime a constant is
+        indistinguishable from a real count."""
         for job, spec in PROOF_SPECS.items():
             with self.subTest(job=job):
                 block = job_block(self.lint, job)
-                derivation = next(
+                line = next(
                     ln for ln in block.splitlines()
-                    if spec["derivation"].match(ln.strip())
+                    if spec["invocation"].match(ln.strip())
                 )
-                indent = " " * (len(derivation) - len(derivation.lstrip()))
+                indent = " " * (len(line) - len(line.lstrip()))
                 assert_disables(
                     job_ran_proof_problems,
                     self.lint,
                     self.lint.replace(
                         block,
                         block.replace(
-                            derivation, f"{indent}{spec['var']}=1", 1
+                            line,
+                            f'{indent}echo "ran=1" >> "$GITHUB_OUTPUT"',
+                            1,
                         ),
                         1,
                     ),
-                    f"{job}: derivation replaced with a constant",
+                    f"{job}: runner replaced with a constant",
                 )
 
-    def test_dropping_the_floor_is_caught(self):
-        """A derivation that produced nothing still publishes without a floor.
+    def test_anything_appended_to_the_invocation_is_caught(self):
+        """The substring-match hole, closed by anchoring — and pinned.
 
-        For `ci-guards` that is the empty string; for the canary it is `0`, which
-        is what a loop that never iterates leaves behind. `lint-gate` rejects both
-        as well — this is the static half of the same check."""
+        `_DISCOVER_RE` used to match `unittest discover ... -p 'test_ci_*.py'`
+        and ignore the rest of the line. Measured, that accepted an appended
+        `-k '*bucket*'` which cut the run from 1264 tests to 18, and a `cd
+        /tmp/decoy` in front which ran a one-test decoy suite — both publishing
+        a GENUINE count, because the scope was the lie, not the number.
+
+        Each row is a separate spelling of "more than the bare invocation"."""
         for job, spec in PROOF_SPECS.items():
-            with self.subTest(job=job):
-                block = job_block(self.lint, job)
-                floor = next(
-                    ln for ln in block.splitlines() if ln.strip() == spec["floor"]
-                )
-                assert_disables(
-                    job_ran_proof_problems,
-                    self.lint,
-                    self.lint.replace(
-                        block, block.replace(floor + "\n", "", 1), 1
-                    ),
-                    f"{job}: floor dropped",
-                )
-
-    def test_moving_the_canary_increment_out_of_the_loop_is_caught(self):
-        """Outside the loop it is incremented a fixed number of times.
-
-        Hoisted above `for` or dropped below `done`, `$adjudicated` stops
-        counting adjudicators and becomes a constant wearing a derivation's
-        shape — which the runtime data dependency cannot tell apart, because the
-        variable is still bound."""
-        spec = PROOF_SPECS[CANARY_JOB]
-        block = job_block(self.lint, CANARY_JOB)
-        inc = next(
-            ln for ln in block.splitlines() if spec["derivation"].match(ln.strip())
-        )
-        done = next(ln for ln in block.splitlines() if ln.strip() == "done")
-        moved = block.replace(inc + "\n", "", 1).replace(
-            done + "\n", done + "\n          " + inc.strip() + "\n", 1
-        )
-        self.assertNotEqual(moved, block, "fixture matched nothing")
-        assert_disables(
-            job_ran_proof_problems,
-            self.lint,
-            self.lint.replace(block, moved, 1),
-            "canary increment moved below `done`",
-        )
+            runner = spec["runner"]
+            for label, mutated in {
+                "argument appended":
+                    f'python3 {runner} -k \'*bucket*\' >> "$GITHUB_OUTPUT"',
+                "failure swallowed":
+                    f'python3 {runner} >> "$GITHUB_OUTPUT" || true',
+                "piped through a filter":
+                    f'python3 {runner} | tail -1 >> "$GITHUB_OUTPUT"',
+                "redirected elsewhere":
+                    f'python3 {runner} >> /tmp/elsewhere',
+                "a `cd` in front":
+                    f'cd /tmp\n          python3 {runner} >> "$GITHUB_OUTPUT"',
+            }.items():
+                with self.subTest(job=job, shape=label):
+                    assert_disables(
+                        job_ran_proof_problems,
+                        self.lint,
+                        apply_mutation(
+                            self.lint, f'python3 {runner} >> "$GITHUB_OUTPUT"', mutated
+                        ),
+                        f"{job}: {label}",
+                    )
 
     def test_dropping_the_output_declaration_is_caught(self):
         for job in PROOF_JOBS:
@@ -1926,51 +2056,6 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
             "aggregator no longer requires the canary's proof",
         )
 
-    def test_dropping_the_per_method_assertion_is_caught(self):
-        """A per-class COUNT floor passes with the adjudicating test parked.
-
-        Measured: parking the one method in `TestTheDocAgreesWithTheRenderer`
-        that reads the real catalog left the class at two synthetic-fixture
-        tests, `Ran 3 tests / OK`, exit 0 — with the residual payload live and a
-        reader seeing 0 of 70 guard rows."""
-        assert_disables(
-            canary_job_problems,
-            self.lint,
-            apply_mutation(
-                self.lint, 'did not run ${method}', 'did not run __removed__'
-            ),
-            "renderer-canary lost its per-method assertion",
-        )
-
-    def test_dropping_an_adjudicating_method_name_is_caught(self):
-        """The class can stay in the loop while the method it must run does
-        not — which is the shape a rename produces."""
-        assert_disables(
-            canary_job_problems,
-            self.lint,
-            apply_mutation(
-                self.lint,
-                "test_the_reduction_and_the_renderer_agree_on_the_real_catalog",
-                "__renamed_away__",
-            ),
-            "an adjudicating method name dropped from the canary loop",
-        )
-
-    def test_flattening_the_per_class_loop_is_caught(self):
-        """An aggregate `Ran [1-9]` over the combined output lets ONE class
-        contribute zero tests while the other two carry the count.
-
-        Not hypothetical: emptying `TestTheDocAgreesWithTheRenderer` — renaming
-        its test methods, which is what an ordinary refactor produces — printed
-        "Ran 5 tests / OK" and exited 0 with the measured residual payload live
-        in the catalog and a reader seeing 0 of 70 guard rows."""
-        assert_disables(
-            canary_job_problems,
-            self.lint,
-            apply_mutation(self.lint, "for spec in \\", "for _unused in \\"),
-            "renderer-canary no longer loops per class",
-        )
-
     def test_removing_the_job_from_the_aggregator_is_caught(self):
         """A job outside `lint-gate.needs` cannot block a merge."""
         assert_disables(
@@ -2003,8 +2088,8 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
             self.lint,
             apply_mutation(
                 self.lint,
-                "python3 -m unittest discover -s . -p 'test_ci_*.py'",
-                "echo 'skipping the guards'",
+                f'python3 {GUARD_RUNNER} >> "$GITHUB_OUTPUT"',
+                'echo "ran=1" >> "$GITHUB_OUTPUT"',
             ),
             "ci-guards runs nothing",
         )
@@ -2016,14 +2101,14 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
         problems = guard_job_problems(
             apply_mutation(
                 self.lint,
-                "          out=$(python3 -m unittest discover -s . -p 'test_ci_*.py' 2>&1) || {",
-                "          # out=$(python3 -m unittest discover -s . -p 'test_ci_*.py' 2>&1) || {\n"
-                "          out=$(echo skipped) || {",
+                f'          python3 {GUARD_RUNNER} >> "$GITHUB_OUTPUT"',
+                f'          # python3 {GUARD_RUNNER} >> "$GITHUB_OUTPUT"\n'
+                '          echo "ran=1" >> "$GITHUB_OUTPUT"',
             )
         )
         self.assertTrue(
             problems,
-            "a commented-out `unittest discover` was accepted as execution",
+            "a commented-out runner invocation was accepted as execution",
         )
 
     def test_renaming_the_job_fails_closed(self):

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -456,6 +456,138 @@ def canary_job_problems(lint_text: str) -> list:
     return problems
 
 
+RAN_MARKER = 'echo "ran=true" >> "$GITHUB_OUTPUT"'
+PROOF_JOBS = ("ci-guards", CANARY_JOB)
+
+
+def job_ran_proof_problems(lint_text: str) -> list:
+    """The two guard jobs prove they reached the END of their work body.
+
+    WHY THIS EXISTS AND WHY IT IS NOT MORE SHAPES
+    ---------------------------------------------
+    Text analysis cannot prove a shell body ran. Measured on `main`:
+
+        control                     canary: []   guard: []
+        exit 0 in renderer-canary : 0 problems
+        exit 0 in ci-guards       : 0 problems
+
+    `if false; then ... fi`, an uncalled function wrapper and `set -n` measure
+    the same. A fourth review closed the heredoc shape and an independent check
+    then showed `exit 0` is cheaper — one token — so patching shape five would be
+    the third patch to an enumeration, which ADR-001 §5 names as the signal to
+    invert instead.
+
+    The inversion: the last line of each body writes `ran=true` to
+    `$GITHUB_OUTPUT`, and `lint-gate` requires it whenever the job reports
+    success. That line is reachable ONLY by executing everything above it, so the
+    property is carried by the shell's own semantics. All four shapes fall to it
+    at once, and so does shape five.
+
+    WHAT THIS FUNCTION ADDS ON TOP
+    ------------------------------
+    The marker alone is a one-line edit away from useless: hoist it above the
+    work, or put `exit 0` below it, and the job parks with the output set. So
+    POSITION is asserted, not presence — it must be the last executed line.
+
+    WHAT IS NOT CLOSED, stated because a defence that reads complete and is not
+    is the failure this file exists to catch: the regress does not terminate
+    inside the workflow. `lint-gate`'s own comparison lives in a `run:` body and
+    is parkable the same way. This raises the cost of parking a guard job from
+    one token to several coordinated edits across two jobs; it is defence in
+    depth, NOT closure. What terminates it is outside this file — branch
+    protection requiring the `Lint` context, and GitHub evaluating `needs:`.
+
+    Scoped to the two guard-running jobs, not all 23 nodes of the required
+    graph (`required_graph(workflow_texts())`, measured). Those two exist to
+    prove other things run, and they are the two where the hole was measured.
+    Twenty-three markers whose per-job value is unproven is a bigger diff than
+    its evidence."""
+    problems = []
+    for job in PROOF_JOBS:
+        block = job_block(lint_text, job)
+        if block is None:
+            problems.append(f"job `{job}` not found in lint.yml")
+            continue
+
+        col = key_column(block)
+        declares = False
+        if col is not None:
+            pat = re.compile(rf"^ {{{col}}}{yaml_key_pattern('outputs')}\s*:")
+            declares = any(
+                pat.match(strip_inline_comment(raw)) for raw in block.splitlines()
+            )
+        if not declares:
+            problems.append(
+                f"job `{job}` declares no `outputs:`. Without it the marker its "
+                "body writes is invisible to `lint-gate`, and the job is back to "
+                "being provable only by reading its text."
+            )
+        else:
+            ref = re.search(
+                r"ran:\s*\$\{\{\s*steps\.([\w-]+)\.outputs\.ran\s*\}\}", block
+            )
+            if ref is None:
+                problems.append(
+                    f"job `{job}` has `outputs:` but does not surface `ran` from a "
+                    "step. An output that reads from nothing is the empty string, "
+                    "which is the undeclared-output vacuity class this repo "
+                    "already paid for once."
+                )
+            elif not re.search(
+                rf"^\s*id:\s*{re.escape(ref.group(1))}\s*$", block, re.M
+            ):
+                # The runtime direction of this is already fail-closed — a typo'd
+                # step id yields an empty output, `lint-gate` sees success with no
+                # proof, and the build goes red. But red-at-runtime for a typo is
+                # a wasted CI cycle and an alarm that looks like a real parking
+                # event, so it is caught here instead, where the diff is.
+                problems.append(
+                    f"job `{job}` surfaces `ran` from step id "
+                    f"`{ref.group(1)}`, which no step in the job declares. The "
+                    "output resolves to the empty string, so the proof can never "
+                    "be satisfied."
+                )
+
+        # POSITION, not presence. `executed_shell` so a marker parked in a
+        # comment or an `env:` scalar counts for nothing — the same routing the
+        # sibling pins use, for the same two measured reasons.
+        lines = [ln.strip() for ln in executed_shell(block).splitlines() if ln.strip()]
+        if RAN_MARKER not in " \n".join(lines):
+            problems.append(
+                f"job `{job}` never writes the `ran` marker in an executed step. "
+                "The proof is the marker; without it the job's `outputs.ran` is "
+                "permanently empty and `lint-gate` fails closed — loudly, but it "
+                "means the mechanism is gone."
+            )
+        elif lines[-1] != RAN_MARKER:
+            problems.append(
+                f"job `{job}` writes the `ran` marker but NOT as its last "
+                f"executed line (last is `{lines[-1]}`). Anything below the "
+                "marker can be skipped while the proof still fires, which is "
+                "exactly the hole the marker was added to close."
+            )
+
+    gate_block = job_block(lint_text, GATE_JOB)
+    if gate_block is None:
+        problems.append(f"aggregator job `{GATE_JOB}` not found")
+        return problems
+    for job in PROOF_JOBS:
+        if not re.search(rf'["\']{re.escape(job)}["\']', gate_block):
+            problems.append(
+                f"`{GATE_JOB}` does not name `{job}` among the jobs whose `ran` "
+                "proof it requires. The marker is then written and read by "
+                "nobody — decoration, and the most expensive kind, because it "
+                "looks like a defence."
+            )
+    if not re.search(r'\.get\(\s*"ran"\s*,?[^)]*\)\s*!=\s*"true"', gate_block):
+        problems.append(
+            f"`{GATE_JOB}` no longer COMPARES the `ran` output against `true`. "
+            "Listing the jobs without checking their marker passes on an empty "
+            "string, which is what a parked body produces."
+        )
+    return problems
+
+
 def uncovered_paths(pattern: str) -> list:
     """Repo-relative paths a guard reads that the `ci_config` bucket misses.
 
@@ -1136,6 +1268,191 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
             "renderer-canary reverted to `unittest -v` (descriptions on)",
         )
 
+    # ------------------------------------------------------------------
+    # THE FALL-THROUGH PROOF. These pin `job_ran_proof_problems`, which
+    # replaces an enumeration of parking shapes with one that closes them by
+    # construction. The four shapes below are the measured ones; the point of
+    # the marker is that a fifth would fall to it too, so they are asserted
+    # against the SHELL (does the marker execute?) rather than against the
+    # static guard, which cannot see control flow and never will.
+    # ------------------------------------------------------------------
+
+    def test_every_measured_parking_shape_stops_a_trailing_marker(self):
+        """The inversion, tested as the shell property it actually is.
+
+        Deliberately NOT run against the real body. A first version neutered the
+        real body line-by-line so it could be wrapped, and the heuristic kept the
+        `}` that closes `ci-guards`' `|| { ... }` block — which closed the
+        wrapping function early, so the marker ran and the test reported the
+        inversion broken. The fixture lied; the mechanism was fine. Running the
+        real body verbatim is not an option either: unparked it invokes the whole
+        guard suite, and `renderer-canary`'s body exits 1 without the oracle and
+        never reaches its last line, so the non-vacuity half could not pass.
+
+        What the real body contributes is the POSITION of the marker, and that is
+        pinned statically by `job_ran_proof_problems` plus the two relocation
+        mutations below. What is left to prove is the bash fact those two rest
+        on: a construct that prevents fall-through prevents the LAST line. Four
+        measured shapes, one assertion — which is the point of inverting rather
+        than patching shape five."""
+        import os
+        import subprocess
+        import tempfile
+
+        bodies = {
+            "exit 0": "exit 0\nwork\n" + RAN_MARKER,
+            "if false": "if false; then\nwork\n" + RAN_MARKER + "\nfi",
+            "uncalled function": "park() {\nwork\n" + RAN_MARKER + "\n}",
+            "set -n": "set -n\nwork\n" + RAN_MARKER,
+        }
+        for name, script in bodies.items():
+            with self.subTest(shape=name):
+                with tempfile.TemporaryDirectory() as d:
+                    out = Path(d, "gh_output")
+                    out.write_text("")
+                    subprocess.run(
+                        ["bash", "-c", "work() { :; }\n" + script],
+                        env={"GITHUB_OUTPUT": str(out), "PATH": os.environ["PATH"]},
+                        capture_output=True,
+                    )
+                    self.assertNotIn(
+                        "ran=true", out.read_text(),
+                        f"`{name}` parked the body and the trailing marker STILL "
+                        "wrote its proof — the inversion does not hold",
+                    )
+
+    def test_an_unparked_body_does_write_the_marker(self):
+        """Non-vacuity for the four subtests above: same harness, no parking.
+
+        Without it, a harness that could never write the marker would make every
+        shape pass for free — the mistake this file has now recorded twice."""
+        import os
+        import subprocess
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d, "gh_output")
+            out.write_text("")
+            subprocess.run(
+                ["bash", "-c", "work() { :; }\nwork\n" + RAN_MARKER],
+                env={"GITHUB_OUTPUT": str(out), "PATH": os.environ["PATH"]},
+                capture_output=True,
+            )
+            self.assertIn(
+                "ran=true", out.read_text(),
+                "the harness cannot write the marker even unparked — the parking "
+                "subtests prove nothing",
+            )
+
+    def test_hoisting_the_marker_above_the_work_is_caught(self):
+        """The evasion the marker alone does not stop.
+
+        Move the marker to the top and the body can be parked below it with the
+        proof already written. `job_ran_proof_problems` asserts POSITION for
+        exactly this, which is why it checks the last executed line rather than
+        containment."""
+        for job in PROOF_JOBS:
+            with self.subTest(job=job):
+                block = job_block(self.lint, job)
+                marker_line = next(
+                    ln for ln in block.splitlines() if ln.strip() == RAN_MARKER
+                )
+                anchor = "          set -euo pipefail\n"
+                self.assertIn(anchor, block, f"{job}: anchor moved")
+                hoisted = block.replace(marker_line + "\n", "").replace(
+                    anchor, anchor + marker_line + "\n", 1
+                )
+                assert_disables(
+                    job_ran_proof_problems,
+                    self.lint,
+                    self.lint.replace(block, hoisted, 1),
+                    f"{job}: marker hoisted above the work",
+                )
+
+    def test_a_command_after_the_marker_is_caught(self):
+        """Same class from the other side: `exit 0` BELOW the marker.
+
+        The proof fires, then the step exits — so the marker must be last, not
+        merely present-and-early. Any trailing command reopens the gap, so the
+        check rejects all of them rather than trying to classify which are
+        harmless."""
+        for job in PROOF_JOBS:
+            with self.subTest(job=job):
+                block = job_block(self.lint, job)
+                marker_line = next(
+                    ln for ln in block.splitlines() if ln.strip() == RAN_MARKER
+                )
+                trailing = block.replace(
+                    marker_line + "\n", marker_line + "\n          echo done\n", 1
+                )
+                assert_disables(
+                    job_ran_proof_problems,
+                    self.lint,
+                    self.lint.replace(block, trailing, 1),
+                    f"{job}: command added after the marker",
+                )
+
+    def test_dropping_the_output_declaration_is_caught(self):
+        for job in PROOF_JOBS:
+            with self.subTest(job=job):
+                block = job_block(self.lint, job)
+                stripped = re.sub(
+                    r"\n    outputs:\n      ran: [^\n]*\n", "\n", block, count=1
+                )
+                self.assertNotEqual(stripped, block, f"{job}: fixture matched nothing")
+                assert_disables(
+                    job_ran_proof_problems,
+                    self.lint,
+                    self.lint.replace(block, stripped, 1),
+                    f"{job}: outputs: dropped",
+                )
+
+    def test_a_typoed_step_id_in_the_output_is_caught(self):
+        """Caught at review time, not at runtime.
+
+        The runtime direction is already fail-closed: a typo'd step id makes the
+        output an empty string, `lint-gate` sees success with no proof, and the
+        build goes red. But a red build for a typo burns a CI cycle and looks
+        exactly like a real parking event — the alarm would be indistinguishable
+        from the thing it is meant to report."""
+        for job in PROOF_JOBS:
+            with self.subTest(job=job):
+                block = job_block(self.lint, job)
+                m = re.search(r"ran: \$\{\{ steps\.([\w-]+)\.outputs\.ran \}\}", block)
+                self.assertIsNotNone(m, f"{job}: fixture premise broke")
+                typoed = block.replace(
+                    f"steps.{m.group(1)}.outputs.ran",
+                    f"steps.{m.group(1)}x.outputs.ran", 1,
+                )
+                assert_disables(
+                    job_ran_proof_problems,
+                    self.lint,
+                    self.lint.replace(block, typoed, 1),
+                    f"{job}: output reads a step id that does not exist",
+                )
+
+    def test_the_aggregator_dropping_the_comparison_is_caught(self):
+        """A gate that LISTS the jobs but stops comparing passes on an empty
+        string — which is precisely what a parked body produces."""
+        gate = job_block(self.lint, GATE_JOB)
+        line = next(
+            ln for ln in gate.splitlines() if '.get("ran") != "true"' in ln
+        )
+        assert_disables(
+            job_ran_proof_problems,
+            self.lint,
+            self.lint.replace(gate, gate.replace(line, "              and False"), 1),
+            "aggregator no longer compares `ran`",
+        )
+
+    def test_the_aggregator_dropping_a_proof_job_is_caught(self):
+        assert_disables(
+            job_ran_proof_problems,
+            self.lint,
+            self.lint.replace('"ci-guards", "renderer-canary"', '"ci-guards"', 1),
+            "aggregator no longer requires the canary's proof",
+        )
+
     def test_dropping_the_per_method_assertion_is_caught(self):
         """A per-class COUNT floor passes with the adjudicating test parked.
 
@@ -1247,3 +1564,120 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTheAggregatorEnforcesTheProof(unittest.TestCase):
+    """EXECUTE `lint-gate`'s body. Nothing in this repo did, before this class.
+
+    Every other check on the aggregator inspects its TEXT — `if: always()`, the
+    `needs:` list, the pass-set string — and #404 already measured what that
+    misses: a gate can satisfy all three and still not gate. The fall-through
+    proof only means something if the aggregator actually rejects an unset `ran`,
+    and only text said it did.
+
+    The critical direction is the FALSE ALARM one. Both proof jobs legitimately
+    skip when the `ci_config` bucket does not match, which is most PRs, and a
+    skipped job has no outputs. An unconditional demand would fail every
+    unrelated PR — the shape that gets a check deleted rather than fixed.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.py = cls._extract(LINT_YML.read_text(encoding="utf-8"))
+
+    @staticmethod
+    def _extract(lint_text: str) -> str:
+        """The aggregator's Python, taken out of the YAML block scalar + heredoc.
+
+        Two layers, both load-bearing: `job_block` returns raw file text, so the
+        YAML indentation is still on it and Python would reject the body; and the
+        script itself lives in a quoted heredoc inside the shell body."""
+        import textwrap
+
+        block = job_block(lint_text, GATE_JOB)
+        if block is None:
+            raise AssertionError(f"job `{GATE_JOB}` not found")
+        marker = "run: |\n"
+        body = textwrap.dedent(block[block.index(marker) + len(marker):])
+        m = re.search(r"^python3 - <<'PY'\n(.*?)^PY", body, re.S | re.M)
+        if m is None:
+            raise AssertionError(
+                f"`{GATE_JOB}` no longer runs a `python3 - <<'PY'` heredoc — this "
+                "class extracts it by that shape and must be updated with it, not "
+                "left to skip"
+            )
+        return m.group(1)
+
+    def _run(self, needs):
+        import json
+        import subprocess
+
+        r = subprocess.run(
+            [sys.executable, "-c", self.py],
+            env={"NEEDS_JSON": json.dumps(needs), "PATH": "/usr/bin:/bin"},
+            capture_output=True, text=True,
+        )
+        return r.returncode, (r.stdout + r.stderr)
+
+    PROVEN = {"result": "success", "outputs": {"ran": "true"}}
+    SKIPPED = {"result": "skipped", "outputs": {}}
+    PARKED = {"result": "success", "outputs": {}}
+
+    def test_the_script_was_extracted(self):
+        # Vacuity canary: an empty script exits 0 and every direction below
+        # would "pass".
+        self.assertGreater(len(self.py.splitlines()), 20, self.py)
+        self.assertIn("proof_required", self.py)
+
+    def test_both_proven_passes(self):
+        code, out = self._run(
+            {"ci-guards": self.PROVEN, "renderer-canary": self.PROVEN}
+        )
+        self.assertEqual(code, 0, out)
+        self.assertIn("Lint gate passed", out)
+
+    def test_both_skipped_passes(self):
+        """THE false-alarm direction. A skipped job has no `ran`, and that is
+        correct, not a parked body."""
+        code, out = self._run(
+            {"ci-guards": self.SKIPPED, "renderer-canary": self.SKIPPED}
+        )
+        self.assertEqual(code, 0, out)
+
+    def test_one_skipped_one_proven_passes(self):
+        code, out = self._run(
+            {"ci-guards": self.SKIPPED, "renderer-canary": self.PROVEN}
+        )
+        self.assertEqual(code, 0, out)
+
+    def test_a_parked_guard_job_fails(self):
+        for job in ("ci-guards", "renderer-canary"):
+            with self.subTest(job=job):
+                needs = {
+                    "ci-guards": self.PROVEN, "renderer-canary": self.PROVEN
+                }
+                needs[job] = self.PARKED
+                code, out = self._run(needs)
+                self.assertEqual(code, 1, out)
+                self.assertIn("without reaching the end", out)
+                self.assertIn(job, out)
+
+    def test_a_renamed_proof_job_fails_closed(self):
+        """A missing NAME must be an error, not a pass.
+
+        `needs.get(name, {})` would wave a renamed job through — the same vacuity
+        as an undeclared `needs.*.outputs.*` resolving to the empty string, which
+        this repo has already paid for once."""
+        code, out = self._run({"renderer-canary": self.PROVEN})
+        self.assertEqual(code, 1, out)
+        self.assertIn("cannot be proven", out)
+
+    def test_an_ordinary_failure_elsewhere_still_fails(self):
+        # No-regression direction: the proof check must not shadow the original
+        # result aggregation.
+        code, out = self._run({
+            "ci-guards": self.PROVEN, "renderer-canary": self.PROVEN,
+            "gitleaks": {"result": "failure", "outputs": {}},
+        })
+        self.assertEqual(code, 1, out)
+        self.assertIn("gitleaks", out)


### PR DESCRIPTION
## What

Makes `ci-guards` and `renderer-canary` prove they **executed their work**, and makes `lint-gate` require that proof.

> **This PR contains four rounds of its own correction.** Each adversarial pass defeated the previous design and the history is kept, because how each one was wrong is the reusable part.

## The four defeats

| # | design | how it fell | cost to the attacker |
|---|---|---|---|
| 1 | constant `ran=true` as the last line | close a parking construct **above** it (`fi` one line up) — the shell falls through | 2 lines |
| 2 | count parsed from `$out` | seed `out="Ran 1 tests in 0.0s"`; or `\|\| true` so a **red** suite publishes a real count | 1–3 lines |
| 3 | `+ grep -qE '^OK'` as a "second reading" | not independent — `2>&1` captures the failure report, and guard messages put `OK  path` at column 0. Also: `cd /tmp/decoy` ran a decoy suite (`ran=1`), and `-k '*bucket*'` cut 1264 tests to 18 | 1 line |
| 4 | count via `$ran`, pinned by counting `^ran=` | bind the variable without `=`: `read`, `printf -v`, `declare`, `export`, `mapfile`, `let`, `(( ))`, `for`, process substitution, or a step-level `env:` (zero shell lines) | 1 line |

Every row measured end-to-end with all static guards returning `[]`. **Rounds 3 and 4 forge nothing** — the published counts were genuine; the *scope* and the *verdict* were the lie.

## The fix

Two tracked runners own the three things shell could not pin:

| | |
|---|---|
| **scope** | scan root from the runner's own `__file__` — `cd` cannot redirect it |
| **filter** | argv refused outright — there is no `-k` to append |
| **verdict** | count printed only on `TestResult.wasSuccessful()` — not grepped from output |

The canary runner additionally treats a SKIP as failure and a missing/wrong-version oracle as a hard error, and owns the adjudicator table (`CANARY_CLASSES` is pinned equal to it).

**The variable is gone.** Each runner prints its own `ran=<count>` and the step appends it:

```bash
python3 scanner/tests/_ci_guard_runner.py >> "$GITHUB_OUTPUT"
```

Both steps are two lines, and the step's executed shell is checked **exhaustively** — `set -euo pipefail` plus one anchored invocation, nothing else. A `cd`, an appended argument, a pipe, a `|| true`, a different redirect target, a second `$GITHUB_OUTPUT` writer, or the `if`/`fi` a parking construct needs are all rejected as extra lines. Parking also appends nothing at runtime, so `lint-gate` fails closed independently of the static check.

## Live CI evidence

`Lint` received counts the runners wrote themselves (run `34426259210`):

```json
"ci-guards":       { "result": "success", "outputs": { "ran": "1250" } }
"renderer-canary": { "result": "success", "outputs": { "ran": "3"    } }
Lint gate passed.
```

`1250` vs `1258` locally is not drift: `ci-guards` installs nothing, so the 8 renderer-adjudicated methods are absent. Reproduced locally by blocking `markdown_it` — **1250, skipped=4**, matching CI exactly.

## Also found and fixed, each measured

- **The runners were outside the `ci_config` bucket** — a PR editing only the script that decides which guards run would not have fired either job. The path gate hiding a change to the gate's own evidence. Bucket widened; narrowing it back is now 3 red.
- **12 mutation tests died with `mutation fixture is stale`** when the shape changed — fail-closed, as designed. They were retargeted at the new design, not mechanically re-anchored. The six asserting properties of the canary's prose-parsing loop were replaced by one test that **executes** the runner across six directions.
- **Mutation scoring found four of its own tests worthless or dangerous.** `if argv:`, `if result.skipped:` and the oracle check each scored **0 red**. The skip test produced its skip by withholding the oracle — which trips the oracle check *first* and returns before the skip logic — so it passed for a reason unrelated to its name.
- **One was worse than worthless:** the argument-refusal test drove the *real* runner, so removing `if argv:` made it discover `scanner/tests`, which contains that test, which spawns the runner again. **Unbounded recursion** — the row hung 18 hours before being killed; in CI it would burn the job timeout instead of failing. Now driven against a temp copy: same mutation, 1 red, seconds.
- **The canary test demanded a package `ci-guards` deliberately does not install** — green locally, red in CI. Fixed with a stub oracle beside the shim rather than a skip (skipping is the fail-open this job exists to close). Verified under **both** job conditions.

## Mutation scores

Each reverted alone against the full suite; all three files restored byte-for-byte after.

| mutation | red | | mutation | red |
|---|---|---|---|---|
| argument appended | 46 | | runner accepts args | 1 *(was TIMEOUT)* |
| cd inserted before | 38 | | publishes on FAILED suite | 1 |
| failure swallowed | 45 | | scans the CWD | 1 |
| redirected elsewhere | 46 | | narrowed-run floor dropped | 1 |
| replaced by a constant | 46 | | canary SKIP-as-pass | 1 |
| extra output writer | 38 | | canary drops an adjudicator | 10 |
| canary constant | 49 | | canary oracle non-fatal | 1 |
| oracle version drift | 9 | | bucket narrowed | 3 |
| gate stops requiring int | 44 | | | |

## Test plan

- [x] Full suite, both conditions: **1258 OK (skipped=1)** with the oracle, **1250 OK (skipped=4)** without
- [x] `ruff check . --no-cache` clean; `markdownlint` clean
- [x] All round-3 and round-4 attacks re-measured against the final shape — every one caught
- [x] CI: **28 pass / 5 skipping / 0 fail**, gate received `ran=1250` and `ran=3`

## Still open, stated rather than implied away

The regress does not terminate inside the workflow: `lint-gate`'s comparison lives in a `run:` body and is parkable the same way — **defence in depth, not closure**. What terminates it is branch protection requiring the `Lint` context and GitHub evaluating `needs:`. Scoped to the two guard-running jobs rather than all 23 nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
