### PR TITLE
fix(guards): attribute by construction, and widen the trust boundary pass 7 understated

### DIFF
--- a/docs/devsecops/ci-config-regression-guards.md
+++ b/docs/devsecops/ci-config-regression-guards.md
@@ -486,10 +486,46 @@ caught it, is gated on the `scanner` bucket and does not run on the
 workflow/docs/template-only PRs this job exists for. The `testsRun < len(files)`
 aggregate floor is therefore replaced by a **per-file contribution** check:
 every discovered file must contribute at least one collected test, verified
-before the run so the verdict does not depend on what the run reports. That is
-the lesson the canary runner already paid for one level up, where a per-class
-count floor was defeated by parking the single adjudicating method and only a
-per-method floor saw it.
+before the run so the verdict does not depend on what the run reports.
+
+## Pass 8: the trust boundary is wider than the two runners
+
+The paragraph above claimed the per-file check was "the lesson the canary runner
+already paid for one level up". **That claim is withdrawn.** The canary's lesson
+was that a per-CLASS *count* floor fell to parking the one adjudicating method,
+and only a per-METHOD floor saw it. A per-FILE *contribution* check is the same
+count-floor shape one level down, and a pass measured it falling the same way:
+
+| attack | edit | effect |
+| --- | --- | --- |
+| `setUpModule` raising `SkipTest` | **2 lines** | `ran=1251`, exit 0, suite `OK (skipped=2)` |
+| `load_tests` returning ONE synthetic test | 5 lines | `ran=1252`, exit 0, suite `OK` |
+| `C.__module__ = "test_ci_<victim>"` | 1 line | a class defined anywhere claims any guard file's stem |
+
+The third is **fixed** here. The first per-file check walked the aggregate suite
+reading `type(test).__module__` — attribution by *attribute*, and the attribute
+is writable. Discovery now runs one file at a time and the union is what
+executes, so a sub-suite belongs to the file it was discovered in whatever its
+classes claim about themselves. Same count (`ran=1262`), no measurable cost.
+
+The first two are **not** fixed, and the skip one cannot be fixed the way the
+canary fixes it. `_ci_canary_runner` rejects any skip outright; `ci-guards`
+legitimately reports `OK (skipped=4)` in CI, because the renderer-adjudicated
+classes skip without the oracle — which is exactly why `renderer-canary` exists
+as a separate job. The job is admissible on a broad path bucket *because* it
+installs nothing, installing nothing means legitimate skips, and with legitimate
+skips present a skip used to silence a guard is indistinguishable from intended
+behaviour without an allowlist keyed to those three classes.
+
+**So the trust boundary is not "the two runners' source" — it is every guard
+module.** `unittest` gives a module documented ways to leave the run that no
+count can see, and a suite cannot establish its own completeness from inside
+itself. Eight passes have walked one rung at a time — publication, binding,
+scope, per-file, per-test — and the terminal rung is a manifest of every test
+id, which is itself a one-line edit. What these checks buy is not closure: it is
+that each weakening is a reviewable edit to a tracked file rather than an
+argument appended to a shell line. Say that, rather than claiming a rung closed
+a class.
 
 One structural note, recorded rather than fixed: the denominator of this whole
 ecosystem is the `test_ci_` **filename prefix**, hardcoded in at least three

--- a/scanner/tests/_ci_guard_runner.py
+++ b/scanner/tests/_ci_guard_runner.py
@@ -59,22 +59,6 @@ GUARD_DIR = Path(__file__).resolve().parent
 PATTERN = "test_ci_*.py"
 
 
-def _modules_of(suite) -> list:
-    """The module every collected test came from, walking nested suites.
-
-    A `_FailedTest` from an unimportable module reports `unittest.loader`, which
-    simply will not match any guard file's stem — so an import error reads as
-    "that file contributed nothing", which is the correct verdict and is also
-    caught by the run itself."""
-    out = []
-    for item in suite:
-        if isinstance(item, unittest.TestSuite):
-            out += _modules_of(item)
-        else:
-            out.append(type(item).__module__)
-    return out
-
-
 def main(argv: list) -> int:
     # NO ARGUMENTS. `-k '*bucket*'` appended to the old shell invocation cut the
     # run from 1264 tests to 18 while every check still passed, so accepting
@@ -97,39 +81,48 @@ def main(argv: list) -> int:
         )
         return 2
 
-    # `discover` is given the resolved directory as BOTH start and top level, so
-    # it does not walk upward looking for a package root.
-    suite = unittest.defaultTestLoader.discover(
-        start_dir=str(GUARD_DIR), pattern=PATTERN, top_level_dir=str(GUARD_DIR)
-    )
-
-    # PER FILE, not in aggregate. This replaces a `testsRun < len(files)` floor
-    # that an adversarial pass walked straight through: two lines in any guard
-    # module —
+    # DISCOVERED ONE FILE AT A TIME, and the union is what runs. `discover` is
+    # given the resolved directory as BOTH start and top level so it does not
+    # walk upward looking for a package root; the pattern is the file's own name.
+    #
+    # WHY PER FILE, AND WHY BY CONSTRUCTION
+    # -------------------------------------
+    # A `testsRun < len(files)` floor was walked through by two lines in any
+    # guard module —
     #
     #     def load_tests(loader, tests, pattern):
     #         return unittest.TestSuite()
     #
-    # — make `discover` collect NOTHING from it, while the file still exists, is
-    # still tracked, still matches `PATTERN`, and so still counts in
+    # — which make `discover` collect NOTHING from it while the file still
+    # exists, is still tracked, still matches `PATTERN`, and so still counts in
     # `len(files)`. Measured: 1262 tests became 1251 with the whole suite at
-    # `OK`, and the count the job published was genuine. `load_tests` is a
-    # documented `unittest` hook, so this is a supported way for a module to
-    # remove itself from the run, not a trick.
+    # `OK` and the published count genuine. `load_tests` is a documented
+    # `unittest` hook, so that is a supported way for a module to leave the run.
+    # Invisible from the other side too — pytest does not honour `load_tests`,
+    # so the same file gave `Ran 0 tests / NO TESTS RAN` under `unittest` and
+    # `11 passed` under pytest, and `scanner-unit-tests` is gated on the
+    # `scanner` bucket, which the PRs this job exists for do not match.
     #
-    # It is also invisible from the other side: pytest does not honour
-    # `load_tests`, so `scanner-unit-tests` still ran all 11 of that module's
-    # tests. Measured both ways on the same file — `Ran 0 tests / NO TESTS RAN`
-    # under `unittest`, `11 passed` under pytest. That job is gated on the
-    # `scanner` bucket, so on a workflow/docs/template-only PR — the shape this
-    # job exists for — nothing runs them at all.
+    # The FIRST attempt at a per-file check walked the aggregate suite and read
+    # `type(test).__module__`. That is attribution by ATTRIBUTE, and the
+    # attribute is writable: one line, `C.__module__ = "test_ci_<victim>"`, lets
+    # a class defined anywhere claim any guard file's stem (measured directly
+    # against the old helper). Discovering each file separately makes the
+    # attribution structural — a sub-suite comes from the file it was discovered
+    # in, whatever its classes claim about themselves.
     #
     # Checked BEFORE the run, so the verdict does not depend on what the run
-    # reports. The same lesson the canary runner already paid for one level up:
-    # a per-class COUNT floor was defeated by parking the single adjudicating
-    # method, and only a per-METHOD floor saw it.
-    collected = set(_modules_of(suite))
-    silent = sorted(p.name for p in files if p.stem not in collected)
+    # reports.
+    loader = unittest.defaultTestLoader
+    suite = unittest.TestSuite()
+    silent = []
+    for path in files:
+        one = loader.discover(
+            start_dir=str(GUARD_DIR), pattern=path.name, top_level_dir=str(GUARD_DIR)
+        )
+        if one.countTestCases() == 0:
+            silent.append(path.name)
+        suite.addTest(one)
     if silent:
         print(
             f"{len(silent)} guard file(s) contributed NO tests, so the run was "

--- a/scanner/tests/test_ci_guard_self_verify.py
+++ b/scanner/tests/test_ci_guard_self_verify.py
@@ -706,6 +706,32 @@ def runner_publication_problems(source: str, path: str, data_expr: str) -> list:
     problems` is the part of pass 6 that WAS closable without enumerating: a set
     compared against `git ls-files`.
 
+    **THE TRUST BOUNDARY IS WIDER THAN "THE TWO RUNNERS", and pass 8 measured
+    where.** Every GUARD MODULE is inside it too, because `unittest` gives a
+    module documented ways to leave the run that no count can see:
+
+        setUpModule raising SkipTest       2 lines -> ran=1251, exit 0, OK
+        load_tests returning ONE synthetic
+          test instead of an empty suite   5 lines -> ran=1252, exit 0, OK
+
+    The second is the sharper lesson: it defeats a per-FILE contribution floor
+    for exactly the reason a per-CLASS count floor was defeated one level up.
+    The pass-7 commit claimed per-file WAS that lesson applied. It was the same
+    mistake one level down, and that claim is withdrawn here.
+
+    The first cannot be closed the way the canary closes it. `_ci_canary_runner`
+    rejects any skip outright — but `ci-guards` legitimately reports
+    `OK (skipped=4)` in CI, because the renderer-adjudicated classes skip without
+    the oracle and that is precisely why `renderer-canary` exists as a separate
+    job. The job is admissible on a broad path bucket BECAUSE it installs
+    nothing; installing nothing means legitimate skips; and with legitimate skips
+    present, a skip used to silence a guard is indistinguishable from intended
+    behaviour without an allowlist keyed to those three classes.
+
+    So the suite cannot establish its own completeness from inside itself. What
+    it can do — and what the checks here do — is make each weakening a reviewable
+    edit to a tracked file rather than an argument appended to a shell line.
+
     Also not pinned here: a body reaching the real `TextTestRunner.run()` with a
     deliberately emptied suite still binds `result`. The runner's own
     `testsRun < len(files)` floor rejects that, and
@@ -2140,6 +2166,35 @@ class TestSelfVerifyDetectorIsNonVacuous(unittest.TestCase):
                 "published",
             )
             self.assertIn("test_ci_gone.py", err)
+
+        with self.subTest(direction="a forged __module__ cannot credit a file"):
+            # ATTRIBUTION BY CONSTRUCTION, not by attribute. The first per-file
+            # check walked the aggregate suite reading `type(test).__module__`,
+            # and that attribute is writable — measured directly against the old
+            # helper, one line let a class defined anywhere claim any guard
+            # file's stem. Discovering each file separately makes a sub-suite
+            # belong to the file it came from, whatever its classes claim.
+            code, out, err = drive({
+                "test_ci_victim.py": (
+                    "import unittest\n"
+                    "class V(unittest.TestCase):\n"
+                    "    def test_it(self): pass\n"
+                    "def load_tests(loader, tests, pattern):\n"
+                    "    return unittest.TestSuite()\n"
+                ),
+                "test_ci_cover.py": (
+                    "import unittest\n"
+                    "class C(unittest.TestCase):\n"
+                    "    def test_it(self): pass\n"
+                    "C.__module__ = 'test_ci_victim'\n"
+                ),
+            })
+            self.assertNotEqual(code, 0, err[-600:])
+            self.assertEqual(
+                out, "",
+                "a forged `__module__` covered for a module that ran nothing",
+            )
+            self.assertIn("test_ci_victim.py", err)
 
         with self.subTest(direction="a narrowed run is rejected"):
             # The floor tied to something the shell does not choose: more guard


### PR DESCRIPTION
Eighth adversarial pass on the `ci-guards` execution proof, aimed at the per-file contribution check #537 added. It fell three ways.

| attack | edit | effect |
| --- | --- | --- |
| `setUpModule` raising `SkipTest` | **2 lines** | `ran=1251`, exit 0, suite `OK (skipped=2)` |
| `load_tests` returning ONE synthetic test | 5 lines | `ran=1252`, exit 0, suite `OK` |
| `C.__module__ = "test_ci_<victim>"` | 1 line | a class defined anywhere claims any guard file's stem |

## Fixed — attribution was by *attribute*

`_modules_of` walked the aggregate suite reading `type(test).__module__`, which is writable. Discovery now runs **one file at a time** and the union is what executes, so a sub-suite belongs to the file it was discovered in whatever its classes claim about themselves. Same count (`ran=1262`), no measurable cost (~45s either way). `_modules_of` is deleted.

## Withdrawn — what #537 claimed about the per-file check

#537 said the per-file check was "the lesson the canary runner already paid for one level up". It was not; it was the same mistake one level down. The canary's lesson is that a per-**class count** floor fell to parking the one adjudicating method, and only a per-**method** floor saw it. "Contributed at least one test" is that same count-floor shape, and `load_tests` returning one synthetic test walks through it in five lines.

## Recorded — and the skip one cannot be fixed the way its sibling fixes it

`_ci_canary_runner` rejects any skip outright. `ci-guards` legitimately reports `OK (skipped=4)` in CI, because the renderer-adjudicated classes skip without the oracle — which is exactly why `renderer-canary` exists as a separate job. The job is admissible on a broad path bucket *because* it installs nothing; installing nothing means legitimate skips; and with those present, a skip used to silence a guard is indistinguishable from intended behaviour without an allowlist keyed to those three classes.

**So the trust boundary is not "the two runners' source" — it is every guard module.** `unittest` gives a module documented ways to leave the run that no count can see, and a suite cannot establish its own completeness from inside itself. Eight passes have climbed one rung at a time (publication, binding, scope, per-file, per-test) and the terminal rung is a manifest of every test id, itself a one-line edit. What these checks buy is not closure but that each weakening is a reviewable edit to a tracked file. The docs now say that rather than claiming a rung closed a class.

## Test plan

- [x] `python3 -m unittest discover -s scanner/tests -p 'test_ci_*.py'` → `OK (Ran 1262)`
- [x] `ruff check` clean; `markdownlint` clean
- [x] new hermetic direction: a victim module with an empty `load_tests` plus a cover class forging `__module__` → runner exits 1 naming the victim, publishes nothing
- [x] regression preserved: empty `load_tests` still exits 1
- [x] both recorded residuals re-measured against **this** code, not the previous one

🤖 Generated with [Claude Code](https://claude.com/claude-code)