### PR TITLE
fix(guards): require per-FILE contribution, and correct what pass 6 claimed

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -444,6 +444,60 @@ equivalent: its scope *is* `ADJUDICATORS`, already pinned. Redirecting
 `GUARD_DIR` measured the same way (`ran=1` with one decoy test) and is closed by
 the same check.
 
+**A seventh pass found that sentence overstated, and it is corrected here.** The
+scope check reads the CONSTANTS; it never establishes that `main` uses them.
+Leave `GUARD_DIR` and `PATTERN` untouched and scan elsewhere behind the same
+location condition that beat pass 6:
+
+```python
+_d = GUARD_DIR.parent / "decoy"
+_scan = _d if _d.is_dir() else GUARD_DIR
+files = sorted(_scan.glob(PATTERN))
+```
+
+Both pins return `[]`, the suite is `OK (Ran 1262 tests)`, and the job publishes
+`ran=1` having run one decoy test. The temp-directory copy has no sibling
+`decoy`, so it takes the fallback and the behaviour test stays green — an
+*unconditional* redirect is caught only by that test's non-vacuity assertion. A
+decoy placed outside `scanner/tests/` also falls outside the check's own prefix
+filter and outside `test_ci_catalog_completeness`'s glob. So the accurate claim
+is **constant rebinding is closed; constant non-use is not** — the fifth
+appearance of presence-vs-attribution in this series. It is the same boundary
+the fabrication residual sits on: the runners' source is trusted, and closing
+this would mean enumerating how `main` may spell its scan root, or executing the
+runner in place, which recurses.
+
+**What pass 7 did close is cheaper and is not in the runner's trusted source at
+all.** Two lines in any guard module —
+
+```python
+def load_tests(loader, tests, pattern):
+    return unittest.TestSuite()
+```
+
+— make `discover` collect nothing from it while the file still exists, is still
+tracked, still matches `PATTERN`, and so still counts in `len(files)`. Measured:
+1262 tests became 1251 at `OK`, with the published count genuine. `load_tests`
+is a documented `unittest` hook, so this is a supported way for a module to
+leave the run. It is invisible from the other side too: pytest does not honour
+it, so the same file gave `Ran 0 tests / NO TESTS RAN` under `unittest` and
+`11 passed` under pytest — and `scanner-unit-tests`, the job that would have
+caught it, is gated on the `scanner` bucket and does not run on the
+workflow/docs/template-only PRs this job exists for. The `testsRun < len(files)`
+aggregate floor is therefore replaced by a **per-file contribution** check:
+every discovered file must contribute at least one collected test, verified
+before the run so the verdict does not depend on what the run reports. That is
+the lesson the canary runner already paid for one level up, where a per-class
+count floor was defeated by parking the single adjudicating method and only a
+per-method floor saw it.
+
+One structural note, recorded rather than fixed: the denominator of this whole
+ecosystem is the `test_ci_` **filename prefix**, hardcoded in at least three
+places (the runner's `PATTERN`, `test_ci_catalog_completeness`'s glob, and the
+scope check's own filter). A guard renamed outside that prefix disappears from
+all three consistently. It also requires editing the inventory and the catalog,
+so it is a three-file diff rather than a one-line one.
+
 The other two are one class, and they are **not closed**. This document
 previously said a fabricated `result` "would be an unmistakable diff rather than
 four innocuous-looking lines". That is withdrawn: the measured diff is thirteen

--- a/scanner/tests/_ci_guard_runner.py
+++ b/scanner/tests/_ci_guard_runner.py
@@ -59,6 +59,22 @@ GUARD_DIR = Path(__file__).resolve().parent
 PATTERN = "test_ci_*.py"
 
 
+def _modules_of(suite) -> list:
+    """The module every collected test came from, walking nested suites.
+
+    A `_FailedTest` from an unimportable module reports `unittest.loader`, which
+    simply will not match any guard file's stem — so an import error reads as
+    "that file contributed nothing", which is the correct verdict and is also
+    caught by the run itself."""
+    out = []
+    for item in suite:
+        if isinstance(item, unittest.TestSuite):
+            out += _modules_of(item)
+        else:
+            out.append(type(item).__module__)
+    return out
+
+
 def main(argv: list) -> int:
     # NO ARGUMENTS. `-k '*bucket*'` appended to the old shell invocation cut the
     # run from 1264 tests to 18 while every check still passed, so accepting
@@ -86,6 +102,41 @@ def main(argv: list) -> int:
     suite = unittest.defaultTestLoader.discover(
         start_dir=str(GUARD_DIR), pattern=PATTERN, top_level_dir=str(GUARD_DIR)
     )
+
+    # PER FILE, not in aggregate. This replaces a `testsRun < len(files)` floor
+    # that an adversarial pass walked straight through: two lines in any guard
+    # module —
+    #
+    #     def load_tests(loader, tests, pattern):
+    #         return unittest.TestSuite()
+    #
+    # — make `discover` collect NOTHING from it, while the file still exists, is
+    # still tracked, still matches `PATTERN`, and so still counts in
+    # `len(files)`. Measured: 1262 tests became 1251 with the whole suite at
+    # `OK`, and the count the job published was genuine. `load_tests` is a
+    # documented `unittest` hook, so this is a supported way for a module to
+    # remove itself from the run, not a trick.
+    #
+    # It is also invisible from the other side: pytest does not honour
+    # `load_tests`, so `scanner-unit-tests` still ran all 11 of that module's
+    # tests. Measured both ways on the same file — `Ran 0 tests / NO TESTS RAN`
+    # under `unittest`, `11 passed` under pytest. That job is gated on the
+    # `scanner` bucket, so on a workflow/docs/template-only PR — the shape this
+    # job exists for — nothing runs them at all.
+    #
+    # Checked BEFORE the run, so the verdict does not depend on what the run
+    # reports. The same lesson the canary runner already paid for one level up:
+    # a per-class COUNT floor was defeated by parking the single adjudicating
+    # method, and only a per-METHOD floor saw it.
+    collected = set(_modules_of(suite))
+    silent = sorted(p.name for p in files if p.stem not in collected)
+    if silent:
+        print(
+            f"{len(silent)} guard file(s) contributed NO tests, so the run was "
+            f"narrowed while the count stayed genuine: {silent}",
+            file=sys.stderr,
+        )
+        return 1
     # Everything human-readable goes to stderr; stdout carries the count and
     # nothing else, so the caller's `$( )` cannot pick up stray text.
     result = unittest.TextTestRunner(stream=sys.stderr, verbosity=1).run(suite)
@@ -97,17 +148,6 @@ def main(argv: list) -> int:
             file=sys.stderr,
         )
         return 1
-    if result.testsRun < len(files):
-        # A floor tied to something the shell does not choose. It cannot detect
-        # a narrowed run in general — one module can hold many tests — but it
-        # does reject the degenerate "discovered almost nothing" shapes.
-        print(
-            f"only {result.testsRun} test(s) ran across {len(files)} guard "
-            "file(s); the suite was narrowed",
-            file=sys.stderr,
-        )
-        return 1
-
     # `ran=<count>`, not a bare count. The caller appends this straight to
     # `$GITHUB_OUTPUT`, so no shell variable ever holds the value — see the
     # step body for the measured reason.

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -557,6 +557,31 @@ def guard_runner_scope_problems() -> list:
     filesystem for the reason `tracked_files()` documents: an untracked local
     file is not what CI builds from. The canary runner needs no equivalent —
     its scope IS `ADJUDICATORS`, already pinned.
+
+    **WHAT THIS DOES NOT COVER, and the commit that added it said otherwise.**
+    It checks the CONSTANTS, never that `main` USES them. A seventh pass measured
+    the gap: leave `GUARD_DIR` and `PATTERN` untouched and have `main` scan
+    somewhere else, behind the same location condition that beat pass 6 —
+
+        _d = GUARD_DIR.parent / "decoy"
+        _scan = _d if _d.is_dir() else GUARD_DIR
+        files = sorted(_scan.glob(PATTERN))
+
+    — and this function returns `[]`, the AST pin returns `[]`, and the suite is
+    `OK (Ran 1262 tests)` while the job publishes `ran=1` having run one decoy
+    test. The temp-directory copy has no sibling `decoy`, so it takes the
+    fallback and the behaviour test stays green; an UNCONDITIONAL redirect is
+    caught by that test's non-vacuity assertion, which is the only reason the
+    unconditional shape fails. A decoy outside `scanner/tests/` is also outside
+    this function's own prefix filter and outside
+    `test_ci_catalog_completeness`'s glob.
+
+    So the accurate claim is **constant REBINDING is closed, constant NON-USE is
+    not** — the fifth appearance of presence-vs-attribution in this file's
+    history. Proving a constant holds the right value is never proof the code
+    reads it. Closing it means either enumerating how `main` may spell its scan
+    root, or executing the runner in place, which recurses. The runner's source
+    is TRUSTED; see `runner_publication_problems` for the same boundary.
     """
     problems = []
     runner = _import_guard_runner()
@@ -2088,6 +2113,33 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
             self.assertEqual(code, 2)
             self.assertEqual(out, "")
             self.assertIn("takes no arguments", err)
+
+        with self.subTest(direction="a module that removes itself is rejected"):
+            # `load_tests` is a DOCUMENTED `unittest` hook, so this is a
+            # supported way for a module to leave the run, not a trick — and it
+            # walked straight through the aggregate `testsRun < len(files)`
+            # floor it replaced. Measured on the real tree: two lines took 1262
+            # tests to 1251 with the whole suite at `OK` and the published count
+            # genuine. Also invisible from the other side — pytest does not
+            # honour `load_tests`, so the same file gave `Ran 0 tests /
+            # NO TESTS RAN` under `unittest` and `11 passed` under pytest.
+            code, out, err = drive({
+                "test_ci_pass.py": PASSING,
+                "test_ci_gone.py": (
+                    "import unittest\n"
+                    "class G(unittest.TestCase):\n"
+                    "    def test_it(self): pass\n"
+                    "def load_tests(loader, tests, pattern):\n"
+                    "    return unittest.TestSuite()\n"
+                ),
+            })
+            self.assertNotEqual(code, 0, err[-600:])
+            self.assertEqual(
+                out, "",
+                "a module removed itself from the run and a count was still "
+                "published",
+            )
+            self.assertIn("test_ci_gone.py", err)
 
         with self.subTest(direction="a narrowed run is rejected"):
             # The floor tied to something the shell does not choose: more guard


### PR DESCRIPTION
Seventh adversarial pass on the `ci-guards` execution proof. Two more shapes were green while defeated; one is closed here, the other corrects a sentence #536 wrote.

## Closed — `load_tests`, two lines, in any guard module

```python
def load_tests(loader, tests, pattern):
    return unittest.TestSuite()
```

`discover` then collects nothing from that module while the file still exists, is still tracked, still matches `PATTERN`, and so still counts in `len(files)` — so the `testsRun < len(files)` floor stayed true. **Measured: 1262 tests became 1251 with the whole suite at `OK` and the published count genuine.** `load_tests` is a documented `unittest` hook, so this is a supported way for a module to leave the run, not a trick.

Invisible from the other side too — pytest does not honour `load_tests`. The same file measured `Ran 0 tests / NO TESTS RAN` under `unittest` and `11 passed` under pytest. `scanner-unit-tests` would have caught it, but it is gated on the `scanner` bucket and does not run on the workflow/docs/template-only PRs `ci-guards` exists for, so the duplicate coverage this design leans on breaks silently in one direction.

The aggregate floor is replaced by a **per-file contribution** check: every discovered file must contribute at least one collected test, verified *before* the run so the verdict does not depend on what the run reports. Same lesson the canary runner already paid for one level up, where a per-class count floor was defeated by parking the single adjudicating method.

## Corrected — #536 said "CLOSED — the scope"

Too strong. `guard_runner_scope_problems` reads the **constants**; it never establishes that `main` uses them:

```python
_d = GUARD_DIR.parent / "decoy"
_scan = _d if _d.is_dir() else GUARD_DIR
files = sorted(_scan.glob(PATTERN))
```

Both pins return `[]`, the suite is `OK (Ran 1262)`, and the job publishes `ran=1` having run one decoy test. The temp-directory copy has no sibling `decoy`, so it takes the fallback and the behaviour test stays green — only an *unconditional* redirect trips that test's non-vacuity assertion. A decoy outside `scanner/tests/` also falls outside the check's own prefix filter and outside `test_ci_catalog_completeness`'s glob.

Accurate claim: **constant rebinding is closed, constant non-use is not** — the fifth appearance of presence-vs-attribution in this series. Same boundary as the fabrication residual from pass 6: the runners' source is trusted.

## Recorded, not fixed

The denominator of this whole ecosystem is the `test_ci_` filename prefix, hardcoded in three places (the runner's `PATTERN`, `test_ci_catalog_completeness`'s glob, the scope check's own filter). A guard renamed outside it disappears from all three consistently. It also needs the inventory and catalog edited, so it is a three-file diff.

## Test plan

- [x] `python3 -m unittest discover -s scanner/tests -p 'test_ci_*.py'` → `OK (Ran 1262)`
- [x] `ruff check` clean; `markdownlint` clean
- [x] `load_tests` mutation replayed → runner exits 1 naming the file, publishes nothing, so `lint-gate` fails closed
- [x] new `drive()` direction pins that behaviour with a synthetic module
- [x] existing `'a narrowed run is rejected'` direction still passes against the replacement check

🤖 Generated with [Claude Code](https://claude.com/claude-code)